### PR TITLE
Add podspec tolerations for RadixNode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -70,7 +70,7 @@
         "RADIXOPERATOR_APP_ROLLING_UPDATE_MAX_SURGE": "25%",
         "RADIXOPERATOR_APP_READINESS_PROBE_INITIAL_DELAY_SECONDS": "5",
         "RADIXOPERATOR_APP_READINESS_PROBE_PERIOD_SECONDS": "10",
-        "RADIX_ACTIVE_CLUSTERNAME": "weekly-49",
+        "RADIX_ACTIVE_CLUSTERNAME": "weekly-07",
         "RADIX_CONFIG_TO_MAP": "radix-config-2-map:master-latest",
         "RADIX_IMAGE_BUILDER": "radix-image-builder:master-latest",
         "RADIX_IMAGE_SCANNER": "radix-image-scanner:master-latest",

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
-version: 1.2.3
-appVersion: 1.19.0
+version: 1.2.4
+appVersion: 1.19.1
 kubeVersion: ">=1.11.2"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -2577,6 +2577,12 @@ func TestUseGpuNodeOnDeploy(t *testing.T) {
 		assert.Equal(t, corev1.NodeSelectorOpIn, expression.Operator)
 		assert.Equal(t, 1, len(expression.Values))
 		assert.Contains(t, expression.Values, gpuNvidiaV100)
+
+		tolerations := deployment.Spec.Template.Spec.Tolerations
+		assert.Len(t, tolerations, 1)
+		assert.Equal(t, kube.NodeTaintGpuCountKey, tolerations[0].Key)
+		assert.Equal(t, corev1.TolerationOpExists, tolerations[0].Operator)
+		assert.Equal(t, corev1.TaintEffectNoSchedule, tolerations[0].Effect)
 	})
 	t.Run("has node with nvidia-v100, nvidia-p100", func(t *testing.T) {
 		t.Parallel()
@@ -2593,6 +2599,12 @@ func TestUseGpuNodeOnDeploy(t *testing.T) {
 		assert.Equal(t, 2, len(expression.Values))
 		assert.Contains(t, expression.Values, gpuNvidiaV100)
 		assert.Contains(t, expression.Values, gpuNvidiaP100)
+
+		tolerations := deployment.Spec.Template.Spec.Tolerations
+		assert.Len(t, tolerations, 1)
+		assert.Equal(t, kube.NodeTaintGpuCountKey, tolerations[0].Key)
+		assert.Equal(t, corev1.TolerationOpExists, tolerations[0].Operator)
+		assert.Equal(t, corev1.TaintEffectNoSchedule, tolerations[0].Effect)
 	})
 	t.Run("has node with nvidia-v100, nvidia-p100, not nvidia-k80", func(t *testing.T) {
 		t.Parallel()
@@ -2614,17 +2626,29 @@ func TestUseGpuNodeOnDeploy(t *testing.T) {
 		assert.Equal(t, corev1.NodeSelectorOpNotIn, expression1.Operator)
 		assert.Equal(t, 1, len(expression1.Values))
 		assert.Contains(t, expression1.Values, gpuNvidiaK80)
+
+		tolerations := deployment.Spec.Template.Spec.Tolerations
+		assert.Len(t, tolerations, 1)
+		assert.Equal(t, kube.NodeTaintGpuCountKey, tolerations[0].Key)
+		assert.Equal(t, corev1.TolerationOpExists, tolerations[0].Operator)
+		assert.Equal(t, corev1.TaintEffectNoSchedule, tolerations[0].Effect)
 	})
 	t.Run("has node with no gpu", func(t *testing.T) {
 		t.Parallel()
 		deployment, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), componentName4, metav1.GetOptions{})
 		assert.Nil(t, deployment.Spec.Template.Spec.Affinity)
+
+		tolerations := deployment.Spec.Template.Spec.Tolerations
+		assert.Len(t, tolerations, 0)
 	})
 	t.Run("job has node, but pod template of Job Scheduler does not have it", func(t *testing.T) {
 		t.Parallel()
 		deployment, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), jobComponentName, metav1.GetOptions{})
 		affinity := deployment.Spec.Template.Spec.Affinity
 		assert.Nil(t, affinity)
+
+		tolerations := deployment.Spec.Template.Spec.Tolerations
+		assert.Len(t, tolerations, 0)
 	})
 }
 

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -185,6 +185,7 @@ func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.Radi
 	desiredDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe = readinessProbe
 
 	desiredDeployment.Spec.Template.Spec.Affinity = utils.GetPodSpecAffinity(deployComponent.GetNode())
+	desiredDeployment.Spec.Template.Spec.Tolerations = utils.GetPodSpecTolerations(deployComponent.GetNode())
 
 	return nil
 }

--- a/pkg/apis/kube/kube.go
+++ b/pkg/apis/kube/kube.go
@@ -59,6 +59,10 @@ const (
 	RadixSecretRefNameLabel            = "radix-secret-ref-name"
 	RadixUserDefinedNetworkPolicyLabel = "is-user-defined"
 
+	// NodeTaintGpuCountKey defines the taint key on GPU nodes.
+	// Pods required to run on nodes with this taint must add a toleration with effect NoSchedule
+	NodeTaintGpuCountKey = "radix-node-gpu-count"
+
 	//Only for backward compatibility
 	RadixBranchDeprecated = "radix-branch"
 )

--- a/pkg/apis/utils/tolerations.go
+++ b/pkg/apis/utils/tolerations.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/equinor/radix-operator/pkg/apis/kube"
+	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetPodSpecTolerations returns tolerations required to schedule the pod on nodes defined by RadixNode
+func GetPodSpecTolerations(node *v1.RadixNode) []corev1.Toleration {
+	if node == nil {
+		return nil
+	}
+
+	// No toleration required if Gpu is empty
+	if len(strings.ReplaceAll(node.Gpu, " ", "")) == 0 {
+		return nil
+	}
+
+	var tolerations []corev1.Toleration
+
+	tolerations = append(tolerations, getGpuNodeTolerations(node)...)
+
+	return tolerations
+}
+
+func getGpuNodeTolerations(node *v1.RadixNode) []corev1.Toleration {
+	if node == nil {
+		return nil
+	}
+
+	// No toleration required if Gpu is empty
+	if len(strings.ReplaceAll(node.Gpu, " ", "")) == 0 {
+		return nil
+	}
+
+	tolerations := []corev1.Toleration{
+		{Key: kube.NodeTaintGpuCountKey, Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+	}
+
+	return tolerations
+}


### PR DESCRIPTION
- Add tolerations for taints defined on k8s nodes with GPU. [https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)