### PR TITLE
103987 fix affinity for job scheduler

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.1
-appVersion: 1.13.2
+appVersion: 1.13.3
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -2631,25 +2631,11 @@ func TestUseGpuNodeOnDeploy(t *testing.T) {
 		deployment, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), componentName4, metav1.GetOptions{})
 		assert.Nil(t, deployment.Spec.Template.Spec.Affinity)
 	})
-	t.Run("job has node with nvidia-p100, not nvidia-k80", func(t *testing.T) {
+	t.Run("job has node, but pod template of Job Scheduler does not have it", func(t *testing.T) {
 		t.Parallel()
 		deployment, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), jobComponentName, metav1.GetOptions{})
 		affinity := deployment.Spec.Template.Spec.Affinity
-		assert.NotNil(t, affinity)
-		assert.NotNil(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
-		nodeSelectorTerms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		assert.Equal(t, 1, len(nodeSelectorTerms))
-		assert.Equal(t, 2, len(nodeSelectorTerms[0].MatchExpressions))
-		expression0 := nodeSelectorTerms[0].MatchExpressions[0]
-		assert.Equal(t, kube.RadixGpuLabel, expression0.Key)
-		assert.Equal(t, corev1.NodeSelectorOpIn, expression0.Operator)
-		assert.Equal(t, 1, len(expression0.Values))
-		assert.Contains(t, expression0.Values, gpuNvidiaP100)
-		expression1 := nodeSelectorTerms[0].MatchExpressions[1]
-		assert.Equal(t, kube.RadixGpuLabel, expression1.Key)
-		assert.Equal(t, corev1.NodeSelectorOpNotIn, expression1.Operator)
-		assert.Equal(t, 1, len(expression1.Values))
-		assert.Contains(t, expression1.Values, gpuNvidiaK80)
+		assert.Nil(t, affinity)
 	})
 }
 
@@ -2866,20 +2852,11 @@ func TestUseGpuNodeCountOnDeployment(t *testing.T) {
 		affinity := deployment.Spec.Template.Spec.Affinity
 		assert.Nil(t, affinity)
 	})
-	t.Run("job has node with gpu-count 10 ", func(t *testing.T) {
+	t.Run("job has node, but pod template of Job Scheduler does not have it", func(t *testing.T) {
 		t.Parallel()
 		deployment, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), jobComponentName, metav1.GetOptions{})
 		affinity := deployment.Spec.Template.Spec.Affinity
-		assert.NotNil(t, affinity)
-		assert.NotNil(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
-		nodeSelectorTerms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		assert.Equal(t, 1, len(nodeSelectorTerms))
-		assert.Equal(t, 1, len(nodeSelectorTerms[0].MatchExpressions))
-		expression0 := nodeSelectorTerms[0].MatchExpressions[0]
-		assert.Equal(t, kube.RadixGpuCountLabel, expression0.Key)
-		assert.Equal(t, corev1.NodeSelectorOpGt, expression0.Operator)
-		assert.Equal(t, 1, len(expression0.Values))
-		assert.Contains(t, expression0.Values, "9")
+		assert.Nil(t, affinity)
 	})
 }
 
@@ -2942,31 +2919,11 @@ func TestUseGpuNodeWithGpuCountOnDeployment(t *testing.T) {
 		assert.Equal(t, 1, len(expression3.Values))
 		assert.Contains(t, expression3.Values, "9")
 	})
-	t.Run("job has node with gpu and gpu-count 10 ", func(t *testing.T) {
+	t.Run("job has node, but pod template of Job Scheduler does not have it", func(t *testing.T) {
 		t.Parallel()
 		deployment, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), jobComponentName, metav1.GetOptions{})
 		affinity := deployment.Spec.Template.Spec.Affinity
-		assert.NotNil(t, affinity)
-		assert.NotNil(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
-		nodeSelectorTerms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		assert.Equal(t, 1, len(nodeSelectorTerms))
-		assert.Equal(t, 3, len(nodeSelectorTerms[0].MatchExpressions))
-		expression0 := nodeSelectorTerms[0].MatchExpressions[0]
-		assert.Equal(t, kube.RadixGpuLabel, expression0.Key)
-		assert.Equal(t, corev1.NodeSelectorOpIn, expression0.Operator)
-		assert.Equal(t, 2, len(expression0.Values))
-		assert.Contains(t, expression0.Values, gpuNvidiaV100)
-		assert.Contains(t, expression0.Values, gpuNvidiaP100)
-		expression1 := nodeSelectorTerms[0].MatchExpressions[1]
-		assert.Equal(t, kube.RadixGpuLabel, expression1.Key)
-		assert.Equal(t, corev1.NodeSelectorOpNotIn, expression1.Operator)
-		assert.Equal(t, 1, len(expression1.Values))
-		assert.Contains(t, expression1.Values, gpuNvidiaK80)
-		expression3 := nodeSelectorTerms[0].MatchExpressions[2]
-		assert.Equal(t, kube.RadixGpuCountLabel, expression3.Key)
-		assert.Equal(t, corev1.NodeSelectorOpGt, expression3.Operator)
-		assert.Equal(t, 1, len(expression3.Values))
-		assert.Contains(t, expression3.Values, "9")
+		assert.Nil(t, affinity)
 	})
 }
 

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -99,14 +99,13 @@ func (deploy *Deployment) getDesiredCreatedDeploymentConfig(deployComponent v1.R
 		return nil, err
 	}
 
-	container := desiredDeployment.Spec.Template.Spec.Containers[0]
-	if len(container.Ports) > 0 {
-		log.Debugln("Set readiness Prob for ports. Amount of ports: ", len(container.Ports))
-		readinessProbe, err := getReadinessProbe(container.Ports[0].ContainerPort)
+	if len(desiredDeployment.Spec.Template.Spec.Containers[0].Ports) > 0 {
+		log.Debugln("Set readiness Prob for ports. Amount of ports: ", len(desiredDeployment.Spec.Template.Spec.Containers[0].Ports))
+		readinessProbe, err := getReadinessProbe(desiredDeployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 		if err != nil {
 			return nil, err
 		}
-		container.ReadinessProbe = readinessProbe
+		desiredDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe = readinessProbe
 	}
 
 	deploymentStrategy, err := getDeploymentStrategy()
@@ -132,8 +131,7 @@ func (deploy *Deployment) getDesiredUpdatedDeploymentConfig(deployComponent v1.R
 
 	if len(deployComponent.GetPorts()) > 0 {
 		log.Debugf("Deployment component has %d ports.", len(deployComponent.GetPorts()))
-		prob := desiredDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe
-		err := getReadinessProbeSettings(prob, &(deployComponent.GetPorts()[0]))
+		err := getReadinessProbeSettings(desiredDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe, &(deployComponent.GetPorts()[0]))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -80,119 +80,52 @@ func (deploy *Deployment) configureDeploymentServiceAccountSettings(deployment *
 func (deploy *Deployment) getDesiredCreatedDeploymentConfig(deployComponent v1.RadixCommonDeployComponent) (*appsv1.Deployment, error) {
 	appName := deploy.radixDeployment.Spec.AppName
 	componentName := deployComponent.GetName()
-	componentType := deployComponent.GetType()
-	automountServiceAccountToken := false
-	branch, commitID := deploy.getRadixBranchAndCommitId()
-	ownerReference := getOwnerReferenceOfDeployment(deploy.radixDeployment)
-	containerSecurityContext := getSecurityContextForContainer(deployComponent.GetRunAsNonRoot())
-	podSecurityContext := getSecurityContextForPod(deployComponent.GetRunAsNonRoot())
-	ports := getContainerPorts(deployComponent)
+	log.Debugf("Get desired created deployment config for application: %s.", appName)
 
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: componentName,
-			Labels: map[string]string{
-				kube.RadixAppLabel:           appName,
-				kube.RadixComponentLabel:     componentName,
-				kube.RadixComponentTypeLabel: componentType,
-				kube.RadixCommitLabel:        commitID,
-			},
-			Annotations: map[string]string{
-				kube.RadixBranchAnnotation: branch,
-			},
-			OwnerReferences: ownerReference,
-		},
+	desiredDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string), Annotations: make(map[string]string)},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(DefaultReplicas),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					kube.RadixComponentLabel: componentName,
-				},
-			},
+			Selector: &metav1.LabelSelector{MatchLabels: make(map[string]string)},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						kube.RadixAppLabel:       appName,
-						kube.RadixComponentLabel: componentName,
-						kube.RadixCommitLabel:    commitID,
-					},
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-						"seccomp.security.alpha.kubernetes.io/pod": "docker/default",
-						kube.RadixBranchAnnotation:                 branch,
-					},
-				},
-				Spec: corev1.PodSpec{
-					SecurityContext:              podSecurityContext,
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					Containers: []corev1.Container{
-						{
-							Name:            componentName,
-							Image:           deployComponent.GetImage(),
-							ImagePullPolicy: corev1.PullAlways,
-							SecurityContext: containerSecurityContext,
-							Ports:           ports,
-						},
-					},
-					ImagePullSecrets: deploy.radixDeployment.Spec.ImagePullSecrets,
-				},
+				ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string), Annotations: make(map[string]string)},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: componentName}}},
 			},
 		},
 	}
 
-	if len(ports) > 0 {
-		log.Debugln("Set readiness Prob for ports. Amount of ports: ", len(ports))
-		readinessProbe, err := getReadinessProbe(ports[0].ContainerPort)
+	err := deploy.setDesiredDeploymentProperties(deployComponent, desiredDeployment, appName, componentName)
+	if err != nil {
+		return nil, err
+	}
+
+	container := desiredDeployment.Spec.Template.Spec.Containers[0]
+	if len(container.Ports) > 0 {
+		log.Debugln("Set readiness Prob for ports. Amount of ports: ", len(container.Ports))
+		readinessProbe, err := getReadinessProbe(container.Ports[0].ContainerPort)
 		if err != nil {
 			return nil, err
 		}
-		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = readinessProbe
+		container.ReadinessProbe = readinessProbe
 	}
 
 	deploymentStrategy, err := getDeploymentStrategy()
 	if err != nil {
 		return nil, err
 	}
-	deployment.Spec.Strategy = deploymentStrategy
+	desiredDeployment.Spec.Strategy = deploymentStrategy
 
-	err = deploy.setCommonPodSpecProperties(&deployment.Spec.Template.Spec, deployComponent)
-	if err != nil {
-		return nil, err
-	}
-	return deploy.updateDeploymentByComponent(deployComponent, deployment, appName)
+	return deploy.updateDeploymentByComponent(deployComponent, desiredDeployment, appName)
 }
 
 func (deploy *Deployment) getDesiredUpdatedDeploymentConfig(deployComponent v1.RadixCommonDeployComponent,
 	currentDeployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-	desiredDeployment := currentDeployment.DeepCopy()
 	appName := deploy.radixDeployment.Spec.AppName
-	log.Debugf("Get desired updated deployment config for application: %s.", appName)
 	componentName := deployComponent.GetName()
-	componentType := deployComponent.GetType()
-	automountServiceAccountToken := false
-	branch, commitID := deploy.getRadixBranchAndCommitId()
-	ports := getContainerPorts(deployComponent)
+	log.Debugf("Get desired updated deployment config for application: %s.", appName)
 
-	desiredDeployment.ObjectMeta.Name = componentName
-	desiredDeployment.ObjectMeta.OwnerReferences = getOwnerReferenceOfDeployment(deploy.radixDeployment)
-	desiredDeployment.ObjectMeta.Labels[kube.RadixAppLabel] = appName
-	desiredDeployment.ObjectMeta.Labels[kube.RadixComponentLabel] = componentName
-	desiredDeployment.ObjectMeta.Labels[kube.RadixComponentTypeLabel] = componentType
-	desiredDeployment.ObjectMeta.Labels[kube.RadixCommitLabel] = commitID
-	desiredDeployment.ObjectMeta.Annotations[kube.RadixBranchAnnotation] = branch
-	desiredDeployment.Spec.Template.ObjectMeta.Labels[kube.RadixCommitLabel] = commitID
-	desiredDeployment.Spec.Template.ObjectMeta.Annotations["apparmor.security.beta.kubernetes.io/pod"] = "runtime/default"
-	desiredDeployment.Spec.Template.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"] = "docker/default"
-	desiredDeployment.Spec.Template.ObjectMeta.Annotations[kube.RadixBranchAnnotation] = branch
-	desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken = &automountServiceAccountToken
-	desiredDeployment.Spec.Template.Spec.Containers[0].Image = deployComponent.GetImage()
-	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
-	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = getSecurityContextForContainer(deployComponent.GetRunAsNonRoot())
-	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
-	desiredDeployment.Spec.Template.Spec.Containers[0].Ports = ports
-	desiredDeployment.Spec.Template.Spec.ImagePullSecrets = deploy.radixDeployment.Spec.ImagePullSecrets
-	desiredDeployment.Spec.Template.Spec.SecurityContext = getSecurityContextForPod(deployComponent.GetRunAsNonRoot())
-	err := deploy.setCommonPodSpecProperties(&desiredDeployment.Spec.Template.Spec, deployComponent)
+	desiredDeployment := currentDeployment.DeepCopy()
+	err := deploy.setDesiredDeploymentProperties(deployComponent, desiredDeployment, appName, componentName)
 	if err != nil {
 		return nil, err
 	}
@@ -216,14 +149,44 @@ func (deploy *Deployment) getDesiredUpdatedDeploymentConfig(deployComponent v1.R
 	return deploy.updateDeploymentByComponent(deployComponent, desiredDeployment, appName)
 }
 
-func (deploy *Deployment) setCommonPodSpecProperties(podSpec *corev1.PodSpec, deployComponent v1.RadixCommonDeployComponent) error {
-	podSpec.Containers[0].VolumeMounts = GetRadixDeployComponentVolumeMounts(deployComponent)
+func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.RadixCommonDeployComponent, desiredDeployment *appsv1.Deployment, appName, componentName string) error {
+	branch, commitID := deploy.getRadixBranchAndCommitId()
+
+	desiredDeployment.ObjectMeta.Name = componentName
+	desiredDeployment.ObjectMeta.OwnerReferences = getOwnerReferenceOfDeployment(deploy.radixDeployment)
+	desiredDeployment.ObjectMeta.Labels[kube.RadixAppLabel] = appName
+	desiredDeployment.ObjectMeta.Labels[kube.RadixComponentLabel] = componentName
+	desiredDeployment.ObjectMeta.Labels[kube.RadixComponentTypeLabel] = deployComponent.GetType()
+	desiredDeployment.ObjectMeta.Labels[kube.RadixCommitLabel] = commitID
+	desiredDeployment.ObjectMeta.Annotations[kube.RadixBranchAnnotation] = branch
+
+	desiredDeployment.Spec.Selector.MatchLabels[kube.RadixComponentLabel] = componentName
+
+	desiredDeployment.Spec.Template.ObjectMeta.Labels[kube.RadixCommitLabel] = commitID
+	desiredDeployment.Spec.Template.ObjectMeta.Annotations["apparmor.security.beta.kubernetes.io/pod"] = "runtime/default"
+	desiredDeployment.Spec.Template.ObjectMeta.Annotations["seccomp.security.alpha.kubernetes.io/pod"] = "docker/default"
+	desiredDeployment.Spec.Template.ObjectMeta.Annotations[kube.RadixBranchAnnotation] = branch
+
+	desiredDeployment.Spec.Template.Spec.Containers[0].Ports = getContainerPorts(deployComponent)
+	desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken = utils.BoolPtr(false)
+	desiredDeployment.Spec.Template.Spec.Containers[0].Image = deployComponent.GetImage()
+	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = getSecurityContextForContainer(deployComponent.GetRunAsNonRoot())
+	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+	desiredDeployment.Spec.Template.Spec.ImagePullSecrets = deploy.radixDeployment.Spec.ImagePullSecrets
+	desiredDeployment.Spec.Template.Spec.SecurityContext = getSecurityContextForPod(deployComponent.GetRunAsNonRoot())
+
+	desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = GetRadixDeployComponentVolumeMounts(deployComponent)
 	volumes, err := deploy.GetVolumesForComponent(deployComponent)
 	if err != nil {
 		return err
 	}
-	podSpec.Volumes = volumes
-	podSpec.Affinity = deploy.getPodSpecAffinity(deployComponent)
+	desiredDeployment.Spec.Template.Spec.Volumes = volumes
+
+	if deployComponent.GetType() != defaults.RadixComponentTypeJobScheduler {
+		desiredDeployment.Spec.Template.Spec.Affinity = deploy.getPodSpecAffinity(deployComponent)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Job component, containing `node` setting, should not have `affinity` for Job Scheduler pod (for which it is created k8s `deployment/spec/template/spec/affinity...` section with node condition), but have it only for sckeduling jobs (RadixDeployment k8 object).
Cleaned duplicated logic for creating/updating k8s `deployment` object.