### PR TITLE
allow app adm to update oauth aux deployment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -80,7 +80,7 @@
         "RADIX_OAUTH_PROXY_DEFAULT_OIDC_ISSUER_URL": "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0",
         "RADIX_OAUTH_PROXY_IMAGE": "quay.io/oauth2-proxy/oauth2-proxy:v7.2.0",
         "RADIXOPERATOR_TENANT_ID": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
-        "KUBERNETES_SERVICE_PORT": 443
+        "KUBERNETES_SERVICE_PORT": "443"
       },
       "args": ["--useOutClusterClient=false"]
     },

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
 version: 1.3.2
-appVersion: 1.20.2
+appVersion: 1.20.3
 kubeVersion: ">=1.20.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/oauthproxyresourcemanager.go
+++ b/pkg/apis/deployment/oauthproxyresourcemanager.go
@@ -498,15 +498,17 @@ func (o *oauthProxyResourceManager) mergeAuxComponentResourceLabels(object metav
 
 func (o *oauthProxyResourceManager) grantAccessToSecret(component v1.RadixCommonDeployComponent) error {
 	secretName := utils.GetAuxiliaryComponentSecretName(component.GetName(), defaults.OAuthProxyAuxiliaryComponentSuffix)
+	deploymentName := utils.GetAuxiliaryComponentDeploymentName(component.GetName(), defaults.OAuthProxyAuxiliaryComponentSuffix)
 	roleName := o.getRoleAndRoleBindingName(component.GetName())
 	namespace := o.rd.Namespace
 
 	// create role
-	role := kube.CreateManageSecretRole(
+	role := kube.CreateAppRole(
 		o.rd.Spec.AppName,
 		roleName,
-		[]string{secretName},
 		o.getLabelsForAuxComponent(component),
+		kube.ManageSecretsRule([]string{secretName}),
+		kube.UpdateDeploymentsRule([]string{deploymentName}),
 	)
 
 	err := o.kubeutil.ApplyRole(namespace, role)

--- a/pkg/apis/kube/roles.go
+++ b/pkg/apis/kube/roles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/equinor/radix-operator/pkg/apis/utils/slice"
 	log "github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -116,8 +117,31 @@ func (kubeutil *Kube) ApplyClusterRole(clusterrole *rbacv1.ClusterRole) error {
 	return nil
 }
 
-// CreateManageSecretRole creates a role that can manage a secret with predefined set of verbs
-func CreateManageSecretRole(appName, roleName string, secretNames []string, customLabels map[string]string) *rbacv1.Role {
+type RuleBuilder func() rbacv1.PolicyRule
+
+func ManageSecretsRule(secretNames []string) RuleBuilder {
+	return func() rbacv1.PolicyRule {
+		return rbacv1.PolicyRule{
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: secretNames,
+			Verbs:         []string{"get", "list", "watch", "update", "patch", "delete"},
+		}
+	}
+}
+
+func UpdateDeploymentsRule(deployments []string) RuleBuilder {
+	return func() rbacv1.PolicyRule {
+		return rbacv1.PolicyRule{
+			APIGroups:     []string{"apps"},
+			Resources:     []string{"deployments"},
+			ResourceNames: deployments,
+			Verbs:         []string{"update"},
+		}
+	}
+}
+
+func CreateAppRole(appName, roleName string, customLabels map[string]string, ruleBuilders ...RuleBuilder) *rbacv1.Role {
 	role := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
@@ -129,14 +153,10 @@ func CreateManageSecretRole(appName, roleName string, secretNames []string, cust
 				RadixAppLabel: appName,
 			},
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				ResourceNames: secretNames,
-				Verbs:         []string{"get", "list", "watch", "update", "patch", "delete"},
-			},
-		},
+	}
+
+	for _, rb := range ruleBuilders {
+		role.Rules = append(role.Rules, rb())
 	}
 
 	for key, value := range customLabels {
@@ -144,6 +164,37 @@ func CreateManageSecretRole(appName, roleName string, secretNames []string, cust
 	}
 
 	return role
+}
+
+// CreateManageSecretRole creates a role that can manage a secret with predefined set of verbs
+func CreateManageSecretRole(appName, roleName string, secretNames []string, customLabels map[string]string) *rbacv1.Role {
+	return CreateAppRole(appName, roleName, customLabels, ManageSecretsRule(secretNames))
+	// role := &rbacv1.Role{
+	// 	TypeMeta: metav1.TypeMeta{
+	// 		APIVersion: "rbac.authorization.k8s.io/v1",
+	// 		Kind:       "Role",
+	// 	},
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name: roleName,
+	// 		Labels: map[string]string{
+	// 			RadixAppLabel: appName,
+	// 		},
+	// 	},
+	// 	Rules: []rbacv1.PolicyRule{
+	// 		{
+	// 			APIGroups:     []string{""},
+	// 			Resources:     []string{"secrets"},
+	// 			ResourceNames: secretNames,
+	// 			Verbs:         []string{"get", "list", "watch", "update", "patch", "delete"},
+	// 		},
+	// 	},
+	// }
+
+	// for key, value := range customLabels {
+	// 	role.ObjectMeta.Labels[key] = value
+	// }
+
+	// return role
 }
 
 // ListRoles List roles


### PR DESCRIPTION
App admins needs update permission on othe oauth aux component. 
This permsission is required to be able to restart the oauth aux component. Restart adds/modifies an annotation on the oauth deployment.