### PR TITLE
Fix bug causing scale down to default replicas for components with HPA defined

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.20.1
-appVersion: 1.40.1
+version: 1.20.2
+appVersion: 1.40.2
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/deployment.yaml
+++ b/charts/radix-operator/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         {{- include "radix-operator.selectorLabels" . | nindent 8 }}
     spec:
+      strategy:
+        type: Recreate
       serviceAccount: {{ include "radix-operator.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -5,15 +5,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+
 	radixutils "github.com/equinor/radix-common/utils"
 	radixmaps "github.com/equinor/radix-common/utils/maps"
+	"github.com/equinor/radix-common/utils/pointers"
 	"github.com/equinor/radix-common/utils/slice"
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
@@ -40,6 +42,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	secretProvider "sigs.k8s.io/secrets-store-csi-driver/pkg/client/clientset/versioned"
@@ -313,6 +316,17 @@ func TestObjectSynced_MultiComponent_ContainsAllElements(t *testing.T) {
 				for _, componentName := range []string{componentNameApp, componentNameRedis, componentNameRadixQuote} {
 					deploy := getDeploymentByName(componentName, deployments)
 					assert.Equal(t, componentName, deploy.Spec.Template.Labels[kube.RadixComponentLabel], "invalid/missing value for label component-name")
+				}
+
+				expectedStartegy := appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+						MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+					},
+				}
+				for _, deployment := range deployments {
+					assert.Equal(t, expectedStartegy, deployment.Spec.Strategy)
 				}
 			})
 
@@ -1489,6 +1503,134 @@ func TestObjectUpdated_ZeroReplicasExistsAndNotSpecifiedReplicas_SetsDefaultRepl
 
 	deployments, _ = client.AppsV1().Deployments(envNamespace).List(context.TODO(), metav1.ListOptions{})
 	assert.Equal(t, int32(1), *deployments.Items[0].Spec.Replicas)
+}
+
+func TestObjectSynced_DeploymentReplicasSetAccordingToSpec(t *testing.T) {
+	tu, client, kubeUtil, radixclient, prometheusclient, _ := setupTest()
+	defer teardownTest()
+	envNamespace := utils.GetEnvironmentNamespace("anyapp", "test")
+
+	// Test
+	applyDeploymentWithSync(tu, client, kubeUtil, radixclient, prometheusclient, utils.ARadixDeployment().
+		WithDeploymentName("a_deployment_name").
+		WithAppName("anyapp").
+		WithEnvironment("test").
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("comp1"),
+			utils.NewDeployComponentBuilder().WithName("comp2").WithReplicas(pointers.Ptr(2)),
+			utils.NewDeployComponentBuilder().WithName("comp3").WithReplicas(pointers.Ptr(4)).WithHorizontalScaling(pointers.Ptr(int32(5)), int32(10), nil, nil),
+			utils.NewDeployComponentBuilder().WithName("comp4").WithReplicas(pointers.Ptr(6)).WithHorizontalScaling(pointers.Ptr(int32(5)), int32(10), nil, nil),
+			utils.NewDeployComponentBuilder().WithName("comp5").WithReplicas(pointers.Ptr(11)).WithHorizontalScaling(pointers.Ptr(int32(5)), int32(10), nil, nil),
+			utils.NewDeployComponentBuilder().WithName("comp6").WithReplicas(pointers.Ptr(0)).WithHorizontalScaling(pointers.Ptr(int32(5)), int32(10), nil, nil),
+		))
+
+	comp1, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp1", metav1.GetOptions{})
+	assert.Equal(t, int32(1), *comp1.Spec.Replicas)
+	comp2, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp2", metav1.GetOptions{})
+	assert.Equal(t, int32(2), *comp2.Spec.Replicas)
+	comp3, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp3", metav1.GetOptions{})
+	assert.Equal(t, int32(5), *comp3.Spec.Replicas)
+	comp4, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp4", metav1.GetOptions{})
+	assert.Equal(t, int32(6), *comp4.Spec.Replicas)
+	comp5, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp5", metav1.GetOptions{})
+	assert.Equal(t, int32(10), *comp5.Spec.Replicas)
+	comp6, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp6", metav1.GetOptions{})
+	assert.Equal(t, int32(0), *comp6.Spec.Replicas)
+}
+
+func TestObjectSynced_DeploymentReplicasFromCurrentDeploymentWhenHPAEnabled(t *testing.T) {
+	tu, client, kubeUtil, radixclient, prometheusclient, _ := setupTest()
+	defer teardownTest()
+	envNamespace := utils.GetEnvironmentNamespace("anyapp", "test")
+
+	// Initial sync creating deployments should use replicas from spec
+	_, err := applyDeploymentWithSync(tu, client, kubeUtil, radixclient, prometheusclient, utils.ARadixDeployment().
+		WithDeploymentName("deployment1").
+		WithAppName("anyapp").
+		WithEnvironment("test").
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("comp1").WithReplicas(pointers.Ptr(1)),
+			utils.NewDeployComponentBuilder().WithName("comp2").WithReplicas(pointers.Ptr(1)).WithHorizontalScaling(pointers.Ptr(int32(1)), int32(4), nil, nil),
+		))
+	require.NoError(t, err)
+
+	comp1, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp1", metav1.GetOptions{})
+	assert.Equal(t, int32(1), *comp1.Spec.Replicas)
+	comp2, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp2", metav1.GetOptions{})
+	assert.Equal(t, int32(1), *comp2.Spec.Replicas)
+
+	// Simulate HPA scaling up comp2 to 2 replicas
+	comp2.Spec.Replicas = pointers.Ptr[int32](3)
+	client.AppsV1().Deployments(envNamespace).Update(context.Background(), comp2, metav1.UpdateOptions{})
+
+	// Resync existing RD should use replicas from current deployment for HPA enabled component
+	err = applyDeploymentUpdateWithSync(tu, client, kubeUtil, radixclient, prometheusclient, utils.ARadixDeployment().
+		WithDeploymentName("deployment1").
+		WithAppName("anyapp").
+		WithEnvironment("test").
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("comp1").WithReplicas(pointers.Ptr(5)),
+			utils.NewDeployComponentBuilder().WithName("comp2").WithReplicas(pointers.Ptr(1)).WithHorizontalScaling(pointers.Ptr(int32(1)), int32(4), nil, nil),
+		))
+	require.NoError(t, err)
+
+	comp1, _ = client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp1", metav1.GetOptions{})
+	assert.Equal(t, int32(5), *comp1.Spec.Replicas)
+	comp2, _ = client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp2", metav1.GetOptions{})
+	assert.Equal(t, int32(3), *comp2.Spec.Replicas)
+
+	// Resync new RD should use replicas from current deployment for HPA enabled component
+	_, err = applyDeploymentWithSync(tu, client, kubeUtil, radixclient, prometheusclient, utils.ARadixDeployment().
+		WithDeploymentName("deployment2").
+		WithAppName("anyapp").
+		WithEnvironment("test").
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("comp1").WithReplicas(pointers.Ptr(5)),
+			utils.NewDeployComponentBuilder().WithName("comp2").WithReplicas(pointers.Ptr(1)).WithHorizontalScaling(pointers.Ptr(int32(1)), int32(4), nil, nil),
+		))
+	require.NoError(t, err)
+
+	comp1, _ = client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp1", metav1.GetOptions{})
+	assert.Equal(t, int32(5), *comp1.Spec.Replicas)
+	comp2, _ = client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp2", metav1.GetOptions{})
+	assert.Equal(t, int32(3), *comp2.Spec.Replicas)
+
+	// Resync new RD with HPA removed should use replicas from RD spec
+	_, err = applyDeploymentWithSync(tu, client, kubeUtil, radixclient, prometheusclient, utils.ARadixDeployment().
+		WithDeploymentName("deployment3").
+		WithAppName("anyapp").
+		WithEnvironment("test").
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("comp1").WithReplicas(pointers.Ptr(5)),
+			utils.NewDeployComponentBuilder().WithName("comp2").WithReplicas(pointers.Ptr(1)),
+		))
+	require.NoError(t, err)
+
+	comp1, _ = client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp1", metav1.GetOptions{})
+	assert.Equal(t, int32(5), *comp1.Spec.Replicas)
+	comp2, _ = client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp2", metav1.GetOptions{})
+	assert.Equal(t, int32(1), *comp2.Spec.Replicas)
+}
+
+func TestObjectSynced_DeploymentRevisionHistoryLimit(t *testing.T) {
+	tu, client, kubeUtil, radixclient, prometheusclient, _ := setupTest()
+	defer teardownTest()
+	envNamespace := utils.GetEnvironmentNamespace("anyapp", "test")
+
+	// Test
+	applyDeploymentWithSync(tu, client, kubeUtil, radixclient, prometheusclient, utils.ARadixDeployment().
+		WithDeploymentName("a_deployment_name").
+		WithAppName("anyapp").
+		WithEnvironment("test").
+		WithComponents(
+			utils.NewDeployComponentBuilder().WithName("comp1"),
+			utils.NewDeployComponentBuilder().WithName("comp2").WithSecretRefs(v1.RadixSecretRefs{AzureKeyVaults: []v1.RadixAzureKeyVault{{}}}),
+		))
+
+	comp1, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp1", metav1.GetOptions{})
+	assert.Nil(t, comp1.Spec.RevisionHistoryLimit)
+	comp2, _ := client.AppsV1().Deployments(envNamespace).Get(context.TODO(), "comp2", metav1.GetOptions{})
+	assert.Equal(t, pointers.Ptr(int32(0)), comp2.Spec.RevisionHistoryLimit)
 }
 
 func TestObjectUpdated_MultipleReplicasExistsAndNotSpecifiedReplicas_SetsDefaultReplicaCount(t *testing.T) {

--- a/pkg/apis/deployment/hpa.go
+++ b/pkg/apis/deployment/hpa.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 	"fmt"
+
 	"github.com/equinor/radix-common/utils/numbers"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
@@ -18,7 +19,6 @@ const targetCPUUtilizationPercentage int32 = 80
 func (deploy *Deployment) createOrUpdateHPA(deployComponent v1.RadixCommonDeployComponent) error {
 	namespace := deploy.radixDeployment.Namespace
 	componentName := deployComponent.GetName()
-	replicas := deployComponent.GetReplicas()
 	horizontalScaling := deployComponent.GetHorizontalScaling()
 
 	// Check if hpa config exists
@@ -27,9 +27,7 @@ func (deploy *Deployment) createOrUpdateHPA(deployComponent v1.RadixCommonDeploy
 		return nil
 	}
 
-	// Check if replicas == 0
-	if replicas != nil && *replicas == 0 {
-		log.Debugf("Skip creating HorizontalPodAutoscaler %s in namespace %s: replicas is 0", componentName, namespace)
+	if isComponentStopped(deployComponent) {
 		return nil
 	}
 

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	commonUtils "github.com/equinor/radix-common/utils"
-	"github.com/equinor/radix-common/utils/numbers"
+	"github.com/equinor/radix-common/utils/pointers"
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
@@ -27,9 +27,8 @@ func (deploy *Deployment) createOrUpdateDeployment(deployComponent v1.RadixCommo
 		return err
 	}
 
-	// If Replicas == 0 or HorizontalScaling is nil then delete hpa if exists before updating deployment
-	deployReplicas := desiredDeployment.Spec.Replicas
-	if deployReplicas != nil && *deployReplicas == 0 || deployComponent.GetHorizontalScaling() == nil {
+	// If component is stopped or HorizontalScaling is nil then delete hpa if exists before updating deployment
+	if isComponentStopped(deployComponent) || deployComponent.GetHorizontalScaling() == nil {
 		err = deploy.deleteHPAIfExists(deployComponent.GetName())
 		if err != nil {
 			return err
@@ -67,7 +66,6 @@ func (deploy *Deployment) getCurrentAndDesiredDeployment(deployComponent v1.Radi
 		return nil, nil, err
 	}
 
-	deploy.configureDeploymentServiceAccountSettings(desiredDeployment, deployComponent)
 	return currentDeployment, desiredDeployment, err
 }
 
@@ -95,16 +93,8 @@ func (deploy *Deployment) getDesiredDeployment(namespace string, deployComponent
 	return currentDeployment, desiredDeployment, nil
 }
 
-func (deploy *Deployment) configureDeploymentServiceAccountSettings(deployment *appsv1.Deployment, deployComponent v1.RadixCommonDeployComponent) {
-	spec := NewServiceAccountSpec(deploy.radixDeployment, deployComponent)
-	deployment.Spec.Template.Spec.AutomountServiceAccountToken = spec.AutomountServiceAccountToken()
-	deployment.Spec.Template.Spec.ServiceAccountName = spec.ServiceAccountName()
-}
-
 func (deploy *Deployment) getDesiredCreatedDeploymentConfig(deployComponent v1.RadixCommonDeployComponent) (*appsv1.Deployment, error) {
-	appName := deploy.radixDeployment.Spec.AppName
-	componentName := deployComponent.GetName()
-	log.Debugf("Get desired created deployment config for application: %s.", appName)
+	log.Debugf("Get desired created deployment config for application: %s.", deploy.radixDeployment.Spec.AppName)
 
 	desiredDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string), Annotations: make(map[string]string)},
@@ -113,23 +103,13 @@ func (deploy *Deployment) getDesiredCreatedDeploymentConfig(deployComponent v1.R
 			Selector: &metav1.LabelSelector{MatchLabels: make(map[string]string)},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string), Annotations: make(map[string]string)},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: componentName}}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: deployComponent.GetName()}}},
 			},
 		},
 	}
 
 	err := deploy.setDesiredDeploymentProperties(deployComponent, desiredDeployment)
-	if err != nil {
-		return nil, err
-	}
-
-	deploymentStrategy, err := getDeploymentStrategy()
-	if err != nil {
-		return nil, err
-	}
-	desiredDeployment.Spec.Strategy = deploymentStrategy
-
-	return deploy.updateDeploymentByComponent(deployComponent, desiredDeployment, appName)
+	return desiredDeployment, err
 }
 func (deploy *Deployment) createJobAuxDeployment(deployComponent v1.RadixCommonDeployComponent) *appsv1.Deployment {
 	jobName := deployComponent.GetName()
@@ -177,21 +157,18 @@ func getJobAuxResources() corev1.ResourceRequirements {
 }
 
 func (deploy *Deployment) getDesiredUpdatedDeploymentConfig(deployComponent v1.RadixCommonDeployComponent, currentDeployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-	appName := deploy.radixDeployment.Spec.AppName
-	log.Debugf("Get desired updated deployment config for application: %s.", appName)
+	log.Debugf("Get desired updated deployment config for application: %s.", deploy.radixDeployment.Spec.AppName)
 
 	desiredDeployment := currentDeployment.DeepCopy()
 	err := deploy.setDesiredDeploymentProperties(deployComponent, desiredDeployment)
-	if err != nil {
-		return nil, err
+
+	// When HPA is enabled for a component, the HPA controller will scale the Deployment up/down by changing Replicas
+	// We must keep this value
+	if hs := deployComponent.GetHorizontalScaling(); hs != nil {
+		desiredDeployment.Spec.Replicas = currentDeployment.Spec.Replicas
 	}
 
-	err = setDeploymentStrategy(&desiredDeployment.Spec.Strategy)
-	if err != nil {
-		return nil, err
-	}
-
-	return deploy.updateDeploymentByComponent(deployComponent, desiredDeployment, appName)
+	return desiredDeployment, err
 }
 
 func (deploy *Deployment) getDeploymentPodLabels(deployComponent v1.RadixCommonDeployComponent) map[string]string {
@@ -267,6 +244,14 @@ func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.Radi
 	desiredDeployment.ObjectMeta.Annotations = deploy.getDeploymentAnnotations(deployComponent)
 
 	desiredDeployment.Spec.Selector.MatchLabels = radixlabels.ForComponentName(componentName)
+	desiredDeployment.Spec.Replicas = getDesiredComponentReplicas(deployComponent)
+	desiredDeployment.Spec.RevisionHistoryLimit = getRevisionHistoryLimit(deployComponent)
+
+	deploymentStrategy, err := getDeploymentStrategy()
+	if err != nil {
+		return err
+	}
+	desiredDeployment.Spec.Strategy = deploymentStrategy
 
 	desiredDeployment.Spec.Template.ObjectMeta.Labels = deploy.getDeploymentPodLabels(deployComponent)
 	desiredDeployment.Spec.Template.ObjectMeta.Annotations = deploy.getDeploymentPodAnnotations(deployComponent)
@@ -275,16 +260,11 @@ func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.Radi
 	desiredDeployment.Spec.Template.Spec.ImagePullSecrets = deploy.radixDeployment.Spec.ImagePullSecrets
 	desiredDeployment.Spec.Template.Spec.SecurityContext = securitycontext.Pod(securitycontext.WithPodSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault))
 
-	desiredDeployment.Spec.Template.Spec.Containers[0].Image = deployComponent.GetImage()
-	desiredDeployment.Spec.Template.Spec.Containers[0].Ports = getContainerPorts(deployComponent)
-	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
-	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = securitycontext.Container(securitycontext.WithContainerSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault))
-
-	volumeMounts, err := GetRadixDeployComponentVolumeMounts(deployComponent, deploy.radixDeployment.GetName())
-	if err != nil {
-		return err
-	}
-	desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+	spec := NewServiceAccountSpec(deploy.radixDeployment, deployComponent)
+	desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken = spec.AutomountServiceAccountToken()
+	desiredDeployment.Spec.Template.Spec.ServiceAccountName = spec.ServiceAccountName()
+	desiredDeployment.Spec.Template.Spec.Affinity = utils.GetPodSpecAffinity(deployComponent.GetNode(), appName, componentName)
+	desiredDeployment.Spec.Template.Spec.Tolerations = utils.GetPodSpecTolerations(deployComponent.GetNode())
 
 	volumes, err := deploy.GetVolumesForComponent(deployComponent)
 	if err != nil {
@@ -292,14 +272,29 @@ func (deploy *Deployment) setDesiredDeploymentProperties(deployComponent v1.Radi
 	}
 	desiredDeployment.Spec.Template.Spec.Volumes = volumes
 
+	desiredDeployment.Spec.Template.Spec.Containers[0].Image = deployComponent.GetImage()
+	desiredDeployment.Spec.Template.Spec.Containers[0].Ports = getContainerPorts(deployComponent)
+	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = securitycontext.Container(securitycontext.WithContainerSeccompProfile(corev1.SeccompProfileTypeRuntimeDefault))
+	desiredDeployment.Spec.Template.Spec.Containers[0].Resources = utils.GetResourceRequirements(deployComponent)
+
+	volumeMounts, err := GetRadixDeployComponentVolumeMounts(deployComponent, deploy.radixDeployment.GetName())
+	if err != nil {
+		return err
+	}
+	desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+
 	readinessProbe, err := getReadinessProbeForComponent(deployComponent)
 	if err != nil {
 		return err
 	}
 	desiredDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe = readinessProbe
 
-	desiredDeployment.Spec.Template.Spec.Affinity = utils.GetPodSpecAffinity(deployComponent.GetNode(), appName, componentName)
-	desiredDeployment.Spec.Template.Spec.Tolerations = utils.GetPodSpecTolerations(deployComponent.GetNode())
+	environmentVariables, err := GetEnvironmentVariablesForRadixOperator(deploy.kubeutil, appName, deploy.radixDeployment, deployComponent)
+	if err != nil {
+		return err
+	}
+	desiredDeployment.Spec.Template.Spec.Containers[0].Env = environmentVariables
 
 	return nil
 }
@@ -317,44 +312,42 @@ func (deploy *Deployment) getRadixBranchAndCommitId() (string, string) {
 	return branch, commitID
 }
 
-func (deploy *Deployment) updateDeploymentByComponent(deployComponent v1.RadixCommonDeployComponent, desiredDeployment *appsv1.Deployment, appName string) (*appsv1.Deployment, error) {
-	replicas := deployComponent.GetReplicas()
-	if replicas != nil && *replicas >= 0 {
-		desiredDeployment.Spec.Replicas = int32Ptr(int32(*replicas))
-	} else {
-		desiredDeployment.Spec.Replicas = int32Ptr(int32(DefaultReplicas))
+func isComponentStopped(deployComponent v1.RadixCommonDeployComponent) bool {
+	if replicas := deployComponent.GetReplicas(); replicas != nil {
+		return *replicas == 0
 	}
 
-	// Override Replicas with horizontalScaling.minReplicas if exists
-	horizontalScaling := deployComponent.GetHorizontalScaling()
-	if replicas != nil && *replicas != 0 && horizontalScaling != nil {
-		desiredDeployment.Spec.Replicas = horizontalScaling.MinReplicas
-	}
-
-	radixDeployment := deploy.radixDeployment
-
-	environmentVariables, err := GetEnvironmentVariablesForRadixOperator(deploy.kubeutil, appName, radixDeployment, deployComponent)
-	if err != nil {
-		return nil, err
-	}
-
-	if environmentVariables != nil {
-		desiredDeployment.Spec.Template.Spec.Containers[0].Env = environmentVariables
-	}
-
-	desiredDeployment.Spec.Template.Spec.Containers[0].Resources = utils.GetResourceRequirements(deployComponent)
-
-	if hasRadixSecretRefs(deployComponent) {
-		desiredDeployment.Spec.RevisionHistoryLimit = numbers.Int32Ptr(0)
-	} else {
-		desiredDeployment.Spec.RevisionHistoryLimit = nil
-	}
-
-	return desiredDeployment, nil
+	return false
 }
 
-func hasRadixSecretRefs(deployComponent v1.RadixCommonDeployComponent) bool {
-	return len(deployComponent.GetSecretRefs().AzureKeyVaults) > 0
+func getDesiredComponentReplicas(deployComponent v1.RadixCommonDeployComponent) *int32 {
+	if isComponentStopped(deployComponent) {
+		return pointers.Ptr[int32](0)
+	}
+
+	componentReplicas := int32(DefaultReplicas)
+	if replicas := deployComponent.GetReplicas(); replicas != nil {
+		componentReplicas = int32(*replicas)
+	}
+
+	if hs := deployComponent.GetHorizontalScaling(); hs != nil {
+		if hs.MinReplicas != nil && *hs.MinReplicas > componentReplicas {
+			componentReplicas = *hs.MinReplicas
+		}
+		if hs.MaxReplicas < componentReplicas {
+			componentReplicas = hs.MaxReplicas
+		}
+	}
+
+	return pointers.Ptr(componentReplicas)
+}
+
+func getRevisionHistoryLimit(deployComponent v1.RadixCommonDeployComponent) *int32 {
+	if len(deployComponent.GetSecretRefs().AzureKeyVaults) > 0 {
+		return pointers.Ptr(int32(0))
+	}
+
+	return nil
 }
 
 func getDeploymentStrategy() (appsv1.DeploymentStrategy, error) {
@@ -369,6 +362,7 @@ func getDeploymentStrategy() (appsv1.DeploymentStrategy, error) {
 	}
 
 	deploymentStrategy := appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateDeployment{
 			MaxUnavailable: &intstr.IntOrString{
 				Type:   intstr.String,
@@ -463,22 +457,6 @@ func getReadinessProbe(componentPort, initialDelaySeconds, periodSeconds int32) 
 		InitialDelaySeconds: initialDelaySeconds,
 		PeriodSeconds:       periodSeconds,
 	}
-}
-
-func setDeploymentStrategy(deploymentStrategy *appsv1.DeploymentStrategy) error {
-	rollingUpdateMaxUnavailable, err := defaults.GetDefaultRollingUpdateMaxUnavailable()
-	if err != nil {
-		return err
-	}
-
-	rollingUpdateMaxSurge, err := defaults.GetDefaultRollingUpdateMaxSurge()
-	if err != nil {
-		return err
-	}
-
-	deploymentStrategy.RollingUpdate.MaxUnavailable.StrVal = rollingUpdateMaxUnavailable
-	deploymentStrategy.RollingUpdate.MaxSurge.StrVal = rollingUpdateMaxSurge
-	return nil
 }
 
 func getContainerPorts(deployComponent v1.RadixCommonDeployComponent) []corev1.ContainerPort {

--- a/pkg/apis/deployment/kubedeployment_test.go
+++ b/pkg/apis/deployment/kubedeployment_test.go
@@ -9,16 +9,9 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/test"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
-
-func teardownRollingUpdate() {
-	os.Unsetenv(defaults.OperatorRollingUpdateMaxUnavailable)
-	os.Unsetenv(defaults.OperatorRollingUpdateMaxSurge)
-}
 
 func teardownReadinessProbe() {
 	os.Unsetenv(defaults.OperatorReadinessProbeInitialDelaySeconds)
@@ -296,40 +289,6 @@ func Test_UpdateResourcesInDeployment(t *testing.T) {
 		assert.Equal(t, parseQuantity(expectedLimits["cpu"]), desiredRes.Limits["cpu"])
 		assert.Equal(t, parseQuantity(expectedLimits["memory"]), desiredRes.Limits["memory"])
 	})
-}
-
-func TestSetDeploymentStrategy_Default(t *testing.T) {
-	teardownRollingUpdate()
-	deploymentStrategy := createDeploymentStrategy()
-	err := setDeploymentStrategy(deploymentStrategy)
-	assert.NotNil(t, err)
-}
-
-func TestSetDeploymentStrategy_Custom(t *testing.T) {
-	test.SetRequiredEnvironmentVariables()
-
-	deploymentStrategy := createDeploymentStrategy()
-	setDeploymentStrategy(deploymentStrategy)
-
-	assert.Equal(t, "25%", deploymentStrategy.RollingUpdate.MaxUnavailable.StrVal)
-	assert.Equal(t, "25%", deploymentStrategy.RollingUpdate.MaxSurge.StrVal)
-
-	teardownRollingUpdate()
-}
-func createDeploymentStrategy() *appsv1.DeploymentStrategy {
-	deploymentStrategy := appsv1.DeploymentStrategy{
-		RollingUpdate: &appsv1.RollingUpdateDeployment{
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.String,
-				StrVal: "none",
-			},
-			MaxSurge: &intstr.IntOrString{
-				Type:   intstr.String,
-				StrVal: "none",
-			},
-		},
-	}
-	return &deploymentStrategy
 }
 
 func applyDeploymentWithSyncWithComponentResources(origRequests, origLimits map[string]string) Deployment {

--- a/pkg/apis/utils/deploymentcomponent_builder.go
+++ b/pkg/apis/utils/deploymentcomponent_builder.go
@@ -28,7 +28,7 @@ type DeployComponentBuilder interface {
 	WithSecretRefs(v1.RadixSecretRefs) DeployComponentBuilder
 	WithDNSAppAlias(bool) DeployComponentBuilder
 	WithDNSExternalAlias(string) DeployComponentBuilder
-	WithHorizontalScaling(*int32, int32, *int32, *int32) DeployComponentBuilder
+	WithHorizontalScaling(minReplicas *int32, maxReplicas int32, cpu *int32, memory *int32) DeployComponentBuilder
 	WithRunAsNonRoot(bool) DeployComponentBuilder
 	WithAuthentication(*v1.Authentication) DeployComponentBuilder
 	WithIdentity(*v1.Identity) DeployComponentBuilder


### PR DESCRIPTION
When HPA is enabled for a component, the HPA controller will scale up/down number of replicas by changing the `replicas` property of the K8S Deployment object.
Because of this, radix-operator should not set `replicas` of the Deployment when synced. It should keep `replicas` from the existing deployment since this reflects the desired value by the HPA.

Ref support case [https://equinor.slack.com/archives/CBKM6N2JY/p1690804203908019](https://equinor.slack.com/archives/CBKM6N2JY/p1690804203908019)