### PR TITLE
add new promethus label to networkpolicy

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.1.6
-appVersion: 1.15.9
+appVersion: 1.15.10
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/networkpolicy.go
+++ b/pkg/apis/deployment/networkpolicy.go
@@ -44,16 +44,17 @@ func defaultNetworkPolicy(appName, env string, owner []metav1.OwnerReference) *v
 		Spec: v1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{},
 			Ingress: []v1.NetworkPolicyIngressRule{
-				v1.NetworkPolicyIngressRule{
+				{
 					From: []v1.NetworkPolicyPeer{
 						// active all pod in the namespace this nsp is created in
-						v1.NetworkPolicyPeer{
+						{
 							PodSelector: &metav1.LabelSelector{},
 						},
 						// namespace hosting prometheus and ingress-nginx need label "purpose:radix-base-ns"
 						createSelector(map[string]string{"app": "nginx-ingress"}, map[string]string{"purpose": "radix-base-ns"}),
 						createSelector(map[string]string{"app.kubernetes.io/name": "ingress-nginx"}, map[string]string{"purpose": "radix-base-ns"}),
 						createSelector(map[string]string{"app": "prometheus"}, map[string]string{"purpose": "radix-base-ns"}),
+						createSelector(map[string]string{"app.kubernetes.io/name": "prometheus"}, map[string]string{"purpose": "radix-base-ns"}),
 					},
 				},
 			},

--- a/pkg/apis/deployment/networkpolicy.go
+++ b/pkg/apis/deployment/networkpolicy.go
@@ -51,9 +51,7 @@ func defaultNetworkPolicy(appName, env string, owner []metav1.OwnerReference) *v
 							PodSelector: &metav1.LabelSelector{},
 						},
 						// namespace hosting prometheus and ingress-nginx need label "purpose:radix-base-ns"
-						createSelector(map[string]string{"app": "nginx-ingress"}, map[string]string{"purpose": "radix-base-ns"}),
 						createSelector(map[string]string{"app.kubernetes.io/name": "ingress-nginx"}, map[string]string{"purpose": "radix-base-ns"}),
-						createSelector(map[string]string{"app": "prometheus"}, map[string]string{"purpose": "radix-base-ns"}),
 						createSelector(map[string]string{"app.kubernetes.io/name": "prometheus"}, map[string]string{"purpose": "radix-base-ns"}),
 					},
 				},


### PR DESCRIPTION
The new version of promethus removed the app=promethus labels and introduced a new label app.kubernetes.io/name=promethus

This new labels must be added to the netwokpolicy added to each app envionment namespace to allow promethus to connect and scrape metrics.
