### PR TITLE
50003 prevent restart of all components

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -70,7 +70,7 @@
         "RADIXOPERATOR_APP_ROLLING_UPDATE_MAX_SURGE": "25%",
         "RADIXOPERATOR_APP_READINESS_PROBE_INITIAL_DELAY_SECONDS": "5",
         "RADIXOPERATOR_APP_READINESS_PROBE_PERIOD_SECONDS": "10",
-        "RADIX_ACTIVE_CLUSTERNAME": "weekly-11",
+        "RADIX_ACTIVE_CLUSTERNAME": "weekly-12",
         "RADIX_CONFIG_TO_MAP": "radix-config-2-map:master-latest",
         "RADIX_IMAGE_BUILDER": "radix-image-builder:master-latest",
         "RADIX_IMAGE_SCANNER": "radix-image-scanner:master-latest",

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.0
-appVersion: 1.9.3
+appVersion: 1.9.4
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 
@@ -225,7 +224,7 @@ func (deploy *Deployment) getRadixBranchAndCommitId() (string, string) {
 
 func (deploy *Deployment) updateDeploymentByComponent(deployComponent v1.RadixCommonDeployComponent, desiredDeployment *appsv1.Deployment, appName string) (*appsv1.Deployment, error) {
 	if deployComponent.IsAlwaysPullImageOnDeploy() {
-		desiredDeployment.Spec.Template.Annotations[kube.RadixUpdateTimeAnnotation] = time.Now().Format(time.RFC3339)
+		desiredDeployment.Spec.Template.Annotations[kube.RadixDeploymentNameAnnotation] = deploy.radixDeployment.Name
 	}
 
 	replicas := deployComponent.GetReplicas()

--- a/pkg/apis/kube/kube.go
+++ b/pkg/apis/kube/kube.go
@@ -17,7 +17,7 @@ import (
 const (
 	RadixBranchAnnotation          = "radix-branch"
 	RadixComponentImagesAnnotation = "radix-component-images"
-	RadixUpdateTimeAnnotation      = "radix-update-time"
+	RadixDeploymentNameAnnotation  = "radix-deployment-name"
 
 	// See https://github.com/equinor/radix-velero-plugin/blob/master/velero-plugins/deployment/restore.go
 	RestoredStatusAnnotation = "equinor.com/velero-restored-status"


### PR DESCRIPTION
Use name of RadixDeployment as annotation for components with alwaysPullImageOnDeploy=true.
This prevents such components form being restarted every time another component is stopped, started or restarted, but will force a restart and image pull whenever a new RadixDeployment is created.
