### PR TITLE
72931 handle jobs in radix api

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.0
-appVersion: 1.9.0
+appVersion: 1.9.1
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -56,11 +56,11 @@ func NewDeployment(kubeclient kubernetes.Interface,
 		kubeutil, prometheusperatorclient, registration, radixDeployment}, nil
 }
 
-// GetDeploymentComponent Gets the index and component/job from a RadixDeployment
+// GetDeploymentCommonComponent Gets the index and component/job from a RadixDeployment
 // The index refers the the index in either the components or jobs spec of the RadixDeployment
 // Use GetType() to identify if the index refers to the components or jobs section
 // Returns -1, nil if component/job does not exist
-func GetDeploymentComponent(rd *v1.RadixDeployment, name string) (int, v1.RadixCommonDeployComponent) {
+func GetDeploymentCommonComponent(rd *v1.RadixDeployment, name string) (int, v1.RadixCommonDeployComponent) {
 	for index, component := range rd.Spec.Components {
 		if strings.EqualFold(component.Name, name) {
 			return index, &component

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -56,11 +56,19 @@ func NewDeployment(kubeclient kubernetes.Interface,
 		kubeutil, prometheusperatorclient, registration, radixDeployment}, nil
 }
 
-// GetDeploymentComponent Gets the index  of and the component given name
-func GetDeploymentComponent(rd *v1.RadixDeployment, name string) (int, *v1.RadixDeployComponent) {
+// GetDeploymentComponent Gets the index and component/job from a RadixDeployment
+// The index refers the the index in either the components or jobs spec of the RadixDeployment
+// Use GetType() to identify if the index refers to the components or jobs section
+// Returns -1, nil if component/job does not exist
+func GetDeploymentComponent(rd *v1.RadixDeployment, name string) (int, v1.RadixCommonDeployComponent) {
 	for index, component := range rd.Spec.Components {
 		if strings.EqualFold(component.Name, name) {
 			return index, &component
+		}
+	}
+	for index, job := range rd.Spec.Jobs {
+		if strings.EqualFold(job.Name, name) {
+			return index, &job
 		}
 	}
 	return -1, nil

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -2407,7 +2407,7 @@ func TestObjectUpdated_UpdatePort_DeploymentPodPortSpecIsCorrect(t *testing.T) {
 	portTestFunc("scheduler-port", 9090, job.Spec.Template.Spec.Containers[0].Ports)
 }
 
-func Test_GetDeploymentComponent(t *testing.T) {
+func Test_GetDeploymentCommonComponent(t *testing.T) {
 	rd := utils.NewDeploymentBuilder().
 		WithComponents(
 			utils.NewDeployComponentBuilder().WithName("app1"),
@@ -2419,19 +2419,19 @@ func Test_GetDeploymentComponent(t *testing.T) {
 		).
 		BuildRD()
 
-	index, comp := GetDeploymentComponent(rd, "app1")
+	index, comp := GetDeploymentCommonComponent(rd, "app1")
 	assert.Equal(t, 0, index)
 	assert.Equal(t, "app1", comp.GetName())
 
-	index, comp = GetDeploymentComponent(rd, "app2")
+	index, comp = GetDeploymentCommonComponent(rd, "app2")
 	assert.Equal(t, 1, index)
 	assert.Equal(t, "app2", comp.GetName())
 
-	index, comp = GetDeploymentComponent(rd, "job1")
+	index, comp = GetDeploymentCommonComponent(rd, "job1")
 	assert.Equal(t, 0, index)
 	assert.Equal(t, "job1", comp.GetName())
 
-	index, comp = GetDeploymentComponent(rd, "job2")
+	index, comp = GetDeploymentCommonComponent(rd, "job2")
 	assert.Equal(t, 1, index)
 	assert.Equal(t, "job2", comp.GetName())
 }

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -2407,6 +2407,35 @@ func TestObjectUpdated_UpdatePort_DeploymentPodPortSpecIsCorrect(t *testing.T) {
 	portTestFunc("scheduler-port", 9090, job.Spec.Template.Spec.Containers[0].Ports)
 }
 
+func Test_GetDeploymentComponent(t *testing.T) {
+	rd := utils.NewDeploymentBuilder().
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("app1"),
+			utils.NewDeployComponentBuilder().WithName("app2"),
+		).
+		WithJobComponents(
+			utils.NewDeployJobComponentBuilder().WithName("job1"),
+			utils.NewDeployJobComponentBuilder().WithName("job2"),
+		).
+		BuildRD()
+
+	index, comp := GetDeploymentComponent(rd, "app1")
+	assert.Equal(t, 0, index)
+	assert.Equal(t, "app1", comp.GetName())
+
+	index, comp = GetDeploymentComponent(rd, "app2")
+	assert.Equal(t, 1, index)
+	assert.Equal(t, "app2", comp.GetName())
+
+	index, comp = GetDeploymentComponent(rd, "job1")
+	assert.Equal(t, 0, index)
+	assert.Equal(t, "job1", comp.GetName())
+
+	index, comp = GetDeploymentComponent(rd, "job2")
+	assert.Equal(t, 1, index)
+	assert.Equal(t, "job2", comp.GetName())
+}
+
 func parseQuantity(value string) resource.Quantity {
 	q, _ := resource.ParseQuantity(value)
 	return q


### PR DESCRIPTION
Function is used in radix-api, and only there, and is used by the stop/start/restart api. (Perhaps it could be moved to radix-api)
Extended to also return jobs to allow stopping, starting and restarting job-scheduler