### PR TITLE
add test for job runAsNonRoot environment config

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.1
-appVersion: 1.11.2
+appVersion: 1.11.3
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/radixjobcomponent_test.go
+++ b/pkg/apis/deployment/radixjobcomponent_test.go
@@ -144,6 +144,29 @@ func Test_GetRadixJobComponents_ImageTagName(t *testing.T) {
 	assert.Equal(t, "job2:tag", jobs[1].Image)
 }
 
+func Test_GetRadixJobComponents_RunAsNonRoot(t *testing.T) {
+	ra := utils.ARadixApplication().
+		WithJobComponents(
+			utils.AnApplicationJobComponent().
+				WithName("job").
+				WithEnvironmentConfigs(
+					utils.NewJobComponentEnvironmentBuilder().
+						WithEnvironment("env1").
+						WithRunAsNonRoot(true),
+					utils.NewJobComponentEnvironmentBuilder().
+						WithEnvironment("env2"),
+				),
+		).BuildRA()
+
+	cfg := jobComponentsBuilder{ra: ra, env: "env1", componentImages: make(map[string]pipeline.ComponentImage)}
+	job := cfg.JobComponents()[0]
+	assert.True(t, job.RunAsNonRoot)
+
+	cfg = jobComponentsBuilder{ra: ra, env: "env2", componentImages: make(map[string]pipeline.ComponentImage)}
+	job = cfg.JobComponents()[0]
+	assert.False(t, job.RunAsNonRoot)
+}
+
 func Test_GetRadixJobComponents_NodeName(t *testing.T) {
 	compGpu := "comp gpu"
 	compGpuCount := "10"

--- a/pkg/apis/utils/deploymentjobcomponent_builder.go
+++ b/pkg/apis/utils/deploymentjobcomponent_builder.go
@@ -21,6 +21,7 @@ type DeployJobComponentBuilder interface {
 	WithSecrets([]string) DeployJobComponentBuilder
 	WithSchedulerPort(*int32) DeployJobComponentBuilder
 	WithPayloadPath(*string) DeployJobComponentBuilder
+	WithRunAsNonRoot(bool) DeployJobComponentBuilder
 	BuildJobComponent() v1.RadixDeployJobComponent
 }
 
@@ -37,6 +38,7 @@ type deployJobComponentBuilder struct {
 	schedulerPort           *int32
 	payloadPath             *string
 	node                    v1.RadixNode
+	runAsNonRoot            bool
 }
 
 func (dcb *deployJobComponentBuilder) WithVolumeMounts(volumeMounts []v1.RadixVolumeMount) DeployJobComponentBuilder {
@@ -119,6 +121,11 @@ func (dcb *deployJobComponentBuilder) WithPayloadPath(path *string) DeployJobCom
 	return dcb
 }
 
+func (dcb *deployJobComponentBuilder) WithRunAsNonRoot(runAsNonRoot bool) DeployJobComponentBuilder {
+	dcb.runAsNonRoot = runAsNonRoot
+	return dcb
+}
+
 func (dcb *deployJobComponentBuilder) BuildJobComponent() v1.RadixDeployJobComponent {
 	componentPorts := make([]v1.ComponentPort, 0)
 	for key, value := range dcb.ports {
@@ -143,6 +150,7 @@ func (dcb *deployJobComponentBuilder) BuildJobComponent() v1.RadixDeployJobCompo
 		Payload:                 payload,
 		AlwaysPullImageOnDeploy: dcb.alwaysPullImageOnDeploy,
 		Node:                    dcb.node,
+		RunAsNonRoot:            dcb.runAsNonRoot,
 	}
 }
 

--- a/pkg/apis/utils/jobcomponentenvironment_builder.go
+++ b/pkg/apis/utils/jobcomponentenvironment_builder.go
@@ -12,6 +12,7 @@ type RadixJobComponentEnvironmentConfigBuilder interface {
 	WithMonitoring(bool) RadixJobComponentEnvironmentConfigBuilder
 	WithImageTagName(string) RadixJobComponentEnvironmentConfigBuilder
 	WithNode(node v1.RadixNode) RadixJobComponentEnvironmentConfigBuilder
+	WithRunAsNonRoot(bool) RadixJobComponentEnvironmentConfigBuilder
 	BuildEnvironmentConfig() v1.RadixJobComponentEnvironmentConfig
 }
 
@@ -23,6 +24,7 @@ type radixJobComponentEnvironmentConfigBuilder struct {
 	imageTagName string
 	monitoring   bool
 	node         v1.RadixNode
+	runAsNonRoot bool
 }
 
 func (ceb *radixJobComponentEnvironmentConfigBuilder) WithResource(request map[string]string, limit map[string]string) RadixJobComponentEnvironmentConfigBuilder {
@@ -68,6 +70,11 @@ func (ceb *radixJobComponentEnvironmentConfigBuilder) WithNode(node v1.RadixNode
 	return ceb
 }
 
+func (ceb *radixJobComponentEnvironmentConfigBuilder) WithRunAsNonRoot(runAsNonRoot bool) RadixJobComponentEnvironmentConfigBuilder {
+	ceb.runAsNonRoot = runAsNonRoot
+	return ceb
+}
+
 func (ceb *radixJobComponentEnvironmentConfigBuilder) BuildEnvironmentConfig() v1.RadixJobComponentEnvironmentConfig {
 	return v1.RadixJobComponentEnvironmentConfig{
 		Environment:  ceb.environment,
@@ -77,6 +84,7 @@ func (ceb *radixJobComponentEnvironmentConfigBuilder) BuildEnvironmentConfig() v
 		Monitoring:   ceb.monitoring,
 		ImageTagName: ceb.imageTagName,
 		Node:         ceb.node,
+		RunAsNonRoot: ceb.runAsNonRoot,
 	}
 }
 


### PR DESCRIPTION
- added missing test for job runAsNonRoot environment config
- Add WithRunAsNonRoot to RadixJobComponentEnvironmentConfigBuilder and DeployJobComponentBuilder