### PR TITLE
add pipeline job name label to all related pods

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.23.7
-appVersion: 1.43.7
+version: 1.23.8
+appVersion: 1.43.8
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pipeline-runner/steps/build_acr.go
+++ b/pipeline-runner/steps/build_acr.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	radixannotations "github.com/equinor/radix-operator/pkg/apis/utils/annotations"
 	"github.com/equinor/radix-operator/pkg/apis/utils/git"
+	radixlabels "github.com/equinor/radix-operator/pkg/apis/utils/labels"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -67,9 +68,7 @@ func createACRBuildJob(rr *v1.RadixRegistration, pipelineInfo *model.PipelineInf
 			BackoffLimit: &backOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						kube.RadixJobNameLabel: jobName,
-					},
+					Labels:      radixlabels.ForPipelineJobName(jobName),
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/pipeline-runner/utils/tekton.go
+++ b/pipeline-runner/utils/tekton.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/apis/utils/annotations"
 	"github.com/equinor/radix-operator/pkg/apis/utils/git"
+	radixlabels "github.com/equinor/radix-operator/pkg/apis/utils/labels"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,7 @@ func CreateActionPipelineJob(containerName string, action string, pipelineInfo *
 			BackoffLimit: &backOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels:      radixlabels.ForPipelineJobName(jobName),
 					Annotations: annotations.ForClusterAutoscalerSafeToEvict(false),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -229,6 +229,11 @@ func (s *RadixJobTestSuite) TestObjectSynced_PipelineJobCreated() {
 			},
 		},
 	}
+
+	expectedPodLabels := map[string]string{kube.RadixJobNameLabel: jobName}
+	s.Equal(expectedPodLabels, podTemplate.Labels)
+	expectedPodAnnotations := annotations.ForClusterAutoscalerSafeToEvict(false)
+	s.Equal(expectedPodAnnotations, podTemplate.Annotations)
 	expectedPodSpec := corev1.PodSpec{
 		RestartPolicy:      corev1.RestartPolicyNever,
 		Tolerations:        expectedTolerations,

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -13,11 +13,12 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/apis/utils/annotations"
 	"github.com/equinor/radix-operator/pkg/apis/utils/git"
+	radixlabels "github.com/equinor/radix-operator/pkg/apis/utils/labels"
 	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	kubelabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/yaml"
 )
@@ -82,6 +83,7 @@ func (job *Job) getPipelineJobConfig() (*batchv1.Job, error) {
 			BackoffLimit: &backOffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels:      radixlabels.ForPipelineJobName(jobName),
 					Annotations: annotations.ForClusterAutoscalerSafeToEvict(false),
 				},
 				Spec: corev1.PodSpec{
@@ -190,17 +192,20 @@ func (job *Job) getPipelineJobArguments(appName, jobName string, jobSpec v1.Radi
 
 func getPipelineJobLabels(appName, jobName string, jobSpec v1.RadixJobSpec, pipeline *pipelineJob.Definition) map[string]string {
 	// Base labels for all types of pipeline
-	labels := map[string]string{
-		kube.RadixJobNameLabel: jobName,
-		kube.RadixJobTypeLabel: kube.RadixJobTypeJob,
-		"radix-pipeline":       string(pipeline.Type),
-		kube.RadixAppLabel:     appName,
-	}
+	labels := radixlabels.Merge(
+		radixlabels.ForApplicationName(appName),
+		radixlabels.ForPipelineJobName(jobName),
+		radixlabels.ForPipelineJobType(),
+		radixlabels.ForPipelineJobPipelineType(pipeline.Type),
+	)
 
 	switch pipeline.Type {
 	case v1.BuildDeploy, v1.Build:
-		labels[kube.RadixImageTagLabel] = jobSpec.Build.ImageTag
-		labels[kube.RadixCommitLabel] = jobSpec.Build.CommitID
+		labels = radixlabels.Merge(
+			labels,
+			radixlabels.ForCommitId(jobSpec.Build.CommitID),
+			radixlabels.ForRadixImageTag(jobSpec.Build.ImageTag),
+		)
 	}
 
 	return labels
@@ -259,7 +264,7 @@ func (job *Job) getRadixJobResult() (*v1.RadixJobResult, error) {
 }
 
 func getRadixPipelineJobResultConfigMapSelector(jobName string) string {
-	radixJobNameReq, _ := labels.NewRequirement(kube.RadixJobNameLabel, selection.Equals, []string{jobName})
-	pipelineResultConfigMapReq, _ := labels.NewRequirement(kube.RadixConfigMapTypeLabel, selection.Equals, []string{string(kube.RadixPipelineResultConfigMap)})
-	return labels.NewSelector().Add(*radixJobNameReq, *pipelineResultConfigMapReq).String()
+	radixJobNameReq, _ := kubelabels.NewRequirement(kube.RadixJobNameLabel, selection.Equals, []string{jobName})
+	pipelineResultConfigMapReq, _ := kubelabels.NewRequirement(kube.RadixConfigMapTypeLabel, selection.Equals, []string{string(kube.RadixPipelineResultConfigMap)})
+	return kubelabels.NewSelector().Add(*radixJobNameReq, *pipelineResultConfigMapReq).String()
 }

--- a/pkg/apis/kube/kube.go
+++ b/pkg/apis/kube/kube.go
@@ -70,6 +70,7 @@ const (
 	RadixBatchJobNameLabel             = "radix-batch-job-name"
 	RadixBatchTypeLabel                = "radix-batch-type"
 	RadixAccessValidationLabel         = "radix-access-validation"
+	RadixPipelineTypeLabels            = "radix-pipeline"
 
 	// NodeTaintGpuCountKey defines the taint key on GPU nodes.
 	// Pods required to run on nodes with this taint must add a toleration with effect NoSchedule

--- a/pkg/apis/utils/labels/labels.go
+++ b/pkg/apis/utils/labels/labels.go
@@ -158,6 +158,32 @@ func ForJobScheduleJobType() kubelabels.Set {
 	return ForJobType(kube.RadixJobTypeJobSchedule)
 }
 
+// ForPipelineJobName returns labels describing the name of a pipeline job
+func ForPipelineJobName(jobName string) kubelabels.Set {
+	return kubelabels.Set{
+		kube.RadixJobNameLabel: jobName,
+	}
+}
+
+// ForPipelineJobType returns labels describing the pipeline-job type
+func ForPipelineJobType() kubelabels.Set {
+	return ForJobType(kube.RadixJobTypeJob)
+}
+
+// ForPipelineJobPipelineType returns label describing the pipeline-job pipeline type, e.g. build-deploy, promote, deploy-only
+func ForPipelineJobPipelineType(pipeline v1.RadixPipelineType) kubelabels.Set {
+	return kubelabels.Set{
+		kube.RadixPipelineTypeLabels: string(pipeline),
+	}
+}
+
+// ForRadixImageTag returns labels describing that image tag used by pipeline job in a build-deploy scenario
+func ForRadixImageTag(imageTag string) kubelabels.Set {
+	return kubelabels.Set{
+		kube.RadixImageTagLabel: imageTag,
+	}
+}
+
 func forAzureWorkloadUseIdentity() kubelabels.Set {
 	return kubelabels.Set{
 		azureWorkloadIdentityUseLabel: "true",

--- a/pkg/apis/utils/labels/labels_test.go
+++ b/pkg/apis/utils/labels/labels_test.go
@@ -112,6 +112,30 @@ func Test_ForAccessValidation(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func Test_ForPipelineJobName(t *testing.T) {
+	actual := ForPipelineJobName("anypipelinejobname")
+	expected := kubelabels.Set{kube.RadixJobNameLabel: "anypipelinejobname"}
+	assert.Equal(t, expected, actual)
+}
+
+func Test_ForPipelineJobType(t *testing.T) {
+	actual := ForPipelineJobType()
+	expected := kubelabels.Set{kube.RadixJobTypeLabel: kube.RadixJobTypeJob}
+	assert.Equal(t, expected, actual)
+}
+
+func Test_ForPipelineJobPipelineType(t *testing.T) {
+	actual := ForPipelineJobPipelineType("anypipelinetype")
+	expected := kubelabels.Set{kube.RadixPipelineTypeLabels: "anypipelinetype"}
+	assert.Equal(t, expected, actual)
+}
+
+func Test_ForRadixImageTag(t *testing.T) {
+	actual := ForRadixImageTag("anyimagetag")
+	expected := kubelabels.Set{kube.RadixImageTagLabel: "anyimagetag"}
+	assert.Equal(t, expected, actual)
+}
+
 func Test_RequirementRadixBatchNameLabelExists(t *testing.T) {
 	actual := requirementRadixBatchNameLabelExists()
 	expected := kubelabels.Set{kube.RadixBatchNameLabel: "anyname"}


### PR DESCRIPTION
Added radix-job_name labels to tektop pods (prepare and run pipelines) and radix-pipeline pod (orchestration)

Will use these labels in radix-log-api to get logs for pipeline job steps.