### PR TITLE
add empty string enum for non-pointer strings to RA schema

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.14.2
-appVersion: 1.34.0
+version: 1.14.3
+appVersion: 1.34.1
 kubeVersion: ">=1.22.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/radixapplication.yaml
+++ b/charts/radix-operator/templates/radixapplication.yaml
@@ -187,6 +187,7 @@ spec:
                               enum:
                               - cookie
                               - redis
+                              - ""
                               type: string
                             setAuthorizationHeader:
                               description: Defines if the IDToken received by the
@@ -343,6 +344,7 @@ spec:
                                     enum:
                                     - cookie
                                     - redis
+                                    - ""
                                     type: string
                                   setAuthorizationHeader:
                                     description: Defines if the IDToken received by
@@ -566,12 +568,14 @@ spec:
                                   - ReadOnlyMany
                                   - ReadWriteOnce
                                   - ReadWriteMany
+                                  - ""
                                   type: string
                                 bindingMode:
                                   description: 'TODO: describe More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/'
                                   enum:
                                   - Immediate
                                   - WaitForFirstConsumer
+                                  - ""
                                   type: string
                                 container:
                                   description: 'Deprecated. Only required by the deprecated
@@ -1238,12 +1242,14 @@ spec:
                                   - ReadOnlyMany
                                   - ReadWriteOnce
                                   - ReadWriteMany
+                                  - ""
                                   type: string
                                 bindingMode:
                                   description: 'TODO: describe More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/'
                                   enum:
                                   - Immediate
                                   - WaitForFirstConsumer
+                                  - ""
                                   type: string
                                 container:
                                   description: 'Deprecated. Only required by the deprecated

--- a/json-schema/radixapplication.json
+++ b/json-schema/radixapplication.json
@@ -171,7 +171,8 @@
                         "description": "Defines where to store session data.",
                         "enum": [
                           "cookie",
-                          "redis"
+                          "redis",
+                          ""
                         ],
                         "type": "string"
                       },
@@ -329,7 +330,8 @@
                               "description": "Defines where to store session data.",
                               "enum": [
                                 "cookie",
-                                "redis"
+                                "redis",
+                                ""
                               ],
                               "type": "string"
                             },
@@ -558,7 +560,8 @@
                             "enum": [
                               "ReadOnlyMany",
                               "ReadWriteOnce",
-                              "ReadWriteMany"
+                              "ReadWriteMany",
+                              ""
                             ],
                             "type": "string"
                           },
@@ -566,7 +569,8 @@
                             "description": "TODO: describe More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/",
                             "enum": [
                               "Immediate",
-                              "WaitForFirstConsumer"
+                              "WaitForFirstConsumer",
+                              ""
                             ],
                             "type": "string"
                           },
@@ -1292,7 +1296,8 @@
                             "enum": [
                               "ReadOnlyMany",
                               "ReadWriteOnce",
-                              "ReadWriteMany"
+                              "ReadWriteMany",
+                              ""
                             ],
                             "type": "string"
                           },
@@ -1300,7 +1305,8 @@
                             "description": "TODO: describe More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/",
                             "enum": [
                               "Immediate",
-                              "WaitForFirstConsumer"
+                              "WaitForFirstConsumer",
+                              ""
                             ],
                             "type": "string"
                           },

--- a/pkg/apis/radix/v1/radixapptypes.go
+++ b/pkg/apis/radix/v1/radixapptypes.go
@@ -678,13 +678,13 @@ type RadixVolumeMount struct {
 
 	// TODO: describe
 	// More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
-	// +kubebuilder:validation:Enum=ReadOnlyMany;ReadWriteOnce;ReadWriteMany
+	// +kubebuilder:validation:Enum=ReadOnlyMany;ReadWriteOnce;ReadWriteMany;""
 	// +optional
 	AccessMode string `json:"accessMode,omitempty"` //Available values: ReadOnlyMany (default) - read-only by many nodes, ReadWriteOnce - read-write by a single node, ReadWriteMany - read-write by many nodes. https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
 
 	// TODO: describe
 	// More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
-	// +kubebuilder:validation:Enum=Immediate;WaitForFirstConsumer
+	// +kubebuilder:validation:Enum=Immediate;WaitForFirstConsumer;""
 	// +optional
 	BindingMode string `json:"bindingMode,omitempty"` //Volume binding mode. Available values: Immediate (default), WaitForFirstConsumer. https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
 }
@@ -977,7 +977,7 @@ type OAuth2 struct {
 	Cookie *OAuth2Cookie `json:"cookie,omitempty"`
 
 	// Defines where to store session data.
-	// +kubebuilder:validation:Enum=cookie;redis
+	// +kubebuilder:validation:Enum=cookie;redis;""
 	// +optional
 	SessionStoreType SessionStoreType `json:"sessionStoreType,omitempty"`
 
@@ -1241,7 +1241,7 @@ func (component *RadixJobComponent) GetIdentity() *Identity {
 	return component.Identity
 }
 
-//GetNotifications Get job component notifications
+// GetNotifications Get job component notifications
 func (component *RadixJobComponent) GetNotifications() *Notifications {
 	return component.Notifications
 }


### PR DESCRIPTION
All radixconfig.yaml files that have not been re-applied as a RadixApplication object are "incorrectly" stored in etc with empty string for non-pointer string properties.

When we tried to restore playgound-07 RAs to a new cluster we got the following errors:

time="2023-03-13T11:03:46Z" level=error msg="Namespace <namespace>, resource restore error: error restoring radixapplications.radix.equinor.com/<namespace>/<resource-name>: RadixApplication.radix.equinor.com \<resource-name> is invalid: [spec.components[2].environmentConfig[0].volumeMounts[0].accessMode: Unsupported value: \"\": supported values: \"ReadOnlyMany\", \"ReadWriteOnce\", \"ReadWriteMany\", spec.components[2].environmentConfig[0].volumeMounts[0].bindingMode: Unsupported value: \"\": supported values: \"Immediate\", \"WaitForFirstConsumer\"]" logSource="pkg/controller/restore_controller.go:531" restore=velero/migration-20230313101427-ra

When doing a k get ra -n <namespace> <resource-name> we get:
volumeMounts:
      - accessMode: ""
        bindingMode: ""
        container: ""
        gid: ""
        name: appstorage
        path: <path>
        requestsStorage: ""
        skuName: ""
        storage: <storagename>
        type: azure-blob
        uid: "1234"

accessMode and bindingMode is empty string. If we do this in weekly-xx for a RA with volumeMounts, properties with omitempty are not present in the output.

We must therefore allow empty string as a valid enum.
