### PR TITLE
RA-147  LimitRange - Request bigger then default limit - pod not created

### DIFF
--- a/pkg/apis/applicationconfig/applicationconfig_test.go
+++ b/pkg/apis/applicationconfig/applicationconfig_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/test"
@@ -239,10 +240,10 @@ func TestObjectSynced_WithEnvironmentsAndLimitsSet_NamespacesAreCreatedWithLimit
 	tu, client, radixclient := setupTest()
 
 	// Setup
-	os.Setenv(OperatorEnvLimitDefaultCPUEnvironmentVariable, "0.5")
-	os.Setenv(OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
-	os.Setenv(OperatorEnvLimitDefaultReqestCPUEnvironmentVariable, "0.25")
-	os.Setenv(OperatorEnvLimitDefaultRequestMemoryEnvironmentVariable, "256M")
+	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "0.5")
+	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
+	os.Setenv(defaults.OperatorEnvLimitDefaultReqestCPUEnvironmentVariable, "0.25")
+	os.Setenv(defaults.OperatorEnvLimitDefaultRequestMemoryEnvironmentVariable, "256M")
 
 	applyApplicationWithSync(tu, client, radixclient, utils.ARadixApplication().
 		WithAppName("any-app").

--- a/pkg/apis/applicationconfig/limitrange.go
+++ b/pkg/apis/applicationconfig/limitrange.go
@@ -1,26 +1,17 @@
 package applicationconfig
 
 import (
-	"os"
-
+	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const (
-	OperatorEnvLimitDefaultMemoryEnvironmentVariable        = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_MEMORY"
-	OperatorEnvLimitDefaultCPUEnvironmentVariable           = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_CPU"
-	OperatorEnvLimitDefaultRequestMemoryEnvironmentVariable = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_MEMORY"
-	OperatorEnvLimitDefaultReqestCPUEnvironmentVariable     = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_CPU"
-
-	limitRangeName = "mem-cpu-limit-range-env"
-)
+const limitRangeName = "mem-cpu-limit-range-env"
 
 func (app *ApplicationConfig) createLimitRangeOnEnvironmentNamespace(namespace string) error {
-	defaultCPULimit := getDefaultCPULimit()
-	defaultMemoryLimit := getDefaultMemoryLimit()
-	defaultCPURequest := getDefaultCPURequest()
-	defaultMemoryRequest := getDefaultMemoryRequest()
+	defaultCPULimit := defaults.GetDefaultCPULimit()
+	defaultMemoryLimit := defaults.GetDefaultMemoryLimit()
+	defaultCPURequest := defaults.GetDefaultCPURequest()
+	defaultMemoryRequest := defaults.GetDefaultMemoryRequest()
 
 	// If not all limits are defined, then don't put any limits on namespace
 	if defaultCPULimit == nil ||
@@ -39,44 +30,4 @@ func (app *ApplicationConfig) createLimitRangeOnEnvironmentNamespace(namespace s
 		*defaultMemoryRequest)
 
 	return app.kubeutil.ApplyLimitRange(namespace, limitRange)
-}
-
-func getDefaultCPULimit() *resource.Quantity {
-	defaultCPULimitSetting := os.Getenv(OperatorEnvLimitDefaultCPUEnvironmentVariable)
-	if defaultCPULimitSetting == "" {
-		return nil
-	}
-
-	defaultCPULimit := resource.MustParse(defaultCPULimitSetting)
-	return &defaultCPULimit
-}
-
-func getDefaultMemoryLimit() *resource.Quantity {
-	defaultMemoryLimitSetting := os.Getenv(OperatorEnvLimitDefaultMemoryEnvironmentVariable)
-	if defaultMemoryLimitSetting == "" {
-		return nil
-	}
-
-	defaultMemoryLimit := resource.MustParse(defaultMemoryLimitSetting)
-	return &defaultMemoryLimit
-}
-
-func getDefaultCPURequest() *resource.Quantity {
-	defaultCPURequestSetting := os.Getenv(OperatorEnvLimitDefaultReqestCPUEnvironmentVariable)
-	if defaultCPURequestSetting == "" {
-		return nil
-	}
-
-	defaultCPURequest := resource.MustParse(defaultCPURequestSetting)
-	return &defaultCPURequest
-}
-
-func getDefaultMemoryRequest() *resource.Quantity {
-	defaultMemoryRequestSetting := os.Getenv(OperatorEnvLimitDefaultRequestMemoryEnvironmentVariable)
-	if defaultMemoryRequestSetting == "" {
-		return nil
-	}
-
-	defaultMemoryRequest := resource.MustParse(defaultMemoryRequestSetting)
-	return &defaultMemoryRequest
 }

--- a/pkg/apis/defaults/resources.go
+++ b/pkg/apis/defaults/resources.go
@@ -1,0 +1,58 @@
+package defaults
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	operatorEnvLimitDefaultMemoryEnvironmentVariable        = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_MEMORY"
+	operatorEnvLimitDefaultCPUEnvironmentVariable           = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_CPU"
+	operatorEnvLimitDefaultRequestMemoryEnvironmentVariable = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_MEMORY"
+	operatorEnvLimitDefaultReqestCPUEnvironmentVariable     = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_CPU"
+)
+
+// GetDefaultCPULimit Gets the default container CPU limit defined as an environment variable
+func GetDefaultCPULimit() *resource.Quantity {
+	defaultCPULimitSetting := os.Getenv(operatorEnvLimitDefaultCPUEnvironmentVariable)
+	if defaultCPULimitSetting == "" {
+		return nil
+	}
+
+	defaultCPULimit := resource.MustParse(defaultCPULimitSetting)
+	return &defaultCPULimit
+}
+
+// GetDefaultMemoryLimit Gets the default container memory limit defined as an environment variable
+func GetDefaultMemoryLimit() *resource.Quantity {
+	defaultMemoryLimitSetting := os.Getenv(operatorEnvLimitDefaultMemoryEnvironmentVariable)
+	if defaultMemoryLimitSetting == "" {
+		return nil
+	}
+
+	defaultMemoryLimit := resource.MustParse(defaultMemoryLimitSetting)
+	return &defaultMemoryLimit
+}
+
+// GetDefaultCPURequest Gets the default container CPU request defined as an environment variable
+func GetDefaultCPURequest() *resource.Quantity {
+	defaultCPURequestSetting := os.Getenv(operatorEnvLimitDefaultReqestCPUEnvironmentVariable)
+	if defaultCPURequestSetting == "" {
+		return nil
+	}
+
+	defaultCPURequest := resource.MustParse(defaultCPURequestSetting)
+	return &defaultCPURequest
+}
+
+// GetDefaultMemoryRequest Gets the default container memory request defined as an environment variable
+func GetDefaultMemoryRequest() *resource.Quantity {
+	defaultMemoryRequestSetting := os.Getenv(operatorEnvLimitDefaultRequestMemoryEnvironmentVariable)
+	if defaultMemoryRequestSetting == "" {
+		return nil
+	}
+
+	defaultMemoryRequest := resource.MustParse(defaultMemoryRequestSetting)
+	return &defaultMemoryRequest
+}

--- a/pkg/apis/defaults/resources.go
+++ b/pkg/apis/defaults/resources.go
@@ -6,16 +6,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// Environment variables that define default resources (limits and requests) for containers and environments
+// See https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/
 const (
-	operatorEnvLimitDefaultMemoryEnvironmentVariable        = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_MEMORY"
-	operatorEnvLimitDefaultCPUEnvironmentVariable           = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_CPU"
-	operatorEnvLimitDefaultRequestMemoryEnvironmentVariable = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_MEMORY"
-	operatorEnvLimitDefaultReqestCPUEnvironmentVariable     = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_CPU"
+	OperatorEnvLimitDefaultMemoryEnvironmentVariable        = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_MEMORY"
+	OperatorEnvLimitDefaultCPUEnvironmentVariable           = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_CPU"
+	OperatorEnvLimitDefaultRequestMemoryEnvironmentVariable = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_MEMORY"
+	OperatorEnvLimitDefaultReqestCPUEnvironmentVariable     = "RADIXOPERATOR_APP_ENV_LIMITS_DEFAULT_REQUEST_CPU"
 )
 
 // GetDefaultCPULimit Gets the default container CPU limit defined as an environment variable
 func GetDefaultCPULimit() *resource.Quantity {
-	defaultCPULimitSetting := os.Getenv(operatorEnvLimitDefaultCPUEnvironmentVariable)
+	defaultCPULimitSetting := os.Getenv(OperatorEnvLimitDefaultCPUEnvironmentVariable)
 	if defaultCPULimitSetting == "" {
 		return nil
 	}
@@ -26,7 +28,7 @@ func GetDefaultCPULimit() *resource.Quantity {
 
 // GetDefaultMemoryLimit Gets the default container memory limit defined as an environment variable
 func GetDefaultMemoryLimit() *resource.Quantity {
-	defaultMemoryLimitSetting := os.Getenv(operatorEnvLimitDefaultMemoryEnvironmentVariable)
+	defaultMemoryLimitSetting := os.Getenv(OperatorEnvLimitDefaultMemoryEnvironmentVariable)
 	if defaultMemoryLimitSetting == "" {
 		return nil
 	}
@@ -37,7 +39,7 @@ func GetDefaultMemoryLimit() *resource.Quantity {
 
 // GetDefaultCPURequest Gets the default container CPU request defined as an environment variable
 func GetDefaultCPURequest() *resource.Quantity {
-	defaultCPURequestSetting := os.Getenv(operatorEnvLimitDefaultReqestCPUEnvironmentVariable)
+	defaultCPURequestSetting := os.Getenv(OperatorEnvLimitDefaultReqestCPUEnvironmentVariable)
 	if defaultCPURequestSetting == "" {
 		return nil
 	}
@@ -48,7 +50,7 @@ func GetDefaultCPURequest() *resource.Quantity {
 
 // GetDefaultMemoryRequest Gets the default container memory request defined as an environment variable
 func GetDefaultMemoryRequest() *resource.Quantity {
-	defaultMemoryRequestSetting := os.Getenv(operatorEnvLimitDefaultRequestMemoryEnvironmentVariable)
+	defaultMemoryRequestSetting := os.Getenv(OperatorEnvLimitDefaultRequestMemoryEnvironmentVariable)
 	if defaultMemoryRequestSetting == "" {
 		return nil
 	}

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/test"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
@@ -26,6 +27,8 @@ func setupTest() (*test.Utils, kube.Interface, radixclient.Interface) {
 	// Setup
 	os.Setenv(OperatorDNSZoneEnvironmentVariable, dnsZone)
 	os.Setenv(OperatorAppAliasBaseURLEnvironmentVariable, ".app.dev.radix.equinor.com")
+	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
+	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
 
 	kubeclient := kubernetes.NewSimpleClientset()
 	radixclient := radix.NewSimpleClientset()

--- a/pkg/apis/deployment/kubedeployment_test.go
+++ b/pkg/apis/deployment/kubedeployment_test.go
@@ -1,0 +1,113 @@
+package deployment
+
+import (
+	"os"
+	"testing"
+
+	"github.com/equinor/radix-operator/pkg/apis/defaults"
+	"github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetResourceRequirements_Provide_Requests_Limits(t *testing.T) {
+	request := map[string]string{
+		"cpu":    "0.1",
+		"memory": "32Mi",
+	}
+
+	limit := map[string]string{
+		"cpu":    "0.5",
+		"memory": "64Mi",
+	}
+
+	component := utils.NewDeployComponentBuilder().
+		WithResource(request, limit).
+		BuildComponent()
+	requirements := getResourceRequirements(component)
+
+	assert.Equal(t, 0, requirements.Requests.Cpu().Cmp(resource.MustParse("0.1")), "CPU request should be included")
+	assert.Equal(t, 0, requirements.Requests.Memory().Cmp(resource.MustParse("32Mi")), "Memory request should be included")
+
+	assert.Equal(t, 0, requirements.Limits.Cpu().Cmp(resource.MustParse("0.5")), "CPU limit should be included")
+	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("64Mi")), "Memory limit should be included")
+}
+
+func TestGetResourceRequirements_Provide_Requests_Only(t *testing.T) {
+	request := map[string]string{
+		"cpu":    "0.2",
+		"memory": "128Mi",
+	}
+
+	component := utils.NewDeployComponentBuilder().
+		WithResourceRequestsOnly(request).
+		BuildComponent()
+	requirements := getResourceRequirements(component)
+
+	assert.Equal(t, 0, requirements.Requests.Cpu().Cmp(resource.MustParse("0.2")), "CPU request should be included")
+	assert.Equal(t, 0, requirements.Requests.Memory().Cmp(resource.MustParse("128Mi")), "Memory request should be included")
+
+	assert.Equal(t, 0, requirements.Limits.Cpu().Cmp(resource.MustParse("0")), "Missing CPU limit should be 0")
+	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("0")), "Missing memory limit should be 0")
+}
+
+func TestGetResourceRequirements_Provide_Requests_Cpu_Only(t *testing.T) {
+	request := map[string]string{
+		"cpu": "0.3",
+	}
+
+	component := utils.NewDeployComponentBuilder().
+		WithResourceRequestsOnly(request).
+		BuildComponent()
+	requirements := getResourceRequirements(component)
+
+	assert.Equal(t, 0, requirements.Requests.Cpu().Cmp(resource.MustParse("0.3")), "CPU request should be included")
+	assert.Equal(t, 0, requirements.Requests.Memory().Cmp(resource.MustParse("0")), "Missing memory request should be 0")
+
+	assert.Equal(t, 0, requirements.Limits.Cpu().Cmp(resource.MustParse("0")), "Missing CPU limit should be 0")
+	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("0")), "Missing memory limit should be 0")
+}
+
+func TestGetResourceRequirements_Provide_Requests_Over_Default_Limits(t *testing.T) {
+	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
+	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
+
+	request := map[string]string{
+		"cpu":    "5",
+		"memory": "5Gi",
+	}
+
+	component := utils.NewDeployComponentBuilder().
+		WithResourceRequestsOnly(request).
+		BuildComponent()
+	requirements := getResourceRequirements(component)
+
+	assert.Equal(t, 0, requirements.Requests.Cpu().Cmp(resource.MustParse("5")), "CPU request should be included")
+	assert.Equal(t, 0, requirements.Requests.Memory().Cmp(resource.MustParse("5Gi")), "Memory request should be included")
+
+	assert.Equal(t, 0, requirements.Limits.Cpu().Cmp(resource.MustParse("5")), "CPU limit should be same as request")
+	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("5Gi")), "Memory limit should be same as request")
+}
+
+func TestGetResourceRequirements_Provide_Requests_Cpu_Over_Default_Limits(t *testing.T) {
+	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
+	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
+
+	request := map[string]string{
+		"cpu": "6",
+	}
+
+	component := utils.NewDeployComponentBuilder().
+		WithResourceRequestsOnly(request).
+		BuildComponent()
+	requirements := getResourceRequirements(component)
+
+	assert.Equal(t, 0, requirements.Requests.Cpu().Cmp(resource.MustParse("6")), "CPU request should be included")
+	assert.Equal(t, 0, requirements.Requests.Memory().Cmp(resource.MustParse("0")), "Missing memory request should be 0")
+
+	assert.Equal(t, 0, requirements.Limits.Cpu().Cmp(resource.MustParse("6")), "CPU limit should be same as request")
+	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("0")), "Missing memory limit should be 0")
+}
+
+func TestGetResourceRequirements_Provide_Limits_Only(t *testing.T) {
+}

--- a/pkg/apis/deployment/kubedeployment_test.go
+++ b/pkg/apis/deployment/kubedeployment_test.go
@@ -10,7 +10,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestGetResourceRequirements_Provide_Requests_Limits(t *testing.T) {
+func setupTests() {
+	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
+	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
+}
+
+func TestGetResourceRequirements_BothProvided_BothReturned(t *testing.T) {
+	setupTests()
+
 	request := map[string]string{
 		"cpu":    "0.1",
 		"memory": "32Mi",
@@ -33,7 +40,9 @@ func TestGetResourceRequirements_Provide_Requests_Limits(t *testing.T) {
 	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("64Mi")), "Memory limit should be included")
 }
 
-func TestGetResourceRequirements_Provide_Requests_Only(t *testing.T) {
+func TestGetResourceRequirements_ProvideRequests_OnlyRequestsReturned(t *testing.T) {
+	setupTests()
+
 	request := map[string]string{
 		"cpu":    "0.2",
 		"memory": "128Mi",
@@ -51,7 +60,9 @@ func TestGetResourceRequirements_Provide_Requests_Only(t *testing.T) {
 	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("0")), "Missing memory limit should be 0")
 }
 
-func TestGetResourceRequirements_Provide_Requests_Cpu_Only(t *testing.T) {
+func TestGetResourceRequirements_ProvideRequestsCpu_OnlyRequestsCpuReturned(t *testing.T) {
+	setupTests()
+
 	request := map[string]string{
 		"cpu": "0.3",
 	}
@@ -68,9 +79,8 @@ func TestGetResourceRequirements_Provide_Requests_Cpu_Only(t *testing.T) {
 	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("0")), "Missing memory limit should be 0")
 }
 
-func TestGetResourceRequirements_Provide_Requests_Over_Default_Limits(t *testing.T) {
-	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
-	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
+func TestGetResourceRequirements_BothProvided_OverDefaultLimits(t *testing.T) {
+	setupTests()
 
 	request := map[string]string{
 		"cpu":    "5",
@@ -89,9 +99,8 @@ func TestGetResourceRequirements_Provide_Requests_Over_Default_Limits(t *testing
 	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("5Gi")), "Memory limit should be same as request")
 }
 
-func TestGetResourceRequirements_Provide_Requests_Cpu_Over_Default_Limits(t *testing.T) {
-	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
-	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
+func TestGetResourceRequirements_ProvideRequestsCpu_OverDefaultLimits(t *testing.T) {
+	setupTests()
 
 	request := map[string]string{
 		"cpu": "6",
@@ -107,7 +116,4 @@ func TestGetResourceRequirements_Provide_Requests_Cpu_Over_Default_Limits(t *tes
 
 	assert.Equal(t, 0, requirements.Limits.Cpu().Cmp(resource.MustParse("6")), "CPU limit should be same as request")
 	assert.Equal(t, 0, requirements.Limits.Memory().Cmp(resource.MustParse("0")), "Missing memory limit should be 0")
-}
-
-func TestGetResourceRequirements_Provide_Limits_Only(t *testing.T) {
 }

--- a/pkg/apis/utils/deployment_builder.go
+++ b/pkg/apis/utils/deployment_builder.go
@@ -205,6 +205,7 @@ type DeployComponentBuilder interface {
 	WithPublicPort(string) DeployComponentBuilder
 	WithMonitoring(bool) DeployComponentBuilder
 	WithReplicas(int) DeployComponentBuilder
+	WithResourceRequestsOnly(map[string]string) DeployComponentBuilder
 	WithResource(map[string]string, map[string]string) DeployComponentBuilder
 	WithSecrets([]string) DeployComponentBuilder
 	WithDNSAppAlias(bool) DeployComponentBuilder
@@ -224,6 +225,13 @@ type deployComponentBuilder struct {
 	secrets     []string
 	dnsappalias bool
 	resources   v1.ResourceRequirements
+}
+
+func (dcb *deployComponentBuilder) WithResourceRequestsOnly(request map[string]string) DeployComponentBuilder {
+	dcb.resources = v1.ResourceRequirements{
+		Requests: request,
+	}
+	return dcb
 }
 
 func (dcb *deployComponentBuilder) WithResource(request map[string]string, limit map[string]string) DeployComponentBuilder {

--- a/radix-operator/deployment/controller_test.go
+++ b/radix-operator/deployment/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/deployment"
 	"github.com/equinor/radix-operator/pkg/apis/test"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
@@ -29,6 +30,8 @@ var synced chan bool
 func setupTest() (*test.Utils, kubernetes.Interface, radixclient.Interface) {
 	os.Setenv(deployment.OperatorDNSZoneEnvironmentVariable, dnsZone)
 	os.Setenv(deployment.OperatorAppAliasBaseURLEnvironmentVariable, ".app.dev.radix.equinor.com")
+	os.Setenv(defaults.OperatorEnvLimitDefaultCPUEnvironmentVariable, "1")
+	os.Setenv(defaults.OperatorEnvLimitDefaultMemoryEnvironmentVariable, "300M")
 
 	client := fake.NewSimpleClientset()
 	radixClient := fakeradix.NewSimpleClientset()


### PR DESCRIPTION
## Container resources

Resolves the conflict by assigning a `limit` equal to the `request` value if `request` is larger than `default limit` and no `limit` has been provided.

The `GetDefault[CPU|Memory][Limit|Request]` functions were refactored to be reusable.