### PR TITLE
SecurityContext for Pod and Container specs

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.17.1
-appVersion: 1.37.1
+version: 1.17.2
+appVersion: 1.37.2
 kubeVersion: ">=1.22.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/batch/kubejob.go
+++ b/pkg/apis/batch/kubejob.go
@@ -162,7 +162,7 @@ func (s *syncer) getContainers(rd *radixv1.RadixDeployment, jobComponent *radixv
 		Env:             environmentVariables,
 		Ports:           ports,
 		VolumeMounts:    volumeMounts,
-		SecurityContext: securitycontext.Container(),
+		SecurityContext: securitycontext.Container(securitycontext.WithContainerSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault)),
 		Resources:       resources,
 	}
 

--- a/pkg/apis/batch/syncer_test.go
+++ b/pkg/apis/batch/syncer_test.go
@@ -467,7 +467,7 @@ func (s *syncerTestSuite) Test_BatchStaticConfiguration() {
 		s.Equal(corev1.RestartPolicyNever, kubejob.Spec.Template.Spec.RestartPolicy)
 		s.Equal(securitycontext.Pod(securitycontext.WithPodSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault)), kubejob.Spec.Template.Spec.SecurityContext)
 		s.Equal(imageName, kubejob.Spec.Template.Spec.Containers[0].Image)
-		s.Equal(securitycontext.Container(), kubejob.Spec.Template.Spec.Containers[0].SecurityContext)
+		s.Equal(securitycontext.Container(securitycontext.WithContainerSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault)), kubejob.Spec.Template.Spec.Containers[0].SecurityContext)
 		s.Len(kubejob.Spec.Template.Spec.Containers[0].Resources.Limits, 0)
 		s.Len(kubejob.Spec.Template.Spec.Containers[0].Resources.Requests, 0)
 		s.Len(kubejob.Spec.Template.Spec.Containers[0].Env, 5)

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -156,11 +156,7 @@ func (deploy *Deployment) getDeploymentPodLabels(deployComponent v1.RadixCommonD
 
 func (deploy *Deployment) getDeploymentPodAnnotations(deployComponent v1.RadixCommonDeployComponent) map[string]string {
 	branch, _ := deploy.getRadixBranchAndCommitId()
-
-	annotations := radixlabels.Merge(
-		radixannotations.ForPodAppArmorRuntimeDefault(),
-		radixannotations.ForRadixBranch(branch),
-	)
+	annotations := radixannotations.ForRadixBranch(branch)
 
 	if deployComponent.IsAlwaysPullImageOnDeploy() {
 		annotations = radixlabels.Merge(annotations, radixannotations.ForRadixDeploymentName(deploy.radixDeployment.Name))
@@ -202,12 +198,12 @@ func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.Radi
 
 	desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken = commonUtils.BoolPtr(false)
 	desiredDeployment.Spec.Template.Spec.ImagePullSecrets = deploy.radixDeployment.Spec.ImagePullSecrets
-	desiredDeployment.Spec.Template.Spec.SecurityContext = securitycontext.Pod()
+	desiredDeployment.Spec.Template.Spec.SecurityContext = securitycontext.Pod(securitycontext.WithPodSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault))
 
 	desiredDeployment.Spec.Template.Spec.Containers[0].Image = deployComponent.GetImage()
 	desiredDeployment.Spec.Template.Spec.Containers[0].Ports = getContainerPorts(deployComponent)
 	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
-	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = securitycontext.Container()
+	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = securitycontext.Container(securitycontext.WithContainerSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault))
 
 	volumeMounts, err := GetRadixDeployComponentVolumeMounts(deployComponent, deploy.radixDeployment.GetName())
 	if err != nil {

--- a/pkg/apis/deployment/oauthproxyresourcemanager.go
+++ b/pkg/apis/deployment/oauthproxyresourcemanager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	"github.com/equinor/radix-operator/pkg/apis/securitycontext"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	oauthutil "github.com/equinor/radix-operator/pkg/apis/utils/oauth"
 	appsv1 "k8s.io/api/apps/v1"
@@ -657,9 +658,6 @@ func (o *oauthProxyResourceManager) getDesiredDeployment(component v1.RadixCommo
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: o.getLabelsForAuxComponent(component),
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -674,14 +672,11 @@ func (o *oauthProxyResourceManager) getDesiredDeployment(component v1.RadixCommo
 									ContainerPort: oauthProxyPortNumber,
 								},
 							},
-							ReadinessProbe: readinessProbe,
+							ReadinessProbe:  readinessProbe,
+							SecurityContext: securitycontext.Container(securitycontext.WithContainerSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault)),
 						},
 					},
-					SecurityContext: &corev1.PodSecurityContext{
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: "RuntimeDefault",
-						},
-					},
+					SecurityContext: securitycontext.Pod(securitycontext.WithPodSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault)),
 				},
 			},
 		},

--- a/pkg/apis/utils/annotations/annotations.go
+++ b/pkg/apis/utils/annotations/annotations.go
@@ -7,19 +7,13 @@ import (
 )
 
 const (
-	podAppArmorAnnotation                   = "apparmor.security.beta.kubernetes.io/pod"
+	podAppArmorAnnotation                   = "container.apparmor.security.beta.kubernetes.io/%s"
 	azureWorkloadIdentityClientIdAnnotation = "azure.workload.identity/client-id"
 )
 
 // Merge multiple maps into one
 func Merge(labels ...map[string]string) map[string]string {
 	return maputils.MergeMaps(labels...)
-}
-
-// ForPodAppArmorRuntimeDefault returns annotations for configuring a pod
-// to run with AppArmor profile "runtime/default"
-func ForPodAppArmorRuntimeDefault() map[string]string {
-	return map[string]string{podAppArmorAnnotation: "runtime/default"}
 }
 
 // ForRadixBranch returns annotations describing a branch name

--- a/pkg/apis/utils/annotations/annotations.go
+++ b/pkg/apis/utils/annotations/annotations.go
@@ -7,7 +7,6 @@ import (
 )
 
 const (
-	podAppArmorAnnotation                   = "container.apparmor.security.beta.kubernetes.io/%s"
 	azureWorkloadIdentityClientIdAnnotation = "azure.workload.identity/client-id"
 )
 

--- a/pkg/apis/utils/annotations/annotations_test.go
+++ b/pkg/apis/utils/annotations/annotations_test.go
@@ -17,12 +17,6 @@ func Test_Merge(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func Test_ForPodAppArmorRuntimeDefault(t *testing.T) {
-	actual := ForPodAppArmorRuntimeDefault()
-	expected := map[string]string{"apparmor.security.beta.kubernetes.io/pod": "runtime/default"}
-	assert.Equal(t, expected, actual)
-}
-
 func Test_ForRadixBranch(t *testing.T) {
 	actual := ForRadixBranch("anybranch")
 	expected := map[string]string{kube.RadixBranchAnnotation: "anybranch"}


### PR DESCRIPTION
- Set seccomp profile for all pod and container specs
- Remove unnecessary apparmor annotation since the default is runtime/default