### PR TITLE
We get failed to verify access

### DIFF
--- a/charts/radix-operator/templates/radix-user-groups-rbac.yaml
+++ b/charts/radix-operator/templates/radix-user-groups-rbac.yaml
@@ -61,6 +61,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
 selfsubjectaccessreviews.authorization.k8s.io is
forbidden when impersonating user. This happens when the canary test user which we impersonate tries to list applications