### PR TITLE
46550 52031 add blobfuse config secrets (#496)

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.0.44
-appVersion: 1.7.0
+appVersion: 1.7.1
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/defaults/secrets.go
+++ b/pkg/apis/defaults/secrets.go
@@ -15,6 +15,9 @@ const (
 	// BlobFuseCredsAccountKeyPartSuffix Account key suffix of secret listed
 	BlobFuseCredsAccountKeyPartSuffix = "-accountkey"
 
+	// BlobFuseCredsAccountNamePartSuffix Account name suffix of secret listed
+	BlobFuseCredsAccountNamePartSuffix = "-accountname"
+
 	// BlobFuseCredsAccountKeyPart Account key part of secret data
 	BlobFuseCredsAccountKeyPart = "accountkey"
 
@@ -24,7 +27,7 @@ const (
 	blobFuseCreds = "%s-blobfusecreds" // <componentname>-blobfusecreds
 )
 
-// GetBlobFuseCredsSecret Helper method
-func GetBlobFuseCredsSecret(componentName string) string {
+// GetBlobFuseCredsSecretName Helper method
+func GetBlobFuseCredsSecretName(componentName string) string {
 	return fmt.Sprintf(blobFuseCreds, componentName)
 }

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -154,10 +154,9 @@ func TestObjectSynced_MultiComponent_ContainsAllElements(t *testing.T) {
 							WithPublicPort("http").
 							WithVolumeMounts([]v1.RadixVolumeMount{
 								{
-									Type:        v1.MountTypeBlob,
-									AccountName: "some-account",
-									Container:   "some-container",
-									Path:        "some-path",
+									Type:      v1.MountTypeBlob,
+									Container: "some-container",
+									Path:      "some-path",
 								},
 							}).
 							WithSecrets([]string{outdatedSecret, remainingSecret}))
@@ -255,12 +254,14 @@ func TestObjectSynced_MultiComponent_ContainsAllElements(t *testing.T) {
 					assert.True(t, envVariableByNameExistOnDeployment(addingSecret, componentNameRadixQuote, deployments))
 				}
 
+				volumesExist := len(spec.Template.Spec.Volumes) > 0
+				volumeMountsExist := len(spec.Template.Spec.Containers[0].VolumeMounts) > 0
 				if !componentsExist {
-					assert.True(t, len(spec.Template.Spec.Volumes) > 0)
-					assert.True(t, len(spec.Template.Spec.Containers[0].VolumeMounts) > 0)
+					assert.True(t, volumesExist, "expected existing volumes")
+					assert.True(t, volumeMountsExist, "expected existing volume mounts")
 				} else {
-					assert.False(t, len(spec.Template.Spec.Volumes) > 0)
-					assert.False(t, len(spec.Template.Spec.Containers[0].VolumeMounts) > 0)
+					assert.False(t, volumesExist, "unexpected existing volumes")
+					assert.False(t, volumeMountsExist, "unexpected existing volume mounts")
 				}
 			})
 
@@ -292,7 +293,7 @@ func TestObjectSynced_MultiComponent_ContainsAllElements(t *testing.T) {
 				componentSecretName := utils.GetComponentSecretName(componentNameRadixQuote)
 				assert.True(t, secretByNameExists(componentSecretName, secrets), "Component secret is not as expected")
 
-				// Exists due to external DNS, even though this is not acive cluster
+				// Exists due to external DNS, even though this is not active cluster
 				if !componentsExist {
 					assert.True(t, secretByNameExists("some.alias.com", secrets), "TLS certificate for external alias is not properly defined")
 					assert.True(t, secretByNameExists("another.alias.com", secrets), "TLS certificate for second external alias is not properly defined")
@@ -301,10 +302,11 @@ func TestObjectSynced_MultiComponent_ContainsAllElements(t *testing.T) {
 					assert.True(t, secretByNameExists("updated_another.alias.com", secrets), "TLS certificate for second external alias is not properly defined")
 				}
 
+				blobFuseSecretExists := secretByNameExists(defaults.GetBlobFuseCredsSecretName(componentNameRadixQuote), secrets)
 				if !componentsExist {
-					assert.True(t, secretByNameExists(defaults.GetBlobFuseCredsSecret(componentNameRadixQuote), secrets), "Volume mount secret")
+					assert.True(t, blobFuseSecretExists, "expected volume mount secret")
 				} else {
-					assert.False(t, secretByNameExists(defaults.GetBlobFuseCredsSecret(componentNameRadixQuote), secrets), "TLS certificate for external alias is not properly defined")
+					assert.False(t, blobFuseSecretExists, "unexpected volume mount secrets")
 				}
 			})
 
@@ -1069,10 +1071,9 @@ func TestConstructForTargetEnvironment_PicksTheCorrectEnvironmentConfig(t *testi
 						}).
 						WithVolumeMounts([]v1.RadixVolumeMount{
 							{
-								Type:        v1.MountTypeBlob,
-								AccountName: "some-account",
-								Container:   "some-container",
-								Path:        "some-path",
+								Type:      v1.MountTypeBlob,
+								Container: "some-container",
+								Path:      "some-path",
 							},
 						}).
 						WithReplicas(test.IntPtr(3)))).

--- a/pkg/apis/deployment/volumemount.go
+++ b/pkg/apis/deployment/volumemount.go
@@ -44,7 +44,7 @@ func (deploy *Deployment) getVolumes(deployComponent *radixv1.RadixDeployCompone
 
 		for _, volumeMount := range deployComponent.VolumeMounts {
 			if volumeMount.Type == radixv1.MountTypeBlob {
-				secretName := defaults.GetBlobFuseCredsSecret(deployComponent.Name)
+				secretName := defaults.GetBlobFuseCredsSecretName(deployComponent.Name)
 
 				flexVolumeOptions := make(map[string]string)
 				flexVolumeOptions["container"] = volumeMount.Container
@@ -70,7 +70,7 @@ func (deploy *Deployment) getVolumes(deployComponent *radixv1.RadixDeployCompone
 	return volumes
 }
 
-func (deploy *Deployment) createOrUpdateVolumeMountsSecrets(namespace, componentName, secretName, accountName string, accountKey []byte) error {
+func (deploy *Deployment) createOrUpdateVolumeMountsSecrets(namespace, componentName, secretName string, accountName, accountKey []byte) error {
 	blobfusecredsSecret := v1.Secret{
 		Type: "azure/blobfuse",
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +86,7 @@ func (deploy *Deployment) createOrUpdateVolumeMountsSecrets(namespace, component
 	// Will need to set fake data in order to apply the secret. The user then need to set data to real values
 	data := make(map[string][]byte)
 	data[defaults.BlobFuseCredsAccountKeyPart] = accountKey
-	data[defaults.BlobFuseCredsAccountNamePart] = []byte(accountName)
+	data[defaults.BlobFuseCredsAccountNamePart] = accountName
 
 	blobfusecredsSecret.Data = data
 

--- a/pkg/apis/radix/v1/radixapptypes.go
+++ b/pkg/apis/radix/v1/radixapptypes.go
@@ -146,10 +146,9 @@ type RadixPrivateImageHubCredential struct {
 
 // RadixVolumeMount defines volume to be mounted to the container
 type RadixVolumeMount struct {
-	Type        MountType `json:"type" yaml:"type"`
-	AccountName string    `json:"accountName" yaml:"accountName"`
-	Container   string    `json:"container" yaml:"container"`
-	Path        string    `json:"path" yaml:"path"`
+	Type      MountType `json:"type" yaml:"type"`
+	Container string    `json:"container" yaml:"container"`
+	Path      string    `json:"path" yaml:"path"`
 }
 
 // MountType Holds types of mount

--- a/pkg/apis/radixvalidators/validate_ra_test.go
+++ b/pkg/apis/radixvalidators/validate_ra_test.go
@@ -574,10 +574,9 @@ func Test_ValidationOfVolumeMounts_Errors(t *testing.T) {
 			func(ra *v1.RadixApplication) {
 				volumeMounts := []v1.RadixVolumeMount{
 					{
-						Type:        "disk",
-						AccountName: "some_account_name",
-						Container:   "some_container_name",
-						Path:        "some_path",
+						Type:      "disk",
+						Container: "some_container_name",
+						Path:      "some_path",
 					},
 				}
 
@@ -591,28 +590,10 @@ func Test_ValidationOfVolumeMounts_Errors(t *testing.T) {
 			func(ra *v1.RadixApplication) {
 				volumeMounts := []v1.RadixVolumeMount{
 					{
-						Type:        v1.MountTypeBlob,
-						AccountName: "some_account_name",
-						Container:   "some_container_name",
-						Path:        "some_path",
+						Type:      v1.MountTypeBlob,
+						Container: "some_container_name",
+						Path:      "some_path",
 					},
-					{
-						Type:        v1.MountTypeBlob,
-						AccountName: "some_account_name",
-						Container:   "some_container_name",
-						Path:        "some_path",
-					},
-				}
-
-				ra.Spec.Components[0].EnvironmentConfig[0].VolumeMounts = volumeMounts
-			},
-			false,
-			false,
-		},
-		{
-			"mount volume account name is not set",
-			func(ra *v1.RadixApplication) {
-				volumeMounts := []v1.RadixVolumeMount{
 					{
 						Type:      v1.MountTypeBlob,
 						Container: "some_container_name",
@@ -626,29 +607,12 @@ func Test_ValidationOfVolumeMounts_Errors(t *testing.T) {
 			false,
 		},
 		{
-			"mount volume container name is not set",
-			func(ra *v1.RadixApplication) {
-				volumeMounts := []v1.RadixVolumeMount{
-					{
-						Type:        v1.MountTypeBlob,
-						AccountName: "some_account_name",
-						Path:        "some_path",
-					},
-				}
-
-				ra.Spec.Components[0].EnvironmentConfig[0].VolumeMounts = volumeMounts
-			},
-			false,
-			false,
-		},
-		{
 			"mount volume path is not set",
 			func(ra *v1.RadixApplication) {
 				volumeMounts := []v1.RadixVolumeMount{
 					{
-						Type:        v1.MountTypeBlob,
-						AccountName: "some_account_name",
-						Container:   "some_container_name",
+						Type:      v1.MountTypeBlob,
+						Container: "some_container_name",
 					},
 				}
 


### PR DESCRIPTION
* 46550-52031 blobfuse account name is taken only from secret - not from config

* 46550-52031 restored BlobFuseCredsAccount PartSuffix

* Added missed accountname to volume

* Removed obsolete accountname from volume

* Code cleanup

* Code cleanup