### PR TITLE
Ra 513 check resource version of rd

### DIFF
--- a/charts/radix-operator/templates/radix-pipeline-rbac.yaml
+++ b/charts/radix-operator/templates/radix-pipeline-rbac.yaml
@@ -55,6 +55,7 @@ rules:
   - radixdeployments
   verbs:
   - get
+  - list
   - create
 - apiGroups:
   - "*"

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -96,14 +96,14 @@
   - Accesses:
     - Get, list, create and update RAs
     - Get, list and create jobs
-    - Get and list configmaps <sup><sup>4</sup></sup>
 - radix-pipeline-runner <sup><sup>2</sup></sup>
   - Purpose: Create environment namespaces and make deployments
   - Created by: Helm chart
   - Cluster role binding: radix-pipeline-runner-\<app\>
   - Accesses:
     - Get, list and create namespaces
-    - Get and create RDs
+    - Get, list and create RDs
+    - Get and list configmaps
 - radix-pipeline-rr-\<app\>
   - Purpose: Get access to read RR belonging to \<app\>
   - Created by: Operator
@@ -137,8 +137,8 @@
   - Accesses:
     - All access to RRs, RAs and RDs
     - All access to events, limitranges, namespaces, secrets, servicesaccounts, roles, rolebindings, clusterroles, clusterrolebindings, deployments, services, ingresses, servicemonitors, networkpolicies, jobs
-    - Get list configmaps <sup><sup>4</sup></sup>
-    - Get list delete pods and pods/log
+    - Get and list configmaps
+    - Get, list and delete pods, as well as pods/log
     
 
 #### Clusterrole bindings

--- a/pipeline-runner/model/pipelineInfo.go
+++ b/pipeline-runner/model/pipelineInfo.go
@@ -8,11 +8,12 @@ import (
 
 // PipelineInfo Holds info about the pipeline to run
 type PipelineInfo struct {
-	Definition         *pipeline.Definition
-	TargetEnvironments map[string]bool
-	BranchIsMapped     bool
-	PipelineArguments  PipelineArguments
-	Steps              []Step
+	Definition            *pipeline.Definition
+	TargetEnvironments    map[string]bool
+	LatestResourceVersion map[string]string
+	BranchIsMapped        bool
+	PipelineArguments     PipelineArguments
+	Steps                 []Step
 }
 
 // PipelineArguments Holds arguments for the pipeline
@@ -72,6 +73,7 @@ func GetPipelineArgsFromArguments(args map[string]string) PipelineArguments {
 // InitPipeline Initialize pipeline with step implementations
 func InitPipeline(pipelineType *pipeline.Definition,
 	targetEnv map[string]bool,
+	latestResourceVersion map[string]string,
 	branchIsMapped bool,
 	pipelineArguments PipelineArguments,
 	stepImplementations ...Step) (*PipelineInfo, error) {
@@ -82,11 +84,12 @@ func InitPipeline(pipelineType *pipeline.Definition,
 	}
 
 	return &PipelineInfo{
-		Definition:         pipelineType,
-		TargetEnvironments: targetEnv,
-		BranchIsMapped:     branchIsMapped,
-		PipelineArguments:  pipelineArguments,
-		Steps:              stepImplementationsForType,
+		Definition:            pipelineType,
+		TargetEnvironments:    targetEnv,
+		LatestResourceVersion: latestResourceVersion,
+		BranchIsMapped:        branchIsMapped,
+		PipelineArguments:     pipelineArguments,
+		Steps:                 stepImplementationsForType,
 	}, nil
 }
 

--- a/pipeline-runner/model/pipelineInfo_test.go
+++ b/pipeline-runner/model/pipelineInfo_test.go
@@ -16,7 +16,7 @@ var (
 
 func Test_DefaultPipeType(t *testing.T) {
 	pipelineType, _ := pipeline.GetPipelineFromName("")
-	p, _ := model.InitPipeline(pipelineType, nil, true, model.PipelineArguments{}, applyConfigStep, buildStep, deployStep)
+	p, _ := model.InitPipeline(pipelineType, nil, nil, true, model.PipelineArguments{}, applyConfigStep, buildStep, deployStep)
 
 	assert.Equal(t, pipeline.BuildDeploy, p.Definition.Name)
 	assert.Equal(t, 3, len(p.Steps))
@@ -27,7 +27,7 @@ func Test_DefaultPipeType(t *testing.T) {
 
 func Test_BuildDeployPipeType(t *testing.T) {
 	pipelineType, _ := pipeline.GetPipelineFromName(pipeline.BuildDeploy)
-	p, _ := model.InitPipeline(pipelineType, nil, true, model.PipelineArguments{}, applyConfigStep, buildStep, deployStep)
+	p, _ := model.InitPipeline(pipelineType, nil, nil, true, model.PipelineArguments{}, applyConfigStep, buildStep, deployStep)
 
 	assert.Equal(t, pipeline.BuildDeploy, p.Definition.Name)
 	assert.Equal(t, 3, len(p.Steps))
@@ -40,7 +40,7 @@ func Test_BuildAndDefaultPushOnlyPipeline(t *testing.T) {
 	pipelineType, _ := pipeline.GetPipelineFromName(pipeline.Build)
 
 	pipelineArgs := model.GetPipelineArgsFromArguments(make(map[string]string))
-	p, _ := model.InitPipeline(pipelineType, nil, true, pipelineArgs, applyConfigStep, buildStep, deployStep)
+	p, _ := model.InitPipeline(pipelineType, nil, nil, true, pipelineArgs, applyConfigStep, buildStep, deployStep)
 	assert.Equal(t, pipeline.Build, p.Definition.Name)
 	assert.True(t, p.PipelineArguments.PushImage)
 	assert.Equal(t, 2, len(p.Steps))
@@ -55,7 +55,7 @@ func Test_BuildOnlyPipeline(t *testing.T) {
 		PushImage: false,
 	}
 
-	p, _ := model.InitPipeline(pipelineType, nil, true, pipelineArgs, applyConfigStep, buildStep, deployStep)
+	p, _ := model.InitPipeline(pipelineType, nil, nil, true, pipelineArgs, applyConfigStep, buildStep, deployStep)
 	assert.Equal(t, pipeline.Build, p.Definition.Name)
 	assert.False(t, p.PipelineArguments.PushImage)
 	assert.Equal(t, 2, len(p.Steps))
@@ -70,7 +70,7 @@ func Test_BuildAndPushOnlyPipeline(t *testing.T) {
 		PushImage: true,
 	}
 
-	p, _ := model.InitPipeline(pipelineType, nil, true, pipelineArgs, applyConfigStep, buildStep, deployStep)
+	p, _ := model.InitPipeline(pipelineType, nil, nil, true, pipelineArgs, applyConfigStep, buildStep, deployStep)
 	assert.Equal(t, pipeline.Build, p.Definition.Name)
 	assert.True(t, p.PipelineArguments.PushImage)
 	assert.Equal(t, 2, len(p.Steps))

--- a/pipeline-runner/pipelines/app.go
+++ b/pipeline-runner/pipelines/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/equinor/radix-operator/pipeline-runner/model"
 	"github.com/equinor/radix-operator/pipeline-runner/steps"
 	application "github.com/equinor/radix-operator/pkg/apis/applicationconfig"
+	"github.com/equinor/radix-operator/pkg/apis/deployment"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	"github.com/equinor/radix-operator/pkg/apis/pipeline"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
@@ -67,11 +68,16 @@ func (cli *PipelineRunner) PrepareRun(pipelineArgs model.PipelineArguments) erro
 	}
 
 	branchIsMapped, targetEnvironments := applicationConfig.IsBranchMappedToEnvironment(pipelineArgs.Branch)
+	latestResourceVersions, err := deployment.GetLatestResourceVersionOfTargetEnvironments(cli.radixclient, appName, targetEnvironments)
+	if err != nil {
+		return err
+	}
 
 	stepImplementations := initStepImplementations(cli.kubeclient, cli.radixclient, cli.prometheusOperatorClient, radixRegistration, cli.radixApplication)
 	cli.pipelineInfo, err = model.InitPipeline(
 		cli.definfition,
 		targetEnvironments,
+		latestResourceVersions,
 		branchIsMapped,
 		pipelineArgs,
 		stepImplementations...)

--- a/pipeline-runner/pipelines/app.go
+++ b/pipeline-runner/pipelines/app.go
@@ -68,6 +68,8 @@ func (cli *PipelineRunner) PrepareRun(pipelineArgs model.PipelineArguments) erro
 	}
 
 	branchIsMapped, targetEnvironments := applicationConfig.IsBranchMappedToEnvironment(pipelineArgs.Branch)
+
+	// Gather latest resource versions, before starting pipeline, in order to check that no other build comes in between
 	latestResourceVersions, err := deployment.GetLatestResourceVersionOfTargetEnvironments(cli.radixclient, appName, targetEnvironments)
 	if err != nil {
 		return err

--- a/pipeline-runner/steps/deploy.go
+++ b/pipeline-runner/steps/deploy.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// EmptyArgument Argument by name cannot be empty
+// DeploymentHasBeenModifiedError There is a new version of an RD in the environment
 func DeploymentHasBeenModifiedError(appName, envName string) error {
 	return fmt.Errorf("Newer version of deployment exists for app %s in environment %s", appName, envName)
 }

--- a/pipeline-runner/steps/deploy.go
+++ b/pipeline-runner/steps/deploy.go
@@ -120,7 +120,7 @@ func (cli *DeployStepImplementation) deploymentHasBeenModified(env, resourceVers
 		return true, err
 	}
 
-	if !strings.EqualFold(latestResourceVersion, resourceVersionAtStartOfPipeline) {
+	if !strings.EqualFold(latestResourceVersion, resourceVersionAtStartOfPipeline) && resourceVersionAtStartOfPipeline != "" {
 		return true, nil
 	}
 

--- a/pipeline-runner/steps/deploy_test.go
+++ b/pipeline-runner/steps/deploy_test.go
@@ -188,3 +188,64 @@ func TestDeploy_PromotionSetup_ShouldCreateNamespacesForAllBranchesIfNotExtists(
 	})
 
 }
+
+func TestDeploy_WrongResourceVersion_ShouldFailDeployment(t *testing.T) {
+	anyApp := "any-app"
+	anyEnv := "dev"
+	anyComponentName := "frontend"
+
+	targetEnvironments := make(map[string]bool)
+	targetEnvironments[anyEnv] = true
+
+	// Setup
+	kubeclient, kubeUtil, radixclient, testUtils := setupTest()
+	rd1, _ := testUtils.ApplyDeployment(
+		utils.ARadixDeployment().
+			WithAppName(anyApp).
+			WithEnvironment(anyEnv).
+			WithEmptyStatus().
+			WithComponents(
+				utils.NewDeployComponentBuilder().
+					WithName(anyComponentName).
+					WithPort("http", 8080).
+					WithPublicPort("http")))
+
+	// Get corresponding RR and RA
+	rr, _ := radixclient.RadixV1().RadixRegistrations().Get(anyApp, metav1.GetOptions{})
+	ra, _ := radixclient.RadixV1().RadixApplications(utils.GetAppNamespace(anyApp)).Get(anyApp, metav1.GetOptions{})
+
+	// Pretend that pipepline start, knowing only about this RD
+	latestResourceVersion := make(map[string]string)
+	latestResourceVersion[anyEnv] = rd1.ResourceVersion
+
+	// Then in the meantime another RD appears
+	testUtils.ApplyDeployment(
+		utils.ARadixDeployment().
+			WithAppName(anyApp).
+			WithEnvironment(anyEnv).
+			WithEmptyStatus().
+			WithComponents(
+				utils.NewDeployComponentBuilder().
+					WithName(anyComponentName).
+					WithPort("http", 8080).
+					WithPublicPort("http")))
+
+	// Test
+	cli := NewDeployStep()
+	cli.Init(kubeclient, radixclient, kubeUtil, &monitoring.Clientset{}, rr, ra)
+
+	pipelineInfo := &model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			JobName:  anyJobName,
+			ImageTag: anyImageTag,
+			Branch:   "master",
+			CommitID: anyCommitID,
+		},
+		BranchIsMapped:        true,
+		TargetEnvironments:    targetEnvironments,
+		LatestResourceVersion: latestResourceVersion,
+	}
+
+	err := cli.Run(pipelineInfo)
+	assert.Error(t, err)
+}

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -45,25 +45,48 @@ func NewDeployment(kubeclient kubernetes.Interface, radixclient radixclient.Inte
 		kubeutil, prometheusperatorclient, registration, radixDeployment}, nil
 }
 
-// ConstructForTargetEnvironments Will build a list of deployments for each target environment
-func ConstructForTargetEnvironments(config *v1.RadixApplication, containerRegistry, jobName, imageTag, branch, commitID string, targetEnvs map[string]bool) ([]v1.RadixDeployment, error) {
-	radixDeployments := []v1.RadixDeployment{}
-	for _, env := range config.Spec.Environments {
-		if _, contains := targetEnvs[env.Name]; !contains {
-			continue
-		}
+// ConstructForTargetEnvironment Will build a deployment for target environment
+func ConstructForTargetEnvironment(config *v1.RadixApplication, containerRegistry, jobName, imageTag, branch, commitID string, env string) (v1.RadixDeployment, error) {
+	radixComponents := getRadixComponentsForEnv(config, containerRegistry, env, imageTag)
+	radixDeployment := constructRadixDeployment(config.Name, env, jobName, imageTag, branch, commitID, radixComponents)
+	return radixDeployment, nil
+}
 
-		if !targetEnvs[env.Name] {
-			// Target environment exists in config but should not be built
-			continue
-		}
-
-		radixComponents := getRadixComponentsForEnv(config, containerRegistry, env.Name, imageTag)
-		radixDeployment := constructRadixDeployment(config.Name, env.Name, jobName, imageTag, branch, commitID, radixComponents)
-		radixDeployments = append(radixDeployments, radixDeployment)
+// DeployToEnvironment Will return true/false depending on it has a mapping in config
+func DeployToEnvironment(env v1.Environment, targetEnvs map[string]bool) bool {
+	if _, contains := targetEnvs[env.Name]; contains && targetEnvs[env.Name] {
+		return true
 	}
 
-	return radixDeployments, nil
+	return false
+}
+
+// GetLatestResourceVersionOfTargetEnvironments Gets the latest resource version of target environments
+func (deploy *Deployment) GetLatestResourceVersionOfTargetEnvironments(targetEnvs map[string]bool) (map[string]string, error) {
+	latestResourceVersions := make(map[string]string)
+
+	for envName, deployToEnvironment := range targetEnvs {
+		if deployToEnvironment {
+			latestResourceVersion, err := deploy.GetLatestResourceVersionOfTargetEnvironment(envName)
+			if err != nil {
+				return nil, err
+			}
+
+			latestResourceVersions[envName] = latestResourceVersion
+		}
+	}
+
+	return latestResourceVersions, nil
+}
+
+// GetLatestResourceVersionOfTargetEnvironment Gets the latest resource version of specified target environment
+func (deploy *Deployment) GetLatestResourceVersionOfTargetEnvironment(envName string) (string, error) {
+	latestRD, err := GetLatestDeploymentInNamespace(deploy.radixclient, utils.GetEnvironmentNamespace(deploy.registration.Name, envName))
+	if err != nil {
+		return "", err
+	}
+
+	return latestRD.ResourceVersion, nil
 }
 
 // Apply Will make deployment effective
@@ -80,7 +103,7 @@ func (deploy *Deployment) Apply() error {
 // converge the two
 func (deploy *Deployment) OnSync() error {
 	if IsRadixDeploymentInactive(deploy.radixDeployment) {
-		log.Warnf("Ignoring RadixDeployment %s/%s as it's inactive.", deploy.GetNamespace(), deploy.GetName())
+		log.Warnf("Ignoring RadixDeployment %s/%s as it's inactive.", deploy.getNamespace(), deploy.getName())
 		return nil
 	}
 
@@ -96,25 +119,43 @@ func (deploy *Deployment) OnSync() error {
 	return deploy.syncDeployment()
 }
 
-// GetNamespace gets the namespace of radixDeployment
-func (deploy *Deployment) GetNamespace() string {
-	return deploy.radixDeployment.GetNamespace()
-}
-
-// GetName gets the name of radixDeployment
-func (deploy *Deployment) GetName() string {
-	return deploy.radixDeployment.GetName()
-}
-
 // IsRadixDeploymentInactive checks if deployment is inactive
 func IsRadixDeploymentInactive(rd *v1.RadixDeployment) bool {
 	return rd == nil || rd.Status.Condition == v1.DeploymentInactive
 }
 
+// GetLatestDeploymentInNamespace Gets the last deployment in namespace
+func GetLatestDeploymentInNamespace(radixclient radixclient.Interface, namespace string) (*v1.RadixDeployment, error) {
+	allRDs, err := radixclient.RadixV1().RadixDeployments(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(allRDs.Items) > 0 {
+		for _, rd := range allRDs.Items {
+			if isLatest(&rd, allRDs.Items) {
+				return &rd, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// getNamespace gets the namespace of radixDeployment
+func (deploy *Deployment) getNamespace() string {
+	return deploy.radixDeployment.GetNamespace()
+}
+
+// getName gets the name of radixDeployment
+func (deploy *Deployment) getName() string {
+	return deploy.radixDeployment.GetName()
+}
+
 func (deploy *Deployment) syncStatuses() (stopReconciliation bool, err error) {
 	stopReconciliation = false
 
-	allRDs, err := deploy.radixclient.RadixV1().RadixDeployments(deploy.GetNamespace()).List(metav1.ListOptions{})
+	allRDs, err := deploy.radixclient.RadixV1().RadixDeployments(deploy.getNamespace()).List(metav1.ListOptions{})
 	if err != nil {
 		err = fmt.Errorf("Failed to get all RadixDeployments. Error was %v", err)
 	}
@@ -125,7 +166,7 @@ func (deploy *Deployment) syncStatuses() (stopReconciliation bool, err error) {
 		stopReconciliation = deploy.radixDeployment.Status.Condition != v1.DeploymentActive
 		err = deploy.setRDToActive()
 		if err != nil {
-			log.Errorf("Failed to set rd (%s) status to active", deploy.GetName())
+			log.Errorf("Failed to set rd (%s) status to active", deploy.getName())
 			return false, err
 		}
 		err = deploy.setOtherRDsToInactive(allRDs.Items)
@@ -137,7 +178,7 @@ func (deploy *Deployment) syncStatuses() (stopReconciliation bool, err error) {
 		// Inactive - Should not be put back on queue - stop reconciliation
 		// Inactive status is updated when latest rd reconciliation is triggered
 		stopReconciliation = true
-		log.Warnf("RadixDeployment %s was not the latest. Ignoring", deploy.GetName())
+		log.Warnf("RadixDeployment %s was not the latest. Ignoring", deploy.getName())
 	}
 	return
 }
@@ -231,7 +272,7 @@ func (deploy *Deployment) setOtherRDsToInactive(allRDs []v1.RadixDeployment) err
 	prevRDActiveFrom := metav1.Time{}
 
 	for _, rd := range sortedRDs {
-		if rd.GetName() != deploy.GetName() {
+		if rd.GetName() != deploy.getName() {
 			err := setRDToInactive(deploy.radixclient, &rd, prevRDActiveFrom)
 			if err != nil {
 				return err
@@ -253,8 +294,13 @@ func sortRDsByActiveFromTimestampDesc(rds []v1.RadixDeployment) []v1.RadixDeploy
 
 // isLatestInTheEnvironment Checks if the deployment is the latest in the same namespace as specified in the deployment
 func (deploy *Deployment) isLatestInTheEnvironment(allRDs []v1.RadixDeployment) bool {
+	return isLatest(deploy.radixDeployment, allRDs)
+}
+
+// isLatest Checks if the deployment is the latest in the same namespace as specified in the deployment
+func isLatest(deploy *v1.RadixDeployment, allRDs []v1.RadixDeployment) bool {
 	for _, rd := range allRDs {
-		if rd.GetName() != deploy.GetName() && isRD1ActiveBeforeRD2(deploy.radixDeployment, &rd) {
+		if rd.GetName() != deploy.GetName() && isRD1ActiveBeforeRD2(deploy, &rd) {
 			return false
 		}
 	}

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -62,12 +62,12 @@ func DeployToEnvironment(env v1.Environment, targetEnvs map[string]bool) bool {
 }
 
 // GetLatestResourceVersionOfTargetEnvironments Gets the latest resource version of target environments
-func (deploy *Deployment) GetLatestResourceVersionOfTargetEnvironments(targetEnvs map[string]bool) (map[string]string, error) {
+func GetLatestResourceVersionOfTargetEnvironments(radixclient radixclient.Interface, appName string, targetEnvs map[string]bool) (map[string]string, error) {
 	latestResourceVersions := make(map[string]string)
 
 	for envName, deployToEnvironment := range targetEnvs {
 		if deployToEnvironment {
-			latestResourceVersion, err := deploy.GetLatestResourceVersionOfTargetEnvironment(envName)
+			latestResourceVersion, err := GetLatestResourceVersionOfTargetEnvironment(radixclient, appName, envName)
 			if err != nil {
 				return nil, err
 			}
@@ -80,10 +80,15 @@ func (deploy *Deployment) GetLatestResourceVersionOfTargetEnvironments(targetEnv
 }
 
 // GetLatestResourceVersionOfTargetEnvironment Gets the latest resource version of specified target environment
-func (deploy *Deployment) GetLatestResourceVersionOfTargetEnvironment(envName string) (string, error) {
-	latestRD, err := GetLatestDeploymentInNamespace(deploy.radixclient, utils.GetEnvironmentNamespace(deploy.registration.Name, envName))
+func GetLatestResourceVersionOfTargetEnvironment(radixclient radixclient.Interface, appName, envName string) (string, error) {
+	latestRD, err := GetLatestDeploymentInNamespace(radixclient, utils.GetEnvironmentNamespace(appName, envName))
 	if err != nil {
 		return "", err
+	}
+
+	if latestRD == nil {
+		// No deployment exists in the environment
+		return "", nil
 	}
 
 	return latestRD.ResourceVersion, nil

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -1222,7 +1222,7 @@ func TestNewDeploymentStatus(t *testing.T) {
 	radixDeployBuilder := utils.ARadixDeployment().
 		WithAppName(anyApp).
 		WithEnvironment(anyEnv).
-		WithEmptyStatus(true).
+		WithEmptyStatus().
 		WithComponents(
 			utils.NewDeployComponentBuilder().
 				WithName(anyComponentName).
@@ -1239,7 +1239,7 @@ func TestNewDeploymentStatus(t *testing.T) {
 	radixDeployBuilder = utils.ARadixDeployment().
 		WithAppName(anyApp).
 		WithEnvironment(anyEnv).
-		WithEmptyStatus(true).
+		WithEmptyStatus().
 		WithComponents(
 			utils.NewDeployComponentBuilder().
 				WithName(anyComponentName).
@@ -1267,7 +1267,7 @@ func TestGetLatestResourceVersionOfTargetEnvironments_ThreeDeployments_ReturnsLa
 		utils.ARadixDeployment().
 			WithAppName(anyApp).
 			WithEnvironment(anyEnv).
-			WithEmptyStatus(true).
+			WithEmptyStatus().
 			WithComponents(
 				utils.NewDeployComponentBuilder().
 					WithName(anyComponentName).
@@ -1279,7 +1279,7 @@ func TestGetLatestResourceVersionOfTargetEnvironments_ThreeDeployments_ReturnsLa
 		utils.ARadixDeployment().
 			WithAppName(anyApp).
 			WithEnvironment(anyEnv).
-			WithEmptyStatus(true).
+			WithEmptyStatus().
 			WithComponents(
 				utils.NewDeployComponentBuilder().
 					WithName(anyComponentName).
@@ -1291,7 +1291,7 @@ func TestGetLatestResourceVersionOfTargetEnvironments_ThreeDeployments_ReturnsLa
 		utils.ARadixDeployment().
 			WithAppName(anyApp).
 			WithEnvironment(anyEnv).
-			WithEmptyStatus(true).
+			WithEmptyStatus().
 			WithComponents(
 				utils.NewDeployComponentBuilder().
 					WithName(anyComponentName).

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -1256,11 +1256,10 @@ func TestNewDeploymentStatus(t *testing.T) {
 	assert.True(t, !rd2.Status.ActiveFrom.IsZero())
 }
 
-func TestGetLatestDeploymentInNamespace_ThreeDeployments_ReturnsLatest(t *testing.T) {
+func TestGetLatestResourceVersionOfTargetEnvironments_ThreeDeployments_ReturnsLatest(t *testing.T) {
 	anyApp := "any-app"
 	anyEnv := "dev"
 	anyComponentName := "frontend"
-	envNamespace := utils.GetEnvironmentNamespace(anyApp, anyEnv)
 
 	// Setup
 	tu, client, radixclient := setupTest()
@@ -1300,12 +1299,15 @@ func TestGetLatestDeploymentInNamespace_ThreeDeployments_ReturnsLatest(t *testin
 					WithPublicPort("http")))
 
 	// Test
-	rd, err := GetLatestDeploymentInNamespace(radixclient, envNamespace)
+	targetEnvironments := make(map[string]bool)
+	targetEnvironments[anyEnv] = true
+
+	latestResourceVersions, err := GetLatestResourceVersionOfTargetEnvironments(radixclient, anyApp, targetEnvironments)
 	assert.NoError(t, err)
 
-	assert.NotEqual(t, rd1.Name, rd.Name)
-	assert.NotEqual(t, rd2.Name, rd.Name)
-	assert.Equal(t, rd3.Name, rd.Name)
+	assert.NotEqual(t, rd1.ResourceVersion, latestResourceVersions[anyEnv])
+	assert.NotEqual(t, rd2.ResourceVersion, latestResourceVersions[anyEnv])
+	assert.Equal(t, rd3.ResourceVersion, latestResourceVersions[anyEnv])
 }
 
 func parseQuantity(value string) resource.Quantity {

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -909,20 +909,30 @@ func TestConstructForTargetEnvironment_PicksTheCorrectEnvironmentConfig(t *testi
 
 	for _, testcase := range testScenarios {
 		t.Run(testcase.environment, func(t *testing.T) {
-			targetEnvs := make(map[string]bool)
-			targetEnvs[testcase.environment] = true
-			rd, _ := ConstructForTargetEnvironments(ra, "anyreg", "anyjob", "anyimage", "anybranch", "anycommit", targetEnvs)
+			rd, _ := ConstructForTargetEnvironment(ra, "anyreg", "anyjob", "anyimage", "anybranch", "anycommit", testcase.environment)
 
-			assert.Equal(t, testcase.expectedReplicas, rd[0].Spec.Components[0].Replicas, "Number of replicas wasn't as expected")
-			assert.Equal(t, testcase.expectedDbHost, rd[0].Spec.Components[0].EnvironmentVariables["DB_HOST"])
-			assert.Equal(t, testcase.expectedDbPort, rd[0].Spec.Components[0].EnvironmentVariables["DB_PORT"])
-			assert.Equal(t, testcase.expectedMemoryLimit, rd[0].Spec.Components[0].Resources.Limits["memory"])
-			assert.Equal(t, testcase.expectedCPULimit, rd[0].Spec.Components[0].Resources.Limits["cpu"])
-			assert.Equal(t, testcase.expectedMemoryRequest, rd[0].Spec.Components[0].Resources.Requests["memory"])
-			assert.Equal(t, testcase.expectedCPURequest, rd[0].Spec.Components[0].Resources.Requests["cpu"])
+			assert.Equal(t, testcase.expectedReplicas, rd.Spec.Components[0].Replicas, "Number of replicas wasn't as expected")
+			assert.Equal(t, testcase.expectedDbHost, rd.Spec.Components[0].EnvironmentVariables["DB_HOST"])
+			assert.Equal(t, testcase.expectedDbPort, rd.Spec.Components[0].EnvironmentVariables["DB_PORT"])
+			assert.Equal(t, testcase.expectedMemoryLimit, rd.Spec.Components[0].Resources.Limits["memory"])
+			assert.Equal(t, testcase.expectedCPULimit, rd.Spec.Components[0].Resources.Limits["cpu"])
+			assert.Equal(t, testcase.expectedMemoryRequest, rd.Spec.Components[0].Resources.Requests["memory"])
+			assert.Equal(t, testcase.expectedCPURequest, rd.Spec.Components[0].Resources.Requests["cpu"])
 		})
 	}
 
+}
+
+func TestDeployToEnvironment_WithMapping_ReturnsForMappedEnvironment(t *testing.T) {
+	// Setup
+	targetEnvs := make(map[string]bool)
+	targetEnvs["dev"] = true
+	targetEnvs["prod"] = false
+
+	// Test
+	assert.True(t, DeployToEnvironment(v1.Environment{Name: "dev"}, targetEnvs))
+	assert.False(t, DeployToEnvironment(v1.Environment{Name: "prod"}, targetEnvs))
+	assert.False(t, DeployToEnvironment(v1.Environment{Name: "orphaned"}, targetEnvs))
 }
 
 func TestObjectSynced_PublicPort_OldPublic(t *testing.T) {
@@ -1244,6 +1254,58 @@ func TestNewDeploymentStatus(t *testing.T) {
 
 	assert.Equal(t, v1.DeploymentActive, rd2.Status.Condition)
 	assert.True(t, !rd2.Status.ActiveFrom.IsZero())
+}
+
+func TestGetLatestDeploymentInNamespace_ThreeDeployments_ReturnsLatest(t *testing.T) {
+	anyApp := "any-app"
+	anyEnv := "dev"
+	anyComponentName := "frontend"
+	envNamespace := utils.GetEnvironmentNamespace(anyApp, anyEnv)
+
+	// Setup
+	tu, client, radixclient := setupTest()
+	rd1, _ := applyDeploymentWithSync(tu, client, radixclient,
+		utils.ARadixDeployment().
+			WithAppName(anyApp).
+			WithEnvironment(anyEnv).
+			WithEmptyStatus(true).
+			WithComponents(
+				utils.NewDeployComponentBuilder().
+					WithName(anyComponentName).
+					WithPort("http", 8080).
+					WithPublicPort("http")))
+
+	time.Sleep(2 * time.Millisecond)
+	rd2, _ := applyDeploymentWithSync(tu, client, radixclient,
+		utils.ARadixDeployment().
+			WithAppName(anyApp).
+			WithEnvironment(anyEnv).
+			WithEmptyStatus(true).
+			WithComponents(
+				utils.NewDeployComponentBuilder().
+					WithName(anyComponentName).
+					WithPort("http", 8080).
+					WithPublicPort("http")))
+
+	time.Sleep(2 * time.Millisecond)
+	rd3, _ := applyDeploymentWithSync(tu, client, radixclient,
+		utils.ARadixDeployment().
+			WithAppName(anyApp).
+			WithEnvironment(anyEnv).
+			WithEmptyStatus(true).
+			WithComponents(
+				utils.NewDeployComponentBuilder().
+					WithName(anyComponentName).
+					WithPort("http", 8080).
+					WithPublicPort("http")))
+
+	// Test
+	rd, err := GetLatestDeploymentInNamespace(radixclient, envNamespace)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, rd1.Name, rd.Name)
+	assert.NotEqual(t, rd2.Name, rd.Name)
+	assert.Equal(t, rd3.Name, rd.Name)
 }
 
 func parseQuantity(value string) resource.Quantity {

--- a/pkg/apis/deployment/radixcomponent.go
+++ b/pkg/apis/deployment/radixcomponent.go
@@ -50,6 +50,7 @@ func getRadixComponentsForEnv(radixApplication *v1.RadixApplication, containerRe
 	return components
 }
 
+// IsDNSAppAlias Checks if environment and component represents the DNS app alias
 func IsDNSAppAlias(env, componentName string, dnsAppAlias v1.AppAlias) bool {
 	return env == dnsAppAlias.Environment && componentName == dnsAppAlias.Component
 }
@@ -75,6 +76,7 @@ func getPublicPortFromAppComponent(appComponent v1.RadixComponent) string {
 	return appComponent.PublicPort
 }
 
+// GetExternalDNSAliasForComponentEnvironment Gets external DNS alias
 func GetExternalDNSAliasForComponentEnvironment(radixApplication *v1.RadixApplication, component, env string) []string {
 	dnsExternalAlias := make([]string, 0)
 

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -22,6 +22,7 @@ type RadixDeployStatus struct {
 	Condition  RadixDeployCondition `json:"condition" yaml:"condition"`
 }
 
+// RadixDeployCondition Holds the condition of a component
 type RadixDeployCondition string
 
 // These are valid conditions of a deployment.

--- a/pkg/apis/utils/deployment_builder.go
+++ b/pkg/apis/utils/deployment_builder.go
@@ -103,6 +103,11 @@ func (db *DeploymentBuilderStruct) WithImageTag(imageTag string) DeploymentBuild
 func (db *DeploymentBuilderStruct) WithEnvironment(environment string) DeploymentBuilder {
 	db.Labels[kube.RadixEnvLabel] = environment
 	db.Environment = environment
+
+	if db.applicationBuilder != nil {
+		db.applicationBuilder = db.applicationBuilder.WithEnvironmentNoBranch(environment)
+	}
+
 	return db
 }
 

--- a/pkg/apis/utils/deployment_builder.go
+++ b/pkg/apis/utils/deployment_builder.go
@@ -22,7 +22,7 @@ type DeploymentBuilder interface {
 	WithEnvironment(string) DeploymentBuilder
 	WithCreated(time.Time) DeploymentBuilder
 	WithUID(types.UID) DeploymentBuilder
-	WithEmptyStatus(bool) DeploymentBuilder
+	WithEmptyStatus() DeploymentBuilder
 	WithComponent(DeployComponentBuilder) DeploymentBuilder
 	WithComponents(...DeployComponentBuilder) DeploymentBuilder
 	GetApplicationBuilder() ApplicationBuilder
@@ -56,8 +56,9 @@ func (db *DeploymentBuilderStruct) WithRadixApplication(applicationBuilder Appli
 	return db
 }
 
-func (db *DeploymentBuilderStruct) WithEmptyStatus(rdStatus bool) DeploymentBuilder {
-	db.emptyStatus = rdStatus
+// WithEmptyStatus Indicates that the RD has no reconciled status
+func (db *DeploymentBuilderStruct) WithEmptyStatus() DeploymentBuilder {
+	db.emptyStatus = true
 	return db
 }
 

--- a/pkg/apis/utils/deployment_builder.go
+++ b/pkg/apis/utils/deployment_builder.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"math/rand"
+	"strconv"
 	"time"
 
 	"github.com/equinor/radix-operator/pkg/apis/kube"
@@ -37,6 +39,7 @@ type DeploymentBuilderStruct struct {
 	ImageTag           string
 	Environment        string
 	Created            time.Time
+	ResourceVersion    string
 	UID                types.UID
 	components         []DeployComponentBuilder
 }
@@ -174,6 +177,7 @@ func (db *DeploymentBuilderStruct) BuildRD() *v1.RadixDeployment {
 			Namespace:         GetEnvironmentNamespace(db.AppName, db.Environment),
 			Labels:            db.Labels,
 			CreationTimestamp: metav1.Time{Time: db.Created},
+			ResourceVersion:   db.ResourceVersion,
 			UID:               db.UID,
 		},
 		Spec: v1.RadixDeploymentSpec{
@@ -189,8 +193,9 @@ func (db *DeploymentBuilderStruct) BuildRD() *v1.RadixDeployment {
 // NewDeploymentBuilder Constructor for deployment builder
 func NewDeploymentBuilder() DeploymentBuilder {
 	return &DeploymentBuilderStruct{
-		Labels:  make(map[string]string),
-		Created: time.Now().UTC(),
+		Labels:          make(map[string]string),
+		Created:         time.Now().UTC(),
+		ResourceVersion: strconv.Itoa(rand.Intn(100)),
 	}
 }
 


### PR DESCRIPTION
Job fails when there is an issue with deployment:

![Screenshot 2019-07-16 at 11 17 43](https://user-images.githubusercontent.com/10051649/61285843-eee4a780-a7c1-11e9-9c87-b980fb1b1969.png)

It is the orchestration step that fails:
![Screenshot 2019-07-16 at 12 04 26](https://user-images.githubusercontent.com/10051649/61285923-0e7bd000-a7c2-11e9-902c-4f78bd575888.png)

The log says it fails because there is a newer deployment:
![Screenshot 2019-07-16 at 12 04 43](https://user-images.githubusercontent.com/10051649/61285952-1cc9ec00-a7c2-11e9-8786-4dd9a152f978.png)
