### PR TITLE
Update deployment/handler.go: Change defaultReplicas to 1

### DIFF
--- a/radix-operator/deployment/handler.go
+++ b/radix-operator/deployment/handler.go
@@ -25,7 +25,7 @@ const radixComponentEnvironmentVariable = "RADIX_COMPONENT"
 const radixPortsEnvironmentVariable = "RADIX_PORTS"
 const radixPortNamesEnvironmentVariable = "RADIX_PORT_NAMES"
 const hostnameTemplate = "%s-%s.%s.dev.radix.equinor.com"
-const defaultReplicas = 2
+const defaultReplicas = 1			
 
 // RadixDeployHandler Instance variables
 type RadixDeployHandler struct {


### PR DESCRIPTION
As agreed with product owner earlier today, we can change default replica count to 1.

Not sure if there are any tests associated with this as well.