### PR TITLE
102114 get common env vars for radix components

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.1
-appVersion: 1.13.5
+appVersion: 1.13.6
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/environmentvariables.go
+++ b/pkg/apis/deployment/environmentvariables.go
@@ -17,6 +17,7 @@ type environmentVariablesSourceDecorator interface {
 	getClusterName() (string, error)
 	getContainerRegistry() (string, error)
 	getDnsZone() (string, error)
+	getClusterType() (string, error)
 }
 
 type radixApplicationEnvironmentVariablesSourceDecorator struct{}
@@ -34,6 +35,10 @@ func (envVarsSource *radixApplicationEnvironmentVariablesSourceDecorator) getCon
 
 func (envVarsSource *radixApplicationEnvironmentVariablesSourceDecorator) getDnsZone() (string, error) {
 	return getEnvVar(defaults.RadixDNSZoneEnvironmentVariable)
+}
+
+func (envVarsSource *radixApplicationEnvironmentVariablesSourceDecorator) getClusterType() (string, error) {
+	return getEnvVar(defaults.RadixClusterTypeEnvironmentVariable)
 }
 
 func (envVarsSource *radixOperatorEnvironmentVariablesSourceDecorator) getClusterName() (string, error) {
@@ -54,6 +59,10 @@ func (envVarsSource *radixOperatorEnvironmentVariablesSourceDecorator) getContai
 
 func (envVarsSource *radixOperatorEnvironmentVariablesSourceDecorator) getDnsZone() (string, error) {
 	return getEnvVar(defaults.OperatorDNSZoneEnvironmentVariable)
+}
+
+func (envVarsSource *radixOperatorEnvironmentVariablesSourceDecorator) getClusterType() (string, error) {
+	return getEnvVar(defaults.OperatorClusterTypeEnvironmentVariable)
 }
 
 //getEnvironmentVariablesForRadixOperator Provides RADIX_* environment variables for Radix operator.
@@ -148,7 +157,7 @@ func appendDefaultVariables(envVarsSource environmentVariablesSourceDecorator, c
 		return envVarSet.Items()
 	}
 
-	clusterType, err := getEnvVar(defaults.RadixClusterTypeEnvironmentVariable)
+	clusterType, err := envVarsSource.getClusterType()
 	if err == nil {
 		envVarSet.Add(defaults.RadixClusterTypeEnvironmentVariable, clusterType)
 	} else {

--- a/pkg/apis/deployment/environmentvariables.go
+++ b/pkg/apis/deployment/environmentvariables.go
@@ -149,7 +149,7 @@ func appendDefaultVariables(envVariablesSource envVariablesSourceDecorator, curr
 	containerRegistry, err := envVariablesSource.GetContainerRegistry()
 	if err != nil {
 		log.Error(err)
-		return environmentVariables
+		return envVarSet.Items()
 	}
 
 	envVarSet.Add(defaults.ContainerRegistryEnvironmentVariable, containerRegistry)
@@ -157,7 +157,7 @@ func appendDefaultVariables(envVariablesSource envVariablesSourceDecorator, curr
 	clusterName, err := envVariablesSource.getClusterName()
 	if err != nil {
 		log.Error(err)
-		return environmentVariables
+		return envVarSet.Items()
 	}
 	envVarSet.Add(defaults.ClusternameEnvironmentVariable, clusterName)
 	envVarSet.Add(defaults.EnvironmentnameEnvironmentVariable, currentEnvironment)

--- a/pkg/apis/deployment/environmentvariables.go
+++ b/pkg/apis/deployment/environmentvariables.go
@@ -136,7 +136,7 @@ func appendDefaultVariables(envVariablesSource envVariablesSourceDecorator, curr
 	dnsZone := os.Getenv(defaults.OperatorDNSZoneEnvironmentVariable)
 	if dnsZone == "" {
 		log.Errorf("Not set environment variable %s", defaults.OperatorDNSZoneEnvironmentVariable)
-		return nil
+		return envVarSet.Items()
 	}
 
 	clusterType := os.Getenv(defaults.OperatorClusterTypeEnvironmentVariable)

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -182,7 +182,7 @@ func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.Radi
 		return err
 	}
 	desiredDeployment.Spec.Template.Spec.Volumes = volumes
-	desiredDeployment.Spec.Template.Spec.Affinity = utils.GetPodSpecAffinity(deployComponent)
+	desiredDeployment.Spec.Template.Spec.Affinity = utils.GetPodSpecAffinity(deployComponent.GetNode())
 
 	return nil
 }

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -219,7 +219,7 @@ func (deploy *Deployment) updateDeploymentByComponent(deployComponent v1.RadixCo
 	}
 
 	radixDeployment := deploy.radixDeployment
-	environmentVariables := GetEnvironmentVariablesFrom(appName, deploy.kubeutil, radixDeployment, deployComponent)
+	environmentVariables := getEnvironmentVariablesForRadixOperator(appName, deploy.kubeutil, radixDeployment, deployComponent)
 
 	if environmentVariables != nil {
 		desiredDeployment.Spec.Template.Spec.Containers[0].Env = environmentVariables

--- a/pkg/apis/deployment/secrets_test.go
+++ b/pkg/apis/deployment/secrets_test.go
@@ -40,6 +40,8 @@ func teardownSecretsTest() {
 	os.Unsetenv(defaults.OperatorReadinessProbePeriodSeconds)
 	os.Unsetenv(defaults.ActiveClusternameEnvironmentVariable)
 	os.Unsetenv(defaults.DeploymentsHistoryLimitEnvironmentVariable)
+	os.Unsetenv(defaults.OperatorRadixJobSchedulerEnvironmentVariable)
+	os.Unsetenv(defaults.OperatorClusterTypeEnvironmentVariable)
 }
 
 func TestSecretDeployed_ClientCertificateSecretGetsSet(t *testing.T) {

--- a/pkg/apis/test/utils.go
+++ b/pkg/apis/test/utils.go
@@ -253,6 +253,7 @@ func SetRequiredEnvironmentVariables() {
 	os.Setenv(defaults.OperatorReadinessProbeInitialDelaySeconds, "5")
 	os.Setenv(defaults.OperatorReadinessProbePeriodSeconds, "10")
 	os.Setenv(defaults.OperatorRadixJobSchedulerEnvironmentVariable, "radix-job-scheduler:main-latest")
+	os.Setenv(defaults.OperatorClusterTypeEnvironmentVariable, "development")
 }
 
 // CreateClusterPrerequisites Will do the needed setup which is part of radix boot

--- a/pkg/apis/utils/affinity.go
+++ b/pkg/apis/utils/affinity.go
@@ -11,8 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func GetPodSpecAffinity(radixComponent v1.RadixCommonDeployComponent) *corev1.Affinity {
-	node := radixComponent.GetNode()
+func GetPodSpecAffinity(node *v1.RadixNode) *corev1.Affinity {
 	if node == nil {
 		return nil
 	}

--- a/pkg/apis/utils/environmentvariables_set.go
+++ b/pkg/apis/utils/environmentvariables_set.go
@@ -17,9 +17,9 @@ func NewEnvironmentVariablesSet() *environmentVariablesSet {
 
 //Init Init set with environment variables list
 func (set *environmentVariablesSet) Init(environmentVariables []corev1.EnvVar) *environmentVariablesSet {
-	(*set).items = environmentVariables
-	(*set).newItems = make([]*corev1.EnvVar, 0)
-	(*set).itemsMap = getMap(&environmentVariables)
+	set.items = environmentVariables
+	set.newItems = make([]*corev1.EnvVar, 0)
+	set.itemsMap = getMap(environmentVariables)
 	return set
 }
 
@@ -54,11 +54,10 @@ func (set *environmentVariablesSet) Get(name string) (corev1.EnvVar, bool) {
 	return corev1.EnvVar{}, false
 }
 
-func getMap(environmentVariables *[]corev1.EnvVar) map[string]*corev1.EnvVar {
-	envVars := *environmentVariables
-	environmentVariablesMap := make(map[string]*corev1.EnvVar, len(envVars))
-	for i := 0; i < len(envVars); i++ {
-		environmentVariablesMap[envVars[i].Name] = &(envVars[i])
+func getMap(environmentVariables []corev1.EnvVar) map[string]*corev1.EnvVar {
+	environmentVariablesMap := make(map[string]*corev1.EnvVar, len(environmentVariables))
+	for i := 0; i < len(environmentVariables); i++ {
+		environmentVariablesMap[environmentVariables[i].Name] = &(environmentVariables[i])
 	}
 	return environmentVariablesMap
 }

--- a/pkg/apis/utils/environmentvariables_set.go
+++ b/pkg/apis/utils/environmentvariables_set.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type environmentVariablesSet struct {
+	items    []corev1.EnvVar
+	newItems []*corev1.EnvVar
+	itemsMap map[string]*corev1.EnvVar
+}
+
+//NewEnvironmentVariablesSet Create new EnvironmentVariablesSet
+func NewEnvironmentVariablesSet() *environmentVariablesSet {
+	return (&environmentVariablesSet{}).Init(make([]corev1.EnvVar, 0))
+}
+
+//Init Init set with environment variables list
+func (set *environmentVariablesSet) Init(environmentVariables []corev1.EnvVar) *environmentVariablesSet {
+	(*set).items = environmentVariables
+	(*set).newItems = make([]*corev1.EnvVar, 0)
+	(*set).itemsMap = getMap(&environmentVariables)
+	return set
+}
+
+//Add Add an environment variable to the set
+func (set *environmentVariablesSet) Add(name string, value string) *environmentVariablesSet {
+	if _, ok := set.itemsMap[name]; ok {
+		set.itemsMap[name].Value = value
+		return set
+	}
+	set.newItems = append(set.newItems, &corev1.EnvVar{
+		Name:  name,
+		Value: value,
+	})
+	set.itemsMap[name] = set.newItems[len(set.newItems)-1]
+	return set
+}
+
+//Items Get environment variables list from the set, ordered as they were added
+func (set *environmentVariablesSet) Items() []corev1.EnvVar {
+	var newItems []corev1.EnvVar
+	for _, envVar := range set.newItems {
+		newItems = append(newItems, *envVar)
+	}
+	return append(set.items, newItems...)
+}
+
+//Get Get an environment variable by name
+func (set *environmentVariablesSet) Get(name string) (corev1.EnvVar, bool) {
+	if envVar, ok := set.itemsMap[name]; ok {
+		return *envVar, true
+	}
+	return corev1.EnvVar{}, false
+}
+
+func getMap(environmentVariables *[]corev1.EnvVar) map[string]*corev1.EnvVar {
+	envVars := *environmentVariables
+	environmentVariablesMap := make(map[string]*corev1.EnvVar, len(envVars))
+	for i := 0; i < len(envVars); i++ {
+		environmentVariablesMap[envVars[i].Name] = &(envVars[i])
+	}
+	return environmentVariablesMap
+}

--- a/pkg/apis/utils/environmentvariables_set_test.go
+++ b/pkg/apis/utils/environmentvariables_set_test.go
@@ -1,0 +1,135 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sort"
+	"testing"
+)
+
+func Test_EmptySet(t *testing.T) {
+	t.Run("Empty set", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet()
+		assert.Equal(t, 0, len(set.Items()))
+	})
+}
+
+func Test_AddValuesToEmptySet(t *testing.T) {
+	t.Run("Add one value", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().Add("name1", "value1")
+		items := set.Items()
+		assert.Equal(t, 1, len(items))
+		assert.Equal(t, "name1", items[0].Name)
+		assert.Equal(t, "value1", items[0].Value)
+	})
+	t.Run("Add multiple values", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().
+			Add("name1", "value1").
+			Add("name2", "value2").
+			Add("name3", "value3")
+		items := set.Items()
+		assert.Equal(t, 3, len(items))
+		assert.Equal(t, "name1", items[0].Name)
+		assert.Equal(t, "value1", items[0].Value)
+		assert.Equal(t, "name2", items[1].Name)
+		assert.Equal(t, "value2", items[1].Value)
+		assert.Equal(t, "name3", items[2].Name)
+		assert.Equal(t, "value3", items[2].Value)
+	})
+}
+
+func Test_AddValuesToNonEmptySet(t *testing.T) {
+	t.Run("Add new value", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().Init([]corev1.EnvVar{
+			{Name: "name1", Value: "value1"},
+		})
+		set.Add("name2", "value2")
+		items := set.Items()
+		sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+		assert.Equal(t, 2, len(items))
+		assert.Equal(t, "name1", items[0].Name)
+		assert.Equal(t, "value1", items[0].Value)
+		assert.Equal(t, "name2", items[1].Name)
+		assert.Equal(t, "value2", items[1].Value)
+	})
+	t.Run("Add multiple new values", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().Init([]corev1.EnvVar{
+			{Name: "name1", Value: "value1"},
+		})
+		set.Add("name2", "value2").
+			Add("name3", "value3").
+			Add("name4", "value4")
+		items := set.Items()
+		assert.Equal(t, 4, len(items))
+		assert.Equal(t, "name1", items[0].Name)
+		assert.Equal(t, "value1", items[0].Value)
+		assert.Equal(t, "name2", items[1].Name)
+		assert.Equal(t, "value2", items[1].Value)
+		assert.Equal(t, "name3", items[2].Name)
+		assert.Equal(t, "value3", items[2].Value)
+		assert.Equal(t, "name4", items[3].Name)
+		assert.Equal(t, "value4", items[3].Value)
+	})
+	t.Run("Add var with existing name of non-empty set", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().Init([]corev1.EnvVar{
+			{Name: "name2", Value: "value2"},
+		})
+		set.Add("name1", "value1").
+			Add("name2", "value22").
+			Add("name3", "value3")
+		items := set.Items()
+		assert.Equal(t, 3, len(items))
+		assert.Equal(t, "name2", items[0].Name)
+		assert.Equal(t, "value22", items[0].Value)
+		assert.Equal(t, "name1", items[1].Name)
+		assert.Equal(t, "value1", items[1].Value)
+		assert.Equal(t, "name3", items[2].Name)
+		assert.Equal(t, "value3", items[2].Value)
+	})
+}
+
+func Test_GetItems(t *testing.T) {
+	t.Run("Get items returns items with same order as they were added", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().Init([]corev1.EnvVar{
+			{Name: "name3", Value: "value3"},
+		})
+		set.Add("name1", "value1").
+			Add("name2", "value2")
+		items := set.Items()
+		assert.Equal(t, 3, len(items))
+		assert.Equal(t, "name3", items[0].Name)
+		assert.Equal(t, "value3", items[0].Value)
+		assert.Equal(t, "name1", items[1].Name)
+		assert.Equal(t, "value1", items[1].Value)
+		assert.Equal(t, "name2", items[2].Name)
+		assert.Equal(t, "value2", items[2].Value)
+	})
+}
+
+func Test_GetValue(t *testing.T) {
+	t.Run("Get existing value", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().
+			Add("name1", "value1").
+			Add("name2", "value2")
+		envVar, found := set.Get("name2")
+		assert.True(t, found)
+		assert.Equal(t, "name2", envVar.Name)
+		assert.Equal(t, "value2", envVar.Value)
+	})
+	t.Run("Get non existing value", func(t *testing.T) {
+		t.Parallel()
+		set := NewEnvironmentVariablesSet().
+			Add("name1", "value1").
+			Add("name2", "value2")
+		_, found := set.Get("name3")
+		assert.False(t, found)
+	})
+}

--- a/radix-operator/main.go
+++ b/radix-operator/main.go
@@ -49,6 +49,8 @@ func main() {
 	switch os.Getenv("LOG_LEVEL") {
 	case "DEBUG":
 		logger.Logger.SetLevel(log.DebugLevel)
+	case "ERROR":
+		logger.Logger.SetLevel(log.ErrorLevel)
 	default:
 		logger.Logger.SetLevel(log.InfoLevel)
 	}


### PR DESCRIPTION
For radix-operator - it is used config-map and DNS_ZONE env-var;
For radix-app (like radix-job-scheduler) - only env-vars used, and RADIX_DNS_ZONE
Class pkg/apis/utils/environmentvariables_set.go is to collect EnvVars, avoid repetition on adding, return list with same order, as EnvVar-s were added