### PR TITLE
use AddAfter for requeue when lock cannot be acquired

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.23.10
-appVersion: 1.43.10
+version: 1.23.11
+appVersion: 1.43.11
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/radix-operator/common/controller.go
+++ b/radix-operator/common/controller.go
@@ -131,7 +131,8 @@ func (c *Controller) processNext(errorGroup *errgroup.Group, stopCh <-chan struc
 
 		if !locker.TryGetLock(lockKey) {
 			c.Log.Debugf("Lock for %s was busy, requeuing %s", lockKey, identifier)
-			c.WorkQueue.AddRateLimited(identifier)
+			// Use AddAfter instead of AddRateLimited. AddRateLimited can potentially cause a delay of 1000 seconds
+			c.WorkQueue.AddAfter(identifier, 100*time.Millisecond)
 			return nil
 		}
 		defer func() {


### PR DESCRIPTION
Using AddAfter when requeuing an item when a lock cannot be acquired. AddRateLimited could potentially lead to situations when an item would be delayed for 1000 seconds when requeuing.