### PR TITLE
panic if reading configmap with ingressConfiguration fails

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-operator
-version: 1.13.3
-appVersion: 1.32.3
+version: 1.13.4
+appVersion: 1.32.4
 kubeVersion: ">=1.22.0"
 description: Radix Operator
 keywords:

--- a/radix-operator/main.go
+++ b/radix-operator/main.go
@@ -371,7 +371,7 @@ func loadIngressConfigFromMap(kubeutil *kube.Kube) (deploymentAPI.IngressConfigu
 	config := deploymentAPI.IngressConfiguration{}
 	configMap, err := kubeutil.GetConfigMap(metav1.NamespaceDefault, ingressConfigurationMap)
 	if err != nil {
-		return config, nil
+		return config, err
 	}
 
 	err = yaml.Unmarshal([]byte(configMap.Data["ingressConfiguration"]), &config)


### PR DESCRIPTION
Fixes a bug that silently swallowed error if reading configmap failed, resulting in missing annotations on Ingress objects