### PR TITLE
add rule allowing own ns to oauth and scheduler pods

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
-version: 1.2.12
-appVersion: 1.19.12
+version: 1.2.13
+appVersion: 1.19.13
 kubeVersion: ">=1.20.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/networkpolicy.go
+++ b/pkg/apis/deployment/networkpolicy.go
@@ -126,6 +126,16 @@ func allowAllHttpsAndDnsEgressNetworkPolicy(policyName string, targetLabelKey st
 						},
 					},
 				},
+				{
+					To: []v1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								kube.RadixAppLabel: appName,
+								kube.RadixEnvLabel: env,
+							},
+						},
+					}},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Last PR broke oauth aux for environments without egress rules