### PR TITLE
Add permissions to tekton to radix-operator

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
-version: 1.4.0
-appVersion: 1.21.0
+version: 1.4.1
+appVersion: 1.21.1
 kubeVersion: ">=1.22.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/radix-operator-rbac.yaml
+++ b/charts/radix-operator/templates/radix-operator-rbac.yaml
@@ -131,6 +131,26 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+    - tekton.dev
+  resources:
+    - pipelines
+    - tasks
+  verbs:
+    - create
+    - get
+    - list
+    - update
+- apiGroups:
+    - tekton.dev
+  resources:
+    - pipelineruns
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Due to `radix-operator` cannot create rolebinding for radix-apps with RBAC permissions it does not have. Error:
```
Error while syncing: failed to create role binding object: rolebindings.rbac.authorization.k8s.io "radix-tekton" is forbidden: user "system:serviceaccount:default:radix-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:default" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["tekton.dev"], Resources:["pipelineruns"], Verbs:["create" "get" "list" "watch" "update"]}
{APIGroups:["tekton.dev"], Resources:["pipelines"], Verbs:["create" "get" "list" "update"]}
{APIGroups:["tekton.dev"], Resources:["tasks"], Verbs:["create" "get" "list" "update"]}"
```