### PR TITLE
45644 Add configBranch to RadixRegistration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/
 rootfs/
 .vscode/
 .idea/
+radix-operator/__debug_bin

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.0.44
-appVersion: 1.5.30
+appVersion: 1.6.0
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/applicationconfig/applicationconfig.go
+++ b/pkg/apis/applicationconfig/applicationconfig.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// MagicBranch The branch that radix config lives on
-const MagicBranch = "master"
+// ConfigBranchFallback The branch to use for radix config if ConfigName is not configured on the radix registration
+const ConfigBranchFallback = "master"
 
 // ApplicationConfig Instance variables
 type ApplicationConfig struct {
@@ -88,9 +88,14 @@ func GetEnvironment(component *v1.RadixComponent, envName string) *v1.RadixEnvir
 	return nil
 }
 
-// IsMagicBranch Checks if given branch is were radix config lives
-func IsMagicBranch(branch string) bool {
-	return strings.EqualFold(branch, MagicBranch)
+// GetConfigBranch Returns config branch name from radix registration, or "master" if not set.
+func GetConfigBranch(rr *v1.RadixRegistration) string {
+	return utils.TernaryString(rr.Spec.ConfigBranch == "", ConfigBranchFallback, rr.Spec.ConfigBranch)
+}
+
+// IsConfigBranch Checks if given branch is were radix config lives
+func IsConfigBranch(branch string, rr *v1.RadixRegistration) bool {
+	return strings.EqualFold(branch, GetConfigBranch(rr))
 }
 
 // IsThereAnythingToDeploy Checks if given branch requires deployment to environments

--- a/pkg/apis/applicationconfig/applicationconfig.go
+++ b/pkg/apis/applicationconfig/applicationconfig.go
@@ -90,7 +90,7 @@ func GetEnvironment(component *v1.RadixComponent, envName string) *v1.RadixEnvir
 
 // GetConfigBranch Returns config branch name from radix registration, or "master" if not set.
 func GetConfigBranch(rr *v1.RadixRegistration) string {
-	return utils.TernaryString(rr.Spec.ConfigBranch == "", ConfigBranchFallback, rr.Spec.ConfigBranch)
+	return utils.TernaryString(strings.TrimSpace(rr.Spec.ConfigBranch) == "", ConfigBranchFallback, rr.Spec.ConfigBranch)
 }
 
 // IsConfigBranch Checks if given branch is were radix config lives

--- a/pkg/apis/applicationconfig/applicationconfig.go
+++ b/pkg/apis/applicationconfig/applicationconfig.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// ConfigBranchFallback The branch to use for radix config if ConfigName is not configured on the radix registration
+// ConfigBranchFallback The branch to use for radix config if ConfigBranch is not configured on the radix registration
 const ConfigBranchFallback = "master"
 
 // ApplicationConfig Instance variables

--- a/pkg/apis/applicationconfig/applicationconfig_test.go
+++ b/pkg/apis/applicationconfig/applicationconfig_test.go
@@ -526,6 +526,39 @@ func Test_RadixEnvironment(t *testing.T) {
 	})
 }
 
+func Test_GetConfigBranch_notSet(t *testing.T) {
+	rr := utils.NewRegistrationBuilder().
+		BuildRR()
+
+	assert.Equal(t, ConfigBranchFallback, GetConfigBranch(rr))
+}
+
+func Test_GetConfigBranch_set(t *testing.T) {
+	configBranch := "main"
+
+	rr := utils.NewRegistrationBuilder().
+		WithConfigBranch(configBranch).
+		BuildRR()
+
+	assert.Equal(t, configBranch, GetConfigBranch(rr))
+}
+
+func Test_IsConfigBranch(t *testing.T) {
+	configBranch, otherBranch := "main", "master"
+
+	rr := utils.NewRegistrationBuilder().
+		WithConfigBranch(configBranch).
+		BuildRR()
+
+	t.Run("Branch is configBranch", func(t *testing.T) {
+		assert.True(t, IsConfigBranch(configBranch, rr))
+	})
+
+	t.Run("Branch is not configBranch", func(t *testing.T) {
+		assert.False(t, IsConfigBranch(otherBranch, rr))
+	})
+}
+
 func rrAsOwnerReference(rr *radixv1.RadixRegistration) []metav1.OwnerReference {
 	trueVar := true
 	return []metav1.OwnerReference{

--- a/pkg/apis/applicationconfig/testdata/sampleregistration.yaml
+++ b/pkg/apis/applicationconfig/testdata/sampleregistration.yaml
@@ -9,3 +9,5 @@ spec:
   sharedSecret: "NotSoSecret"
   secrets:
     test: test
+  wbs: "wbs.000"
+  configBranch: "main"

--- a/pkg/apis/radix/v1/radixregistrationtypes.go
+++ b/pkg/apis/radix/v1/radixregistrationtypes.go
@@ -32,6 +32,7 @@ type RadixRegistrationSpec struct {
 	Owner           string   `json:"owner" yaml:"owner"`
 	MachineUser     bool     `json:"machineUser" yaml:"machineUser"`
 	WBS             string   `json:"wbs" yaml:"wbs"`
+	ConfigBranch    string   `json:"configBranch" yaml:"configBranch"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/radixvalidators/testdata/radixregistration.yaml
+++ b/pkg/apis/radixvalidators/testdata/radixregistration.yaml
@@ -12,3 +12,4 @@ spec:
   secrets:
     test: test
   wbs: "T.O123A.AZ.45678"
+  configBranch: "main"

--- a/pkg/apis/radixvalidators/validate_rr.go
+++ b/pkg/apis/radixvalidators/validate_rr.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	"github.com/equinor/radix-operator/pkg/apis/utils/branch"
 	errorUtils "github.com/equinor/radix-operator/pkg/apis/utils/errors"
 	radixclient "github.com/equinor/radix-operator/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -250,8 +251,7 @@ func validateConfigBranch(name string) error {
 		return ResourceNameCannotBeEmptyError("branch name")
 	}
 
-	re := regexp.MustCompile("")
-	if isValid := re.MatchString(name); !isValid {
+	if isValid := branch.IsValidName(name); !isValid {
 		return fmt.Errorf("branch name is not valid")
 	}
 

--- a/pkg/apis/radixvalidators/validate_rr.go
+++ b/pkg/apis/radixvalidators/validate_rr.go
@@ -78,32 +78,36 @@ func CanRadixRegistrationBeInserted(client radixclient.Interface, radixRegistrat
 // CanRadixRegistrationBeUpdated Validates update of RR
 func CanRadixRegistrationBeUpdated(client radixclient.Interface, radixRegistration *v1.RadixRegistration) (bool, error) {
 	errs := []error{}
-	err := validateAppName(radixRegistration.Name)
-	if err != nil {
+
+	if err := validateAppName(radixRegistration.Name); err != nil {
 		errs = append(errs, err)
 	}
-	err = validateEmail("owner", radixRegistration.Spec.Owner)
-	if err != nil {
+
+	if err := validateEmail("owner", radixRegistration.Spec.Owner); err != nil {
 		errs = append(errs, err)
 	}
-	err = validateWbs(radixRegistration.Spec.WBS)
-	if err != nil {
+
+	if err := validateWbs(radixRegistration.Spec.WBS); err != nil {
 		errs = append(errs, err)
 	}
-	err = validateGitSSHUrl(radixRegistration.Spec.CloneURL)
-	if err != nil {
+
+	if err := validateGitSSHUrl(radixRegistration.Spec.CloneURL); err != nil {
 		errs = append(errs, err)
 	}
-	err = validateSSHKey(radixRegistration.Spec.DeployKey)
-	if err != nil {
+
+	if err := validateSSHKey(radixRegistration.Spec.DeployKey); err != nil {
 		errs = append(errs, err)
 	}
-	err = validateAdGroups(radixRegistration.Spec.AdGroups)
-	if err != nil {
+
+	if err := validateAdGroups(radixRegistration.Spec.AdGroups); err != nil {
 		errs = append(errs, err)
 	}
-	err = validateNoDuplicateGitRepo(client, radixRegistration.Name, radixRegistration.Spec.CloneURL)
-	if err != nil {
+
+	if err := validateNoDuplicateGitRepo(client, radixRegistration.Name, radixRegistration.Spec.CloneURL); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := validateConfigBranch(radixRegistration.Spec.ConfigBranch); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -238,5 +242,18 @@ func validateDoesRRExist(client radixclient.Interface, appName string) error {
 	if rr == nil || err != nil {
 		return NoRegistrationExistsForApplicationError(appName)
 	}
+	return nil
+}
+
+func validateConfigBranch(name string) error {
+	if name == "" {
+		return ResourceNameCannotBeEmptyError("branch name")
+	}
+
+	re := regexp.MustCompile("")
+	if isValid := re.MatchString(name); !isValid {
+		return fmt.Errorf("branch name is not valid")
+	}
+
 	return nil
 }

--- a/pkg/apis/radixvalidators/validate_rr.go
+++ b/pkg/apis/radixvalidators/validate_rr.go
@@ -251,7 +251,7 @@ func validateConfigBranch(name string) error {
 		return ResourceNameCannotBeEmptyError("branch name")
 	}
 
-	if isValid := branch.IsValidName(name); !isValid {
+	if !branch.IsValidName(name) {
 		return fmt.Errorf("branch name is not valid")
 	}
 

--- a/pkg/apis/radixvalidators/validate_rr_test.go
+++ b/pkg/apis/radixvalidators/validate_rr_test.go
@@ -1,6 +1,9 @@
 package radixvalidators_test
 
 import (
+	"strings"
+	"testing"
+
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/radixvalidators"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
@@ -9,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	"strings"
-	"testing"
 )
 
 func Test_valid_rr_returns_true(t *testing.T) {
@@ -49,6 +50,7 @@ func TestCanRadixApplicationBeInserted(t *testing.T) {
 		{"invalid ad group lenght", func(rr *v1.RadixRegistration) { rr.Spec.AdGroups = []string{"7552642f-asdff-fs43-23sf-3ab8f3742c16"} }},
 		{"invalid ad group name", func(rr *v1.RadixRegistration) { rr.Spec.AdGroups = []string{"fg_some_group_name"} }},
 		{"empty ad group", func(rr *v1.RadixRegistration) { rr.Spec.AdGroups = []string{""} }},
+		{"empty configBranch", func(rr *v1.RadixRegistration) { rr.Spec.ConfigBranch = "" }},
 	}
 
 	_, client := validRRSetup()

--- a/pkg/apis/radixvalidators/validate_rr_test.go
+++ b/pkg/apis/radixvalidators/validate_rr_test.go
@@ -51,6 +51,7 @@ func TestCanRadixApplicationBeInserted(t *testing.T) {
 		{"invalid ad group name", func(rr *v1.RadixRegistration) { rr.Spec.AdGroups = []string{"fg_some_group_name"} }},
 		{"empty ad group", func(rr *v1.RadixRegistration) { rr.Spec.AdGroups = []string{""} }},
 		{"empty configBranch", func(rr *v1.RadixRegistration) { rr.Spec.ConfigBranch = "" }},
+		{"invalid configBranch", func(rr *v1.RadixRegistration) { rr.Spec.ConfigBranch = "main.." }},
 	}
 
 	_, client := validRRSetup()

--- a/pkg/apis/utils/branch/name_validator.go
+++ b/pkg/apis/utils/branch/name_validator.go
@@ -1,0 +1,14 @@
+package branch
+
+import (
+	"regexp"
+)
+
+var (
+	invalidSeq = regexp.MustCompile("([\\?\\s\\\\\\^~:\\*\\[[:cntrl:]])|([\\./]{2,})|(@\\{)|(/\\.)|^@$|^/|/$|\\.lock$|(\\.lock/)|^$")
+)
+
+// IsValidName Checks if a branch name is valid
+func IsValidName(branch string) bool {
+	return !invalidSeq.MatchString(branch)
+}

--- a/pkg/apis/utils/branch/name_validator_test.go
+++ b/pkg/apis/utils/branch/name_validator_test.go
@@ -1,0 +1,67 @@
+package branch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type branchNameTest struct {
+	s     string
+	valid bool
+}
+
+func TestIsValidName(t *testing.T) {
+
+	tests := []branchNameTest{
+		{"main?", false},
+		{"ma?in", false},
+		{"?main", false},
+		{"main ", false},
+		{"ma in", false},
+		{" main", false},
+		{"main\\", false},
+		{"ma\\in", false},
+		{"\\main", false},
+		{"main^", false},
+		{"ma^in", false},
+		{"^main", false},
+		{"main~", false},
+		{"ma~in", false},
+		{"~main", false},
+		{"main:", false},
+		{"ma:in", false},
+		{":main", false},
+		{"main*", false},
+		{"ma*in", false},
+		{"*main", false},
+		{"main[", false},
+		{"ma[in", false},
+		{"[main", false},
+		{"main/.feat", false},
+		{"/main", false},
+		{"main/", false},
+		{"ma//in", false},
+		{string([]byte{0x40, 0x41, 0x41, 0x1F}), false},
+		{string([]byte{0x40, 0x41, 0x41, 0x7F}), false},
+		{"main..", false},
+		{"ma..in", false},
+		{"..main", false},
+		{"ma@{in", false},
+		{"main.lock", false},
+		{"main.lock/feat", false},
+		{"@", false},
+		{"", false},
+		{"main", true},
+		{"main/feature", true},
+		{"main/feat.ure", true},
+		{"main/feature.", true},
+		{"main/@feature", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.s, func(t *testing.T) {
+			assert.Equal(t, test.valid, IsValidName(test.s))
+		})
+	}
+}

--- a/pkg/apis/utils/registration_builder.go
+++ b/pkg/apis/utils/registration_builder.go
@@ -24,6 +24,7 @@ type RegistrationBuilder interface {
 	WithEmptyStatus() RegistrationBuilder
 	WithMachineUser(bool) RegistrationBuilder
 	WithWBS(string) RegistrationBuilder
+	WithConfigBranch(string) RegistrationBuilder
 	WithRadixRegistration(*v1.RadixRegistration) RegistrationBuilder
 	BuildRR() *v1.RadixRegistration
 }
@@ -43,6 +44,7 @@ type RegistrationBuilderStruct struct {
 	emptyStatus  bool
 	machineUser  bool
 	wbs          string
+	configBranch string
 }
 
 // WithRadixRegistration Re-enginers a builder from a registration
@@ -138,6 +140,12 @@ func (rb *RegistrationBuilderStruct) WithWBS(wbs string) RegistrationBuilder {
 	return rb
 }
 
+// WithConfigBranch Sets ConfigBranch
+func (rb *RegistrationBuilderStruct) WithConfigBranch(configBranch string) RegistrationBuilder {
+	rb.configBranch = configBranch
+	return rb
+}
+
 // BuildRR Builds the radix registration
 func (rb *RegistrationBuilderStruct) BuildRR() *v1.RadixRegistration {
 	cloneURL := rb.cloneURL
@@ -171,6 +179,7 @@ func (rb *RegistrationBuilderStruct) BuildRR() *v1.RadixRegistration {
 			Creator:         rb.creator,
 			MachineUser:     rb.machineUser,
 			WBS:             rb.wbs,
+			ConfigBranch:    rb.configBranch,
 		},
 		Status: status,
 	}
@@ -192,7 +201,8 @@ func ARadixRegistration() RegistrationBuilder {
 		WithAdGroups([]string{"604bad73-c53b-4a95-ab17-d7953f75c8c3"}).
 		WithOwner("radix@equinor.com").
 		WithCreator("radix@equinor.com").
-		WithWBS("A.BCD.00.999")
+		WithWBS("A.BCD.00.999").
+		WithConfigBranch("main")
 
 	return builder
 }


### PR DESCRIPTION
- Add configBranch to RR
- Use configBranch when cloning radixconfig.yaml in pipeline-runner
- Extend RR validation functions used by radix-api