### PR TITLE
95583 orphaned environment bug

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.1
-appVersion: 1.12.1
+appVersion: 1.12.2
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.1
-appVersion: 1.12.2
+appVersion: 1.12.3
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/applicationconfig/applicationconfig.go
+++ b/pkg/apis/applicationconfig/applicationconfig.go
@@ -188,6 +188,8 @@ func (app *ApplicationConfig) createEnvironments() error {
 			WithRegistrationOwner(app.registration).
 			// Orphaned flag will be set by the environment handler but until
 			// reconciliation we must ensure it is false
+			// Update: It seems Update method does not update status object when using real k8s client. The fake client works differently.
+			// Only an explicit call to UpdateStatus can update status object, and it is only handled by the RadixEnvironment controller.
 			WithOrphaned(false).
 			BuildRE())
 	}

--- a/pkg/apis/applicationconfig/applicationconfig.go
+++ b/pkg/apis/applicationconfig/applicationconfig.go
@@ -188,8 +188,8 @@ func (app *ApplicationConfig) createEnvironments() error {
 			WithRegistrationOwner(app.registration).
 			// Orphaned flag will be set by the environment handler but until
 			// reconciliation we must ensure it is false
-			// Update: It seems Update method does not update status object when using real k8s client. The fake client works differently.
-			// Only an explicit call to UpdateStatus can update status object, and it is only handled by the RadixEnvironment controller.
+			// Update: It seems Update method does not update status object when using real k8s client, but the fake client does.
+			// Only an explicit call to UpdateStatus can update status object, and this is only done by the RadixEnvironment controller.
 			WithOrphaned(false).
 			BuildRE())
 	}

--- a/radix-operator/environment/controller.go
+++ b/radix-operator/environment/controller.go
@@ -157,7 +157,8 @@ func NewController(client kubernetes.Interface,
 				return
 			}
 
-			for _, envName := range droppedEnvironments(oldRa, newRa) {
+			addedOrDroppedEnvionments := getAddedOrDroppedEnvironmentNames(oldRa, newRa)
+			for _, envName := range addedOrDroppedEnvionments {
 				uniqueName := utils.GetEnvironmentNamespace(oldRa.Name, envName)
 				re, err := radixClient.RadixV1().RadixEnvironments().Get(context.TODO(), uniqueName, metav1.GetOptions{})
 				if err == nil {
@@ -193,11 +194,19 @@ func getOwner(radixClient radixclient.Interface, namespace, name string) (interf
 	return radixClient.RadixV1().RadixEnvironments().Get(context.TODO(), name, meta.GetOptions{})
 }
 
-func droppedEnvironments(oldRa *v1.RadixApplication, newRa *v1.RadixApplication) []string {
+func getAddedOrDroppedEnvironmentNames(oldRa *v1.RadixApplication, newRa *v1.RadixApplication) []string {
+	var environmentNames []string
+	environmentNames = append(environmentNames, getMissingEnvironmentNames(oldRa.Spec.Environments, newRa.Spec.Environments)...)
+	environmentNames = append(environmentNames, getMissingEnvironmentNames(newRa.Spec.Environments, oldRa.Spec.Environments)...)
+	return environmentNames
+}
+
+// getMissingEnvironmentNames returns environment names that exists in source list but not in target list
+func getMissingEnvironmentNames(source []v1.Environment, target []v1.Environment) []string {
 	droppedNames := make([]string, 0)
-	for _, oldEnvConfig := range oldRa.Spec.Environments {
+	for _, oldEnvConfig := range source {
 		dropped := true
-		for _, newEnvConfig := range newRa.Spec.Environments {
+		for _, newEnvConfig := range target {
 			if oldEnvConfig.Name == newEnvConfig.Name {
 				dropped = false
 			}

--- a/radix-operator/environment/controller.go
+++ b/radix-operator/environment/controller.go
@@ -157,8 +157,8 @@ func NewController(client kubernetes.Interface,
 				return
 			}
 
-			addedOrDroppedEnvionments := getAddedOrDroppedEnvironmentNames(oldRa, newRa)
-			for _, envName := range addedOrDroppedEnvionments {
+			environmentsToResync := getAddedOrDroppedEnvironmentNames(oldRa, newRa)
+			for _, envName := range environmentsToResync {
 				uniqueName := utils.GetEnvironmentNamespace(oldRa.Name, envName)
 				re, err := radixClient.RadixV1().RadixEnvironments().Get(context.TODO(), uniqueName, metav1.GetOptions{})
 				if err == nil {


### PR DESCRIPTION
The EnvironmentController listens to changes in RadixApplication objects. If an environment is removed from the RA, the corresponding RadixEnvironment is updated with Status.Orphaned=true. Orphaned environments added back to RA was not updated with Status.Orphaned=false.
This PR fixes this issue.