### PR TITLE
fix job labels to support prometheus alerts

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.14.3
-appVersion: 1.34.1
+version: 1.14.4
+appVersion: 1.34.2
 kubeVersion: ">=1.22.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/batch/kubejob.go
+++ b/pkg/apis/batch/kubejob.go
@@ -52,9 +52,9 @@ func (s *syncer) reconcileKubeJob(batchJob radixv1.RadixBatchJob, rd *radixv1.Ra
 }
 
 func (s *syncer) buildJob(batchJob radixv1.RadixBatchJob, jobComponent *radixv1.RadixDeployJobComponent, rd *radixv1.RadixDeployment) (*batchv1.Job, error) {
-	jobLabels := s.batchJobIdentifierLabel(batchJob.Name)
+	jobLabels := s.batchJobIdentifierLabel(batchJob.Name, rd.Spec.AppName)
 	podLabels := radixlabels.Merge(
-		s.batchJobIdentifierLabel(batchJob.Name),
+		jobLabels,
 		radixlabels.ForPodWithRadixIdentity(jobComponent.Identity),
 	)
 

--- a/pkg/apis/batch/service.go
+++ b/pkg/apis/batch/service.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (s *syncer) reconcileService(batchJob radixv1.RadixBatchJob, jobComponent *radixv1.RadixDeployJobComponent, existingServices []*corev1.Service) error {
+func (s *syncer) reconcileService(batchJob radixv1.RadixBatchJob, rd *radixv1.RadixDeployment, jobComponent *radixv1.RadixDeployJobComponent, existingServices []*corev1.Service) error {
 	if len(jobComponent.GetPorts()) == 0 {
 		return nil
 	}
@@ -22,14 +22,14 @@ func (s *syncer) reconcileService(batchJob radixv1.RadixBatchJob, jobComponent *
 		return nil
 	}
 
-	service := s.buildService(batchJob.Name, jobComponent.GetPorts())
+	service := s.buildService(batchJob.Name, rd.Spec.AppName, jobComponent.GetPorts())
 	return s.kubeutil.ApplyService(s.batch.GetNamespace(), service)
 }
 
-func (s *syncer) buildService(batchJobName string, componentPorts []radixv1.ComponentPort) *corev1.Service {
+func (s *syncer) buildService(batchJobName, appName string, componentPorts []radixv1.ComponentPort) *corev1.Service {
 	serviceName := getKubeServiceName(s.batch.GetName(), batchJobName)
-	labels := s.batchJobIdentifierLabel(batchJobName)
-	selector := s.batchJobIdentifierLabel(batchJobName)
+	labels := s.batchJobIdentifierLabel(batchJobName, appName)
+	selector := s.batchJobIdentifierLabel(batchJobName, appName)
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            serviceName,

--- a/pkg/apis/batch/syncer.go
+++ b/pkg/apis/batch/syncer.go
@@ -64,7 +64,7 @@ func (s *syncer) reconcile() error {
 	}
 
 	for i, batchJob := range s.batch.Spec.Jobs {
-		if err := s.reconcileService(batchJob, jobComponent, existingServices); err != nil {
+		if err := s.reconcileService(batchJob, rd, jobComponent, existingServices); err != nil {
 			return err
 		}
 
@@ -103,14 +103,16 @@ func (s *syncer) getRadixDeployment() (*radixv1.RadixDeployment, error) {
 
 func (s *syncer) batchIdentifierLabel() labels.Set {
 	return radixlabels.Merge(
-		radixlabels.ForComponentName(s.batch.Spec.RadixDeploymentJobRef.Job),
 		radixlabels.ForBatchName(s.batch.GetName()),
 	)
 }
 
-func (s *syncer) batchJobIdentifierLabel(batchJobName string) labels.Set {
+func (s *syncer) batchJobIdentifierLabel(batchJobName, appName string) labels.Set {
 	return radixlabels.Merge(
+		radixlabels.ForApplicationName(appName),
+		radixlabels.ForComponentName(s.batch.Spec.RadixDeploymentJobRef.Job),
 		s.batchIdentifierLabel(),
+		radixlabels.ForJobScheduleJobType(),
 		radixlabels.ForBatchJobName(batchJobName),
 	)
 }

--- a/pkg/apis/batch/syncer_test.go
+++ b/pkg/apis/batch/syncer_test.go
@@ -319,11 +319,11 @@ func (s *syncerTestSuite) Test_ServiceCreated() {
 		jobServices := slice.FindAll(allServices.Items, func(svc corev1.Service) bool { return svc.Name == getKubeServiceName(batchName, jobName) })
 		s.Len(jobServices, 1)
 		service := jobServices[0]
-		expectedServiceLabels := map[string]string{kube.RadixComponentLabel: componentName, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
-		s.Equal(expectedServiceLabels, service.Labels)
+		expectedServiceLabels := map[string]string{kube.RadixAppLabel: appName, kube.RadixComponentLabel: componentName, kube.RadixJobTypeLabel: kube.RadixJobTypeJobSchedule, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
+		s.Equal(expectedServiceLabels, service.Labels, "service labels")
 		s.Equal(ownerReference(batch), service.OwnerReferences)
-		expectedSelectorLabels := map[string]string{kube.RadixComponentLabel: componentName, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
-		s.Equal(expectedSelectorLabels, service.Spec.Selector)
+		expectedSelectorLabels := map[string]string{kube.RadixAppLabel: appName, kube.RadixComponentLabel: componentName, kube.RadixJobTypeLabel: kube.RadixJobTypeJobSchedule, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
+		s.Equal(expectedSelectorLabels, service.Spec.Selector, "selector")
 		s.ElementsMatch([]corev1.ServicePort{{Name: "port1", Port: 8000, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8000)}, {Name: "port2", Port: 9000, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(9000)}}, service.Spec.Ports)
 	}
 }
@@ -458,10 +458,10 @@ func (s *syncerTestSuite) Test_BatchStaticConfiguration() {
 		jobKubeJobs := slice.FindAll(allJobs.Items, func(job batchv1.Job) bool { return job.Name == getKubeJobName(batchName, jobName) })
 		s.Len(jobKubeJobs, 1)
 		kubejob := jobKubeJobs[0]
-		expectedJobLabels := map[string]string{kube.RadixComponentLabel: componentName, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
-		s.Equal(expectedJobLabels, kubejob.Labels)
-		expectedPodLabels := map[string]string{kube.RadixComponentLabel: componentName, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
-		s.Equal(expectedPodLabels, kubejob.Spec.Template.Labels)
+		expectedJobLabels := map[string]string{kube.RadixAppLabel: appName, kube.RadixComponentLabel: componentName, kube.RadixJobTypeLabel: kube.RadixJobTypeJobSchedule, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
+		s.Equal(expectedJobLabels, kubejob.Labels, "job labels")
+		expectedPodLabels := map[string]string{kube.RadixAppLabel: appName, kube.RadixComponentLabel: componentName, kube.RadixJobTypeLabel: kube.RadixJobTypeJobSchedule, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName}
+		s.Equal(expectedPodLabels, kubejob.Spec.Template.Labels, "pod labels")
 		s.Equal(ownerReference(batch), kubejob.OwnerReferences)
 		s.Equal(numbers.Int32Ptr(0), kubejob.Spec.BackoffLimit)
 		s.Equal(corev1.RestartPolicyNever, kubejob.Spec.Template.Spec.RestartPolicy)
@@ -707,7 +707,7 @@ func (s *syncerTestSuite) Test_JobWithIdentity() {
 	s.Require().NoError(sut.OnSync())
 	jobs, _ := s.kubeClient.BatchV1().Jobs(namespace).List(context.Background(), metav1.ListOptions{})
 	s.Require().Len(jobs.Items, 1)
-	expectedPodLabels := map[string]string{kube.RadixComponentLabel: componentName, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName, "azure.workload.identity/use": "true"}
+	expectedPodLabels := map[string]string{kube.RadixAppLabel: appName, kube.RadixComponentLabel: componentName, kube.RadixJobTypeLabel: kube.RadixJobTypeJobSchedule, kube.RadixBatchNameLabel: batchName, kube.RadixBatchJobNameLabel: jobName, "azure.workload.identity/use": "true"}
 	s.Equal(expectedPodLabels, jobs.Items[0].Spec.Template.Labels)
 	s.Equal(utils.GetComponentServiceAccountName(componentName), jobs.Items[0].Spec.Template.Spec.ServiceAccountName)
 	s.Equal(utils.BoolPtr(false), jobs.Items[0].Spec.Template.Spec.AutomountServiceAccountToken)


### PR DESCRIPTION
Added missing labels `radix-app` and `radix-job-type` required by Prometheus alerting.

Verified that service and endpoints for Job pods work as intended.