### PR TITLE
restore ownerreference of job step output configmaps

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.3
-appVersion: 1.14.1
+appVersion: 1.14.2
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/job/job_steps_test.go
+++ b/pkg/apis/job/job_steps_test.go
@@ -508,7 +508,9 @@ func (s *RadixJobStepTestSuite) testSetStatusOfJobTestScenario(scenario *setStat
 	}
 
 	job := NewJob(s.kubeClient, s.kubeUtils, s.radixClient, scenario.radixjob)
-	err := job.setStatusOfJob()
+	if err := job.setStatusOfJob(); err != nil {
+		assert.FailNowf(s.T(), err.Error(), "scenario %s", scenario.name)
+	}
 
 	actualRj, err := s.radixClient.RadixV1().RadixJobs(scenario.radixjob.Namespace).Get(context.Background(), scenario.radixjob.Name, metav1.GetOptions{})
 	if err != nil {
@@ -648,18 +650,12 @@ func (s *RadixJobStepTestSuite) getJobPod(podName, jobName, namespace string) *c
 }
 
 func (s *RadixJobStepTestSuite) appendJobPodContainerStatus(pod *corev1.Pod, containerStatus ...corev1.ContainerStatus) *corev1.Pod {
-	for _, s := range containerStatus {
-		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, s)
-	}
-
+	pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, containerStatus...)
 	return pod
 }
 
 func (s *RadixJobStepTestSuite) appendJobPodInitContainerStatus(pod *corev1.Pod, containerStatus ...corev1.ContainerStatus) *corev1.Pod {
-	for _, s := range containerStatus {
-		pod.Status.InitContainerStatuses = append(pod.Status.InitContainerStatuses, s)
-	}
-
+	pod.Status.InitContainerStatuses = append(pod.Status.InitContainerStatuses, containerStatus...)
 	return pod
 }
 

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	pipelineJob "github.com/equinor/radix-operator/pkg/apis/pipeline"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
-	"github.com/equinor/radix-operator/pkg/apis/utils"
 	conditionUtils "github.com/equinor/radix-operator/pkg/apis/utils/conditions"
 	numberUtils "github.com/equinor/radix-operator/pkg/apis/utils/numbers"
 	log "github.com/sirupsen/logrus"
@@ -100,22 +97,6 @@ func (job *Job) getJobConfig(name string) (*batchv1.Job, error) {
 	}
 
 	return &jobCfg, nil
-}
-
-func getUniqueJobName(image string) (string, string) {
-	var jobName []string
-	randomStr := strings.ToLower(utils.RandString(5))
-	jobName = append(jobName, image)
-	jobName = append(jobName, "-")
-	jobName = append(jobName, getCurrentTimestamp())
-	jobName = append(jobName, "-")
-	jobName = append(jobName, randomStr)
-	return strings.Join(jobName, ""), randomStr
-}
-
-func getCurrentTimestamp() string {
-	t := time.Now()
-	return t.Format("20060102150405") // YYYYMMDDHHMISS in Go
 }
 
 func (job *Job) getPipelineJobArguments(appName, jobName string, jobSpec v1.RadixJobSpec, pipeline *pipelineJob.Definition) []string {

--- a/pkg/apis/job/ownerreference.go
+++ b/pkg/apis/job/ownerreference.go
@@ -12,7 +12,7 @@ import (
 func GetOwnerReference(radixJob *v1.RadixJob) []metav1.OwnerReference {
 	trueVar := true
 	return []metav1.OwnerReference{
-		metav1.OwnerReference{
+		{
 			APIVersion: "radix.equinor.com/v1", //need to hardcode these values for now - seems they are missing from the CRD in k8s 1.8
 			Kind:       "RadixJob",
 			Name:       radixJob.Name,

--- a/pkg/apis/utils/job_builder.go
+++ b/pkg/apis/utils/job_builder.go
@@ -201,6 +201,7 @@ type JobStatusBuilder interface {
 	WithStarted(time.Time) JobStatusBuilder
 	WithEnded(time.Time) JobStatusBuilder
 	WithSteps(...JobStepBuilder) JobStatusBuilder
+	WithStep(JobStepBuilder) JobStatusBuilder
 	Build() v1.RadixJobStatus
 }
 
@@ -228,6 +229,11 @@ func (jsb *jobStatusBuilder) WithEnded(ended time.Time) JobStatusBuilder {
 
 func (jsb *jobStatusBuilder) WithSteps(steps ...JobStepBuilder) JobStatusBuilder {
 	jsb.steps = steps
+	return jsb
+}
+
+func (jsb *jobStatusBuilder) WithStep(step JobStepBuilder) JobStatusBuilder {
+	jsb.steps = append(jsb.steps, step)
 	return jsb
 }
 


### PR DESCRIPTION
restores ownerreference of configmaps created by scan steps when job handler restores RJ status from velero annotation