### PR TITLE
refactor promote pipeline

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.1
-appVersion: 1.12.0
+appVersion: 1.12.1
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -69,7 +69,7 @@ func GetDeploymentComponent(rd *v1.RadixDeployment, name string) (int, *v1.Radix
 
 // ConstructForTargetEnvironment Will build a deployment for target environment
 func ConstructForTargetEnvironment(config *v1.RadixApplication, jobName, imageTag, branch, commitID string, componentImages map[string]pipeline.ComponentImage, env string) (v1.RadixDeployment, error) {
-	components := getRadixComponentsForEnv(config, env, componentImages)
+	components := GetRadixComponentsForEnv(config, env, componentImages)
 	jobs := NewJobComponentsBuilder(config, env, componentImages).JobComponents()
 	radixDeployment := constructRadixDeployment(config, env, jobName, imageTag, branch, commitID, components, jobs)
 	return radixDeployment, nil

--- a/pkg/apis/deployment/radixcomponent.go
+++ b/pkg/apis/deployment/radixcomponent.go
@@ -8,7 +8,7 @@ import (
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
-func getRadixComponentsForEnv(radixApplication *v1.RadixApplication, env string, componentImages map[string]pipeline.ComponentImage) []v1.RadixDeployComponent {
+func GetRadixComponentsForEnv(radixApplication *v1.RadixApplication, env string, componentImages map[string]pipeline.ComponentImage) []v1.RadixDeployComponent {
 	dnsAppAlias := radixApplication.Spec.DNSAppAlias
 	components := []v1.RadixDeployComponent{}
 

--- a/pkg/apis/deployment/radixcomponent_test.go
+++ b/pkg/apis/deployment/radixcomponent_test.go
@@ -105,7 +105,7 @@ func TestGetRadixComponentsForEnv_PublicPort_OldPublic(t *testing.T) {
 	componentImages := make(map[string]pipeline.ComponentImage)
 	componentImages["app"] = pipeline.ComponentImage{ImageName: anyImage, ImagePath: anyImagePath}
 
-	deployComponent := getRadixComponentsForEnv(ra, env, componentImages)
+	deployComponent := GetRadixComponentsForEnv(ra, env, componentImages)
 	assert.Equal(t, ra.Spec.Components[0].PublicPort, deployComponent[0].PublicPort)
 	assert.Equal(t, ra.Spec.Components[0].Public, deployComponent[0].Public)
 	assert.Equal(t, "", deployComponent[0].PublicPort)
@@ -119,7 +119,7 @@ func TestGetRadixComponentsForEnv_PublicPort_OldPublic(t *testing.T) {
 				WithPort("http", 80).
 				WithPort("https", 443).
 				WithPublicPort("http")).BuildRA()
-	deployComponent = getRadixComponentsForEnv(ra, env, componentImages)
+	deployComponent = GetRadixComponentsForEnv(ra, env, componentImages)
 	assert.Equal(t, ra.Spec.Components[0].PublicPort, deployComponent[0].PublicPort)
 	assert.Equal(t, ra.Spec.Components[0].Public, deployComponent[0].Public)
 	assert.Equal(t, "http", deployComponent[0].PublicPort)
@@ -134,7 +134,7 @@ func TestGetRadixComponentsForEnv_PublicPort_OldPublic(t *testing.T) {
 				WithPort("https", 443).
 				WithPublicPort("http").
 				WithPublic(true)).BuildRA()
-	deployComponent = getRadixComponentsForEnv(ra, env, componentImages)
+	deployComponent = GetRadixComponentsForEnv(ra, env, componentImages)
 	assert.Equal(t, ra.Spec.Components[0].PublicPort, deployComponent[0].PublicPort)
 	assert.NotEqual(t, ra.Spec.Components[0].Public, deployComponent[0].Public)
 	assert.Equal(t, "http", deployComponent[0].PublicPort)
@@ -148,7 +148,7 @@ func TestGetRadixComponentsForEnv_PublicPort_OldPublic(t *testing.T) {
 				WithPort("http", 80).
 				WithPort("https", 443).
 				WithPublic(true)).BuildRA()
-	deployComponent = getRadixComponentsForEnv(ra, env, componentImages)
+	deployComponent = GetRadixComponentsForEnv(ra, env, componentImages)
 	assert.Equal(t, ra.Spec.Components[0].Ports[0].Name, deployComponent[0].PublicPort)
 	assert.NotEqual(t, ra.Spec.Components[0].Public, deployComponent[0].Public)
 	assert.Equal(t, false, deployComponent[0].Public)
@@ -170,7 +170,7 @@ func TestGetRadixComponentsForEnv_ListOfExternalAliasesForComponent_GetListOfAli
 		WithDNSExternalAlias("another.alias.com", "prod", "componentA").
 		WithDNSExternalAlias("athird.alias.com", "prod", "componentB").BuildRA()
 
-	deployComponent := getRadixComponentsForEnv(ra, "prod", componentImages)
+	deployComponent := GetRadixComponentsForEnv(ra, "prod", componentImages)
 	assert.Equal(t, 2, len(deployComponent))
 	assert.Equal(t, 2, len(deployComponent[0].DNSExternalAlias))
 	assert.Equal(t, "some.alias.com", deployComponent[0].DNSExternalAlias[0])
@@ -179,7 +179,7 @@ func TestGetRadixComponentsForEnv_ListOfExternalAliasesForComponent_GetListOfAli
 	assert.Equal(t, 1, len(deployComponent[1].DNSExternalAlias))
 	assert.Equal(t, "athird.alias.com", deployComponent[1].DNSExternalAlias[0])
 
-	deployComponent = getRadixComponentsForEnv(ra, "dev", componentImages)
+	deployComponent = GetRadixComponentsForEnv(ra, "dev", componentImages)
 	assert.Equal(t, 2, len(deployComponent))
 	assert.Equal(t, 0, len(deployComponent[0].DNSExternalAlias))
 }
@@ -213,7 +213,7 @@ func TestGetRadixComponentsForEnv_CommonEnvironmentVariables_No_Override(t *test
 						WithEnvironment("dev").
 						WithEnvironmentVariable("ENV_4", "environment_4"))).BuildRA()
 
-	deployComponentProd := getRadixComponentsForEnv(ra, "prod", componentImages)
+	deployComponentProd := GetRadixComponentsForEnv(ra, "prod", componentImages)
 	assert.Equal(t, 2, len(deployComponentProd))
 
 	assert.Equal(t, "comp_1", deployComponentProd[0].Name)
@@ -226,7 +226,7 @@ func TestGetRadixComponentsForEnv_CommonEnvironmentVariables_No_Override(t *test
 	assert.Equal(t, "environment_3", deployComponentProd[1].EnvironmentVariables["ENV_3"])
 	assert.Equal(t, "environment_common_2", deployComponentProd[1].EnvironmentVariables["ENV_COMMON_2"])
 
-	deployComponentDev := getRadixComponentsForEnv(ra, "dev", componentImages)
+	deployComponentDev := GetRadixComponentsForEnv(ra, "dev", componentImages)
 	assert.Equal(t, 2, len(deployComponentDev))
 
 	assert.Equal(t, "comp_1", deployComponentDev[0].Name)
@@ -274,7 +274,7 @@ func TestGetRadixComponentsForEnv_CommonEnvironmentVariables_With_Override(t *te
 						WithEnvironmentVariable("ENV_4", "environment_4").
 						WithEnvironmentVariable("ENV_COMMON_2", "environment_common_2_dev_override"))).BuildRA()
 
-	deployComponentProd := getRadixComponentsForEnv(ra, "prod", componentImages)
+	deployComponentProd := GetRadixComponentsForEnv(ra, "prod", componentImages)
 	assert.Equal(t, 2, len(deployComponentProd))
 
 	assert.Equal(t, "comp_1", deployComponentProd[0].Name)
@@ -287,7 +287,7 @@ func TestGetRadixComponentsForEnv_CommonEnvironmentVariables_With_Override(t *te
 	assert.Equal(t, "environment_3", deployComponentProd[1].EnvironmentVariables["ENV_3"])
 	assert.Equal(t, "environment_common_2_prod_override", deployComponentProd[1].EnvironmentVariables["ENV_COMMON_2"])
 
-	deployComponentDev := getRadixComponentsForEnv(ra, "dev", componentImages)
+	deployComponentDev := GetRadixComponentsForEnv(ra, "dev", componentImages)
 	assert.Equal(t, 2, len(deployComponentDev))
 
 	assert.Equal(t, "comp_1", deployComponentDev[0].Name)
@@ -314,23 +314,19 @@ func TestGetRadixComponentsForEnv_CommonEnvironmentVariables_NilVariablesMapInEn
 				WithCommonEnvironmentVariable("ENV_COMMON_1", "environment_common_1").
 				WithEnvironmentConfigs(
 					utils.AnEnvironmentConfig().
-						WithEnvironment("prod").
-						WithNilVariablesMap(),
+						WithEnvironment("prod"),
 					utils.AnEnvironmentConfig().
-						WithEnvironment("dev").
-						WithNilVariablesMap()),
+						WithEnvironment("dev")),
 			utils.NewApplicationComponentBuilder().
 				WithName("comp_2").
 				WithCommonEnvironmentVariable("ENV_COMMON_2", "environment_common_2").
 				WithEnvironmentConfigs(
 					utils.AnEnvironmentConfig().
-						WithEnvironment("prod").
-						WithNilVariablesMap(),
+						WithEnvironment("prod"),
 					utils.AnEnvironmentConfig().
-						WithEnvironment("dev").
-						WithNilVariablesMap())).BuildRA()
+						WithEnvironment("dev"))).BuildRA()
 
-	deployComponentProd := getRadixComponentsForEnv(ra, "prod", componentImages)
+	deployComponentProd := GetRadixComponentsForEnv(ra, "prod", componentImages)
 	assert.Equal(t, 2, len(deployComponentProd))
 
 	assert.Equal(t, "comp_1", deployComponentProd[0].Name)
@@ -341,7 +337,7 @@ func TestGetRadixComponentsForEnv_CommonEnvironmentVariables_NilVariablesMapInEn
 	assert.Equal(t, 1, len(deployComponentProd[1].EnvironmentVariables))
 	assert.Equal(t, "environment_common_2", deployComponentProd[1].EnvironmentVariables["ENV_COMMON_2"])
 
-	deployComponentDev := getRadixComponentsForEnv(ra, "dev", componentImages)
+	deployComponentDev := GetRadixComponentsForEnv(ra, "dev", componentImages)
 	assert.Equal(t, 2, len(deployComponentDev))
 
 	assert.Equal(t, "comp_1", deployComponentDev[0].Name)
@@ -380,7 +376,7 @@ func TestGetRadixComponentsForEnv_CommonResources(t *testing.T) {
 						"cpu":    "750m",
 					}))).BuildRA()
 
-	deployComponentProd := getRadixComponentsForEnv(ra, "prod", componentImages)
+	deployComponentProd := GetRadixComponentsForEnv(ra, "prod", componentImages)
 	assert.Equal(t, 1, len(deployComponentProd))
 	assert.Equal(t, "comp_1", deployComponentProd[0].Name)
 	assert.Equal(t, "500m", deployComponentProd[0].Resources.Requests["cpu"])
@@ -388,7 +384,7 @@ func TestGetRadixComponentsForEnv_CommonResources(t *testing.T) {
 	assert.Equal(t, "750m", deployComponentProd[0].Resources.Limits["cpu"])
 	assert.Equal(t, "256Mi", deployComponentProd[0].Resources.Limits["memory"])
 
-	deployComponentDev := getRadixComponentsForEnv(ra, "dev", componentImages)
+	deployComponentDev := GetRadixComponentsForEnv(ra, "dev", componentImages)
 	assert.Equal(t, 1, len(deployComponentDev))
 	assert.Equal(t, "comp_1", deployComponentDev[0].Name)
 	assert.Equal(t, "250m", deployComponentDev[0].Resources.Requests["cpu"])
@@ -428,25 +424,25 @@ func Test_GetRadixComponents_NodeName(t *testing.T) {
 
 	t.Run("override job gpu and gpu-count with environment gpu and gpu-count", func(t *testing.T) {
 		t.Parallel()
-		deployComponent := getRadixComponentsForEnv(ra, "env1", componentImages)
+		deployComponent := GetRadixComponentsForEnv(ra, "env1", componentImages)
 		assert.Equal(t, envGpu1, deployComponent[0].Node.Gpu)
 		assert.Equal(t, envGpuCount1, deployComponent[0].Node.GpuCount)
 	})
 	t.Run("override job gpu-count with environment gpu-count", func(t *testing.T) {
 		t.Parallel()
-		deployComponent := getRadixComponentsForEnv(ra, "env2", componentImages)
+		deployComponent := GetRadixComponentsForEnv(ra, "env2", componentImages)
 		assert.Equal(t, compGpu, deployComponent[0].Node.Gpu)
 		assert.Equal(t, envGpuCount2, deployComponent[0].Node.GpuCount)
 	})
 	t.Run("override job gpu with environment gpu", func(t *testing.T) {
 		t.Parallel()
-		deployComponent := getRadixComponentsForEnv(ra, "env3", componentImages)
+		deployComponent := GetRadixComponentsForEnv(ra, "env3", componentImages)
 		assert.Equal(t, envGpu3, deployComponent[0].Node.Gpu)
 		assert.Equal(t, compGpuCount, deployComponent[0].Node.GpuCount)
 	})
 	t.Run("do not override job gpu or gpu-count with environment gpu or gpu-count", func(t *testing.T) {
 		t.Parallel()
-		deployComponent := getRadixComponentsForEnv(ra, "env4", componentImages)
+		deployComponent := GetRadixComponentsForEnv(ra, "env4", componentImages)
 		assert.Equal(t, compGpu, deployComponent[0].Node.Gpu)
 		assert.Equal(t, compGpuCount, deployComponent[0].Node.GpuCount)
 	})

--- a/pkg/apis/utils/applicationcomponent_builder.go
+++ b/pkg/apis/utils/applicationcomponent_builder.go
@@ -88,6 +88,10 @@ func (rcb *radixApplicationComponentBuilder) WithIngressConfiguration(ingressCon
 }
 
 func (rcb *radixApplicationComponentBuilder) WithPort(name string, port int32) RadixApplicationComponentBuilder {
+	if rcb.ports == nil {
+		rcb.ports = make(map[string]int32)
+	}
+
 	rcb.ports[name] = port
 	return rcb
 }
@@ -103,6 +107,10 @@ func (rcb *radixApplicationComponentBuilder) WithEnvironmentConfigs(environmentC
 }
 
 func (rcb *radixApplicationComponentBuilder) WithCommonEnvironmentVariable(name, value string) RadixApplicationComponentBuilder {
+	if rcb.variables == nil {
+		rcb.variables = make(v1.EnvVarsMap)
+	}
+
 	rcb.variables[name] = value
 	return rcb
 }
@@ -157,17 +165,12 @@ func (rcb *radixApplicationComponentBuilder) BuildComponent() v1.RadixComponent 
 
 // NewApplicationComponentBuilder Constructor for component builder
 func NewApplicationComponentBuilder() RadixApplicationComponentBuilder {
-	return &radixApplicationComponentBuilder{
-		ports:     make(map[string]int32),
-		variables: make(map[string]string),
-	}
+	return &radixApplicationComponentBuilder{}
 }
 
 // AnApplicationComponent Constructor for component builder builder containing test data
 func AnApplicationComponent() RadixApplicationComponentBuilder {
 	return &radixApplicationComponentBuilder{
-		name:      "app",
-		ports:     make(map[string]int32),
-		variables: make(map[string]string),
+		name: "app",
 	}
 }

--- a/pkg/apis/utils/applicationjobcomponent_builder.go
+++ b/pkg/apis/utils/applicationjobcomponent_builder.go
@@ -61,6 +61,10 @@ func (rcb *radixApplicationJobComponentBuilder) WithSecrets(secrets ...string) R
 }
 
 func (rcb *radixApplicationJobComponentBuilder) WithPort(name string, port int32) RadixApplicationJobComponentBuilder {
+	if rcb.ports == nil {
+		rcb.ports = make(map[string]int32)
+	}
+
 	rcb.ports[name] = port
 	return rcb
 }
@@ -76,6 +80,10 @@ func (rcb *radixApplicationJobComponentBuilder) WithEnvironmentConfigs(environme
 }
 
 func (rcb *radixApplicationJobComponentBuilder) WithCommonEnvironmentVariable(name, value string) RadixApplicationJobComponentBuilder {
+	if rcb.variables == nil {
+		rcb.variables = make(v1.EnvVarsMap)
+	}
+
 	rcb.variables[name] = value
 	return rcb
 }
@@ -137,17 +145,12 @@ func (rcb *radixApplicationJobComponentBuilder) BuildJobComponent() v1.RadixJobC
 
 // NewApplicationJobComponentBuilder Constructor for job component builder
 func NewApplicationJobComponentBuilder() RadixApplicationJobComponentBuilder {
-	return &radixApplicationJobComponentBuilder{
-		ports:     make(map[string]int32),
-		variables: make(map[string]string),
-	}
+	return &radixApplicationJobComponentBuilder{}
 }
 
 // AnApplicationJobComponent Constructor for job component builder containing test data
 func AnApplicationJobComponent() RadixApplicationJobComponentBuilder {
 	return &radixApplicationJobComponentBuilder{
-		name:      "job",
-		ports:     make(map[string]int32),
-		variables: make(map[string]string),
+		name: "job",
 	}
 }

--- a/pkg/apis/utils/componentenvironment_builder.go
+++ b/pkg/apis/utils/componentenvironment_builder.go
@@ -13,7 +13,6 @@ type RadixEnvironmentConfigBuilder interface {
 	WithVolumeMounts([]v1.RadixVolumeMount) RadixEnvironmentConfigBuilder
 	BuildEnvironmentConfig() v1.RadixEnvironmentConfig
 	WithAlwaysPullImageOnDeploy(bool) RadixEnvironmentConfigBuilder
-	WithNilVariablesMap() RadixEnvironmentConfigBuilder
 	WithRunAsNonRoot(bool) RadixEnvironmentConfigBuilder
 	WithNode(node v1.RadixNode) RadixEnvironmentConfigBuilder
 	WithAuthentication(authentication *v1.Authentication) RadixEnvironmentConfigBuilder
@@ -23,7 +22,6 @@ type radixEnvironmentConfigBuilder struct {
 	environment             string
 	variables               v1.EnvVarsMap
 	replicas                *int
-	ports                   map[string]int32
 	secrets                 []string
 	resources               v1.ResourceRequirements
 	alwaysPullImageOnDeploy *bool
@@ -57,17 +55,16 @@ func (ceb *radixEnvironmentConfigBuilder) WithReplicas(replicas *int) RadixEnvir
 }
 
 func (ceb *radixEnvironmentConfigBuilder) WithEnvironmentVariable(name, value string) RadixEnvironmentConfigBuilder {
+	if ceb.variables == nil {
+		ceb.variables = make(v1.EnvVarsMap)
+	}
+
 	ceb.variables[name] = value
 	return ceb
 }
 
 func (ceb *radixEnvironmentConfigBuilder) WithAlwaysPullImageOnDeploy(val bool) RadixEnvironmentConfigBuilder {
 	ceb.alwaysPullImageOnDeploy = &val
-	return ceb
-}
-
-func (ceb *radixEnvironmentConfigBuilder) WithNilVariablesMap() RadixEnvironmentConfigBuilder {
-	ceb.variables = nil
 	return ceb
 }
 
@@ -102,15 +99,12 @@ func (ceb *radixEnvironmentConfigBuilder) BuildEnvironmentConfig() v1.RadixEnvir
 
 // NewComponentEnvironmentBuilder Constructor for component environment builder
 func NewComponentEnvironmentBuilder() RadixEnvironmentConfigBuilder {
-	return &radixEnvironmentConfigBuilder{
-		variables: make(map[string]string),
-	}
+	return &radixEnvironmentConfigBuilder{}
 }
 
 // AnEnvironmentConfig Constructor for component environment builder containing test data
 func AnEnvironmentConfig() RadixEnvironmentConfigBuilder {
 	return &radixEnvironmentConfigBuilder{
 		environment: "app",
-		variables:   make(map[string]string),
 	}
 }

--- a/pkg/apis/utils/deploymentcomponent_builder.go
+++ b/pkg/apis/utils/deploymentcomponent_builder.go
@@ -113,6 +113,10 @@ func (dcb *deployComponentBuilder) WithImage(image string) DeployComponentBuilde
 }
 
 func (dcb *deployComponentBuilder) WithPort(name string, port int32) DeployComponentBuilder {
+	if dcb.ports == nil {
+		dcb.ports = make(map[string]int32)
+	}
+
 	dcb.ports[name] = port
 	return dcb
 }
@@ -139,6 +143,10 @@ func (dcb *deployComponentBuilder) WithReplicas(replicas *int) DeployComponentBu
 }
 
 func (dcb *deployComponentBuilder) WithEnvironmentVariable(name string, value string) DeployComponentBuilder {
+	if dcb.environmentVariables == nil {
+		dcb.environmentVariables = make(map[string]string)
+	}
+
 	dcb.environmentVariables[name] = value
 	return dcb
 }
@@ -207,8 +215,5 @@ func (dcb *deployComponentBuilder) BuildComponent() v1.RadixDeployComponent {
 
 // NewDeployComponentBuilder Constructor for component builder
 func NewDeployComponentBuilder() DeployComponentBuilder {
-	return &deployComponentBuilder{
-		ports:                make(map[string]int32),
-		environmentVariables: make(map[string]string),
-	}
+	return &deployComponentBuilder{}
 }

--- a/pkg/apis/utils/deploymentjobcomponent_builder.go
+++ b/pkg/apis/utils/deploymentjobcomponent_builder.go
@@ -82,6 +82,10 @@ func (dcb *deployJobComponentBuilder) WithImage(image string) DeployJobComponent
 }
 
 func (dcb *deployJobComponentBuilder) WithPort(name string, port int32) DeployJobComponentBuilder {
+	if dcb.ports == nil {
+		dcb.ports = make(map[string]int32)
+	}
+
 	dcb.ports[name] = port
 	return dcb
 }
@@ -97,6 +101,10 @@ func (dcb *deployJobComponentBuilder) WithAlwaysPullImageOnDeploy(val bool) Depl
 }
 
 func (dcb *deployJobComponentBuilder) WithEnvironmentVariable(name string, value string) DeployJobComponentBuilder {
+	if dcb.environmentVariables == nil {
+		dcb.environmentVariables = make(map[string]string)
+	}
+
 	dcb.environmentVariables[name] = value
 	return dcb
 }
@@ -156,8 +164,5 @@ func (dcb *deployJobComponentBuilder) BuildJobComponent() v1.RadixDeployJobCompo
 
 // NewDeployJobComponentBuilder Constructor for jop component builder
 func NewDeployJobComponentBuilder() DeployJobComponentBuilder {
-	return &deployJobComponentBuilder{
-		ports:                make(map[string]int32),
-		environmentVariables: make(map[string]string),
-	}
+	return &deployJobComponentBuilder{}
 }

--- a/pkg/apis/utils/jobcomponentenvironment_builder.go
+++ b/pkg/apis/utils/jobcomponentenvironment_builder.go
@@ -8,7 +8,6 @@ type RadixJobComponentEnvironmentConfigBuilder interface {
 	WithEnvironmentVariable(string, string) RadixJobComponentEnvironmentConfigBuilder
 	WithResource(map[string]string, map[string]string) RadixJobComponentEnvironmentConfigBuilder
 	WithVolumeMounts([]v1.RadixVolumeMount) RadixJobComponentEnvironmentConfigBuilder
-	WithNilVariablesMap() RadixJobComponentEnvironmentConfigBuilder
 	WithMonitoring(bool) RadixJobComponentEnvironmentConfigBuilder
 	WithImageTagName(string) RadixJobComponentEnvironmentConfigBuilder
 	WithNode(node v1.RadixNode) RadixJobComponentEnvironmentConfigBuilder
@@ -46,12 +45,11 @@ func (ceb *radixJobComponentEnvironmentConfigBuilder) WithEnvironment(environmen
 }
 
 func (ceb *radixJobComponentEnvironmentConfigBuilder) WithEnvironmentVariable(name, value string) RadixJobComponentEnvironmentConfigBuilder {
-	ceb.variables[name] = value
-	return ceb
-}
+	if ceb.variables == nil {
+		ceb.variables = make(v1.EnvVarsMap)
+	}
 
-func (ceb *radixJobComponentEnvironmentConfigBuilder) WithNilVariablesMap() RadixJobComponentEnvironmentConfigBuilder {
-	ceb.variables = nil
+	ceb.variables[name] = value
 	return ceb
 }
 
@@ -90,15 +88,12 @@ func (ceb *radixJobComponentEnvironmentConfigBuilder) BuildEnvironmentConfig() v
 
 // NewJobComponentEnvironmentBuilder Constructor for job component environment builder
 func NewJobComponentEnvironmentBuilder() RadixJobComponentEnvironmentConfigBuilder {
-	return &radixJobComponentEnvironmentConfigBuilder{
-		variables: make(map[string]string),
-	}
+	return &radixJobComponentEnvironmentConfigBuilder{}
 }
 
 // AJobComponentEnvironmentConfig Constructor for job component environment builder containing test data
 func AJobComponentEnvironmentConfig() RadixJobComponentEnvironmentConfigBuilder {
 	return &radixJobComponentEnvironmentConfigBuilder{
 		environment: "app",
-		variables:   make(map[string]string),
 	}
 }


### PR DESCRIPTION
- Refactor promote pipeline to build new components for target environment, and copy fields from source to target deployment that must be kept. This is opposite from how it was, where specific fields in the source deployment was updated with new environment specific values in the target environment. It was too easy to miss new environment configs, like we did with volumeMounts and Node.
- Removed map initialization in all builders to align with how unmarshaling does it.