### PR TITLE
Enforce lowercase name in radixconfig

### DIFF
--- a/pipeline-runner/steps/apply_radixconfig.go
+++ b/pipeline-runner/steps/apply_radixconfig.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/equinor/radix-operator/pipeline-runner/model"
 	application "github.com/equinor/radix-operator/pkg/apis/applicationconfig"
@@ -57,6 +58,12 @@ func (cli *ApplyConfigStepImplementation) Run(pipelineInfo *model.PipelineInfo) 
 	// Validate RA
 	if validate.RAContainsOldPublic(ra) {
 		log.Warnf("component.public is deprecated, please use component.publicPort instead")
+	}
+
+	isAppNameLowercase, err := validate.IsApplicationNameLowercase(ra.Name)
+	if !isAppNameLowercase {
+		log.Warnf("%s Converting name to lowercase", err.Error())
+		ra.Name = strings.ToLower(ra.Name)
 	}
 
 	isRAValid, errs := validate.CanRadixApplicationBeInsertedErrors(cli.GetRadixclient(), ra)

--- a/pkg/apis/radixvalidators/validate_ra.go
+++ b/pkg/apis/radixvalidators/validate_ra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/utils/branch"
@@ -131,6 +132,20 @@ func CanRadixApplicationBeInserted(client radixclient.Interface, app *radixv1.Ra
 	}
 
 	return false, errorUtils.Concat(errs)
+}
+
+// IsApplicationNameLowercase checks if the application name has any uppercase letters
+func IsApplicationNameLowercase(appName string) (bool, error) {
+	for _, r := range appName {
+		if unicode.IsUpper(r) && unicode.IsLetter(r) {
+			return false, ApplicationNameNotLowercaseError(appName)
+		}
+	}
+	return true, nil
+}
+
+func ApplicationNameNotLowercaseError(appName string) error {
+	return fmt.Errorf("Application with name %s contains uppercase letters.", appName)
 }
 
 // PublicImageComponentCannotHaveSourceOrDockerfileSet Error if image is set and radix config contains src or dockerfile

--- a/pkg/apis/radixvalidators/validate_ra_test.go
+++ b/pkg/apis/radixvalidators/validate_ra_test.go
@@ -50,7 +50,6 @@ func Test_application_name_casing_is_validated(t *testing.T) {
 		{"Upper case name", radixvalidators.ApplicationNameNotLowercaseError(upperCaseName), func(ra *v1.RadixApplication) { ra.Name = upperCaseName }},
 	}
 
-	// _, client := validRASetup()
 	for _, testcase := range testScenarios {
 		t.Run(testcase.name, func(t *testing.T) {
 			validRA := createValidRA()


### PR DESCRIPTION
Applications with uppercase /metadata/name in radixconfig.yaml will trigger a warning in the build process stating that the name contains uppercase letters and automatically convert it to lowercase for  the user.