### PR TITLE
get radixbatch from k8s api in batch handler

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.23.11
-appVersion: 1.43.11
+version: 1.23.12
+appVersion: 1.43.12
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/radix-operator/batch/handler.go
+++ b/radix-operator/batch/handler.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/equinor/radix-operator/pkg/apis/batch"
@@ -9,6 +10,7 @@ import (
 	"github.com/equinor/radix-operator/radix-operator/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -67,7 +69,7 @@ func NewHandler(
 }
 
 func (h *Handler) Sync(namespace, name string, eventRecorder record.EventRecorder) error {
-	radixBatch, err := h.kubeutil.GetRadixBatch(namespace, name)
+	radixBatch, err := h.radixclient.RadixV1().RadixBatches(namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if err != nil {
 		// The resource may no longer exist, in which case we stop
 		// processing.


### PR DESCRIPTION
Batch handler must get RadixBatch objects from k8s API instead of lister to prevent processing an outdated version of radixbatch. When this happens, a 429 conflict error (see below) is returned when syncing status of radixbatch.

429 conflict error example:
```
Error while syncing: Operation cannot be fulfilled on radixbatches.radix.equinor.com \"batch-computetqca9zzqo-20231020102544-ygb4eki0\": the object has been modified; please apply your changes to the latest version and try again
```