### PR TITLE
Update validation of imageTagName in CICD pipeline

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,14 +40,15 @@
       "program": "${workspaceFolder}/pipeline-runner/main.go",
       "env": {},
       "args": [
-        "--RADIX_APP=radix-job-demo",
+        "--RADIX_APP=oauth-demo",
         "--IMAGE_TAG=abcdef",
-        "--JOB_NAME=radix-pipeline-promotion-1",
+        "--JOB_NAME=radix-pipeline-20231121120818-sb2xq",
         "--PIPELINE_TYPE=promote",
         "--RADIX_TEKTON_IMAGE=radix-tekton:main-latest",
-        "--FROM_ENVIRONMENT=qa",
+        "--FROM_ENVIRONMENT=dev",
         "--TO_ENVIRONMENT=prod",
-        "--DEPLOYMENT_NAME=qa-etxkt-ac6rxchq",
+        "--DEPLOYMENT_NAME=dev-hyxzv-j9pg34k2",
+        "--RADIX_FILE_NAME=/workspace/radixconfig.yaml",
         "--DEBUG=true",
         "--RADIX_CONTAINER_REGISTRY=radixdev.azurecr.io"
       ]
@@ -97,7 +98,7 @@
         "RADIXOPERATOR_APP_ROLLING_UPDATE_MAX_SURGE": "25%",
         "RADIXOPERATOR_APP_READINESS_PROBE_INITIAL_DELAY_SECONDS": "5",
         "RADIXOPERATOR_APP_READINESS_PROBE_PERIOD_SECONDS": "10",
-        "RADIX_ACTIVE_CLUSTERNAME": "weekly-45",
+        "RADIX_ACTIVE_CLUSTERNAME": "weekly-47",
         "RADIX_IMAGE_BUILDER": "radix-image-builder:master-latest",
         "RADIX_TEKTON_IMAGE": "radix-tekton:main-latest",
         "RADIXOPERATOR_JOB_SCHEDULER": "radix-job-scheduler:main-latest",

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.25.4
-appVersion: 1.45.4
+version: 1.25.5
+appVersion: 1.45.5
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.25.6
-appVersion: 1.45.6
+version: 1.25.7
+appVersion: 1.45.7
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pipeline-runner/internal/test/utils.go
+++ b/pipeline-runner/internal/test/utils.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"context"
+
+	"github.com/equinor/radix-operator/pipeline-runner/internal/hash"
+	"github.com/equinor/radix-operator/pipeline-runner/model"
+	pipelineDefaults "github.com/equinor/radix-operator/pipeline-runner/model/defaults"
+	"github.com/equinor/radix-operator/pkg/apis/defaults"
+	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	"github.com/equinor/radix-operator/pkg/apis/utils"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	yamlk8s "sigs.k8s.io/yaml"
+)
+
+func CreatePreparePipelineConfigMapResponse(kubeClient kubernetes.Interface, configMapName, appName string, ra *radixv1.RadixApplication, buildCtx *model.PrepareBuildContext) error {
+	raBytes, err := yamlk8s.Marshal(ra)
+	if err != nil {
+		return err
+	}
+	data := map[string]string{
+		pipelineDefaults.PipelineConfigMapContent: string(raBytes),
+	}
+
+	if buildCtx != nil {
+		buildCtxBytes, err := yaml.Marshal(buildCtx)
+		if err != nil {
+			return err
+		}
+		data[pipelineDefaults.PipelineConfigMapBuildContext] = string(buildCtxBytes)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+		Data:       data,
+	}
+	_, err = kubeClient.CoreV1().ConfigMaps(utils.GetAppNamespace(appName)).Create(context.Background(), cm, metav1.CreateOptions{})
+	return err
+}
+
+func CreateGitInfoConfigMapResponse(kubeClient kubernetes.Interface, configMapName, appName, gitHash, gitTags string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+		Data: map[string]string{
+			defaults.RadixGitCommitHashKey: gitHash,
+			defaults.RadixGitTagsKey:       gitTags,
+		},
+	}
+	_, err := kubeClient.CoreV1().ConfigMaps(utils.GetAppNamespace(appName)).Create(context.Background(), cm, metav1.CreateOptions{})
+	return err
+}
+
+func CreateBuildSecret(kubeClient kubernetes.Interface, appName string, data map[string][]byte) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: defaults.BuildSecretsName},
+		Data:       data,
+	}
+
+	_, err := kubeClient.CoreV1().Secrets(utils.GetAppNamespace(appName)).Create(context.Background(), secret, metav1.CreateOptions{})
+	return err
+}
+
+func GetRadixApplicationHash(ra *radixv1.RadixApplication) string {
+	if ra == nil {
+		hash, _ := hash.ToHashString(hash.SHA256, "0nXSg9l6EUepshGFmolpgV3elB0m8Mv7")
+		return hash
+	}
+	hash, _ := hash.ToHashString(hash.SHA256, ra.Spec)
+	return hash
+}
+
+func GetBuildSecretHash(secret *corev1.Secret) string {
+	if secret == nil {
+		hash, _ := hash.ToHashString(hash.SHA256, "34Wd68DsJRUzrHp2f63o3U5hUD6zl8Tj")
+		return hash
+	}
+	hash, _ := hash.ToHashString(hash.SHA256, secret.Data)
+	return hash
+}

--- a/pipeline-runner/steps/apply_radixconfig.go
+++ b/pipeline-runner/steps/apply_radixconfig.go
@@ -90,11 +90,6 @@ func (cli *ApplyConfigStepImplementation) Run(pipelineInfo *model.PipelineInfo) 
 	applicationConfig := application.NewApplicationConfig(cli.GetKubeclient(), cli.GetKubeutil(),
 		cli.GetRadixclient(), cli.GetRegistration(), ra)
 
-	err = applicationConfig.ApplyConfigToApplicationNamespace()
-	if err != nil {
-		return err
-	}
-
 	pipelineInfo.SetApplicationConfig(applicationConfig)
 
 	if err := cli.setBuildSecret(pipelineInfo); err != nil {
@@ -117,6 +112,11 @@ func (cli *ApplyConfigStepImplementation) Run(pipelineInfo *model.PipelineInfo) 
 		}
 		pipelineInfo.SetGitAttributes(gitCommitHash, gitTags)
 		pipelineInfo.StopPipeline, pipelineInfo.StopPipelineMessage = getPipelineShouldBeStopped(pipelineInfo.PrepareBuildContext)
+	}
+
+	err = applicationConfig.ApplyConfigToApplicationNamespace()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pipeline-runner/steps/apply_radixconfig.go
+++ b/pipeline-runner/steps/apply_radixconfig.go
@@ -2,7 +2,7 @@ package steps
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -21,6 +21,7 @@ import (
 	operatorutils "github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/apis/utils/git"
 	radixclient "github.com/equinor/radix-operator/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -571,10 +572,10 @@ func validateDeployComponentImages(deployComponentImages pipeline.DeployEnvironm
 					continue
 				}
 
-				errs = append(errs, ErrMissingRequiredImageTagName(componentName, envName))
+				errs = append(errs, errors.WithMessagef(ErrMissingRequiredImageTagName, "component %s in environment %s", componentName, envName))
 			}
 		}
 	}
 
-	return errors.Join(errs...)
+	return stderrors.Join(errs...)
 }

--- a/pipeline-runner/steps/apply_radixconfig_test.go
+++ b/pipeline-runner/steps/apply_radixconfig_test.go
@@ -120,7 +120,9 @@ func (s *applyConfigTestSuite) Test_Deploy_ComponentWithMissingImageTagNameShoul
 	applyStep := steps.NewApplyConfigStep()
 	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
 	err := applyStep.Run(&pipeline)
-	s.ErrorContains(err, steps.ErrMissingRequiredImageTagName("deploycomp", "dev").Error())
+	s.ErrorIs(err, steps.ErrMissingRequiredImageTagName)
+	s.ErrorContains(err, "deploycomp")
+	s.ErrorContains(err, "dev")
 }
 
 func (s *applyConfigTestSuite) Test_Deploy_ComponentWithImageTagNameInRAShouldSucceed() {
@@ -204,7 +206,9 @@ func (s *applyConfigTestSuite) Test_Deploy_JobWithMissingImageTagNameShouldFail(
 	applyStep := steps.NewApplyConfigStep()
 	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
 	err := applyStep.Run(&pipeline)
-	s.ErrorContains(err, steps.ErrMissingRequiredImageTagName("deployjob", "dev").Error())
+	s.ErrorIs(err, steps.ErrMissingRequiredImageTagName)
+	s.ErrorContains(err, "deployjob")
+	s.ErrorContains(err, "dev")
 }
 
 func (s *applyConfigTestSuite) Test_Deploy_JobWithImageTagNameInRAShouldSucceed() {

--- a/pipeline-runner/steps/apply_radixconfig_test.go
+++ b/pipeline-runner/steps/apply_radixconfig_test.go
@@ -1,0 +1,264 @@
+package steps_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equinor/radix-common/utils/pointers"
+	internaltest "github.com/equinor/radix-operator/pipeline-runner/internal/test"
+	"github.com/equinor/radix-operator/pipeline-runner/model"
+	"github.com/equinor/radix-operator/pipeline-runner/steps"
+	"github.com/equinor/radix-operator/pkg/apis/kube"
+	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	"github.com/equinor/radix-operator/pkg/apis/utils"
+	radixfake "github.com/equinor/radix-operator/pkg/client/clientset/versioned/fake"
+	prometheusfake "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_RunApplyConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(applyConfigTestSuite))
+}
+
+type applyConfigTestSuite struct {
+	suite.Suite
+	kubeClient  *kubefake.Clientset
+	radixClient *radixfake.Clientset
+	promClient  *prometheusfake.Clientset
+	kubeUtil    *kube.Kube
+}
+
+func (s *applyConfigTestSuite) SetupTest() {
+	s.kubeClient = kubefake.NewSimpleClientset()
+	s.radixClient = radixfake.NewSimpleClientset()
+	s.promClient = prometheusfake.NewSimpleClientset()
+	s.kubeUtil, _ = kube.New(s.kubeClient, s.radixClient, nil)
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_BuildComponentInDeployPiplineShouldFail() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithComponents(
+			utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName("buildcomp"),
+			utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName("deploycomp").WithImage("any:latest"),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	err := applyStep.Run(&pipeline)
+	s.ErrorIs(err, steps.ErrDeployOnlyPipelineDoesNotSupportBuild)
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_BuildJobInDeployPiplineShouldFail() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithJobComponents(
+			utils.NewApplicationJobComponentBuilder().WithSchedulerPort(pointers.Ptr[int32](9999)).WithName("buildjob"),
+			utils.NewApplicationJobComponentBuilder().WithSchedulerPort(pointers.Ptr[int32](9999)).WithName("deployjob").WithImage("any:latest"),
+		).
+		WithEnvironment("dev", "anybranch").
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	err := applyStep.Run(&pipeline)
+	s.ErrorIs(err, steps.ErrDeployOnlyPipelineDoesNotSupportBuild)
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_ComponentWithMissingImageTagNameShouldFail() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithComponents(
+			utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName("deploycomp").WithImage("any:{imageTagName}"),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	err := applyStep.Run(&pipeline)
+	s.ErrorContains(err, steps.ErrMissingRequiredImageTagName("deploycomp", "dev").Error())
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_ComponentWithImageTagNameInRAShouldSucceed() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithComponents(
+			utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName("deploycomp").WithImage("any:{imageTagName}").
+				WithEnvironmentConfig(utils.NewComponentEnvironmentBuilder().WithEnvironment("dev").WithImageTagName("anytag")),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	s.NoError(applyStep.Run(&pipeline))
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_ComponentWithImageTagNameInPipelineArgShouldSucceed() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithComponents(
+			utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName("deploycomp").WithImage("any:{imageTagName}"),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+			ImageTagNames: map[string]string{"deploycomp": "tag"},
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	s.NoError(applyStep.Run(&pipeline))
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_JobWithMissingImageTagNameShouldFail() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithJobComponents(
+			utils.NewApplicationJobComponentBuilder().WithSchedulerPort(pointers.Ptr[int32](9999)).WithName("deployjob").WithImage("any:{imageTagName}"),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	err := applyStep.Run(&pipeline)
+	s.ErrorContains(err, steps.ErrMissingRequiredImageTagName("deployjob", "dev").Error())
+}
+
+func (s *applyConfigTestSuite) Test_Deploy_JobWithImageTagNameInRAShouldSucceed() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithJobComponents(
+			utils.NewApplicationJobComponentBuilder().WithSchedulerPort(pointers.Ptr[int32](9999)).WithName("deployjob").WithImage("any:{imageTagName}").
+				WithEnvironmentConfig(utils.NewJobComponentEnvironmentBuilder().WithEnvironment("dev").WithImageTagName("anytag")),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	s.NoError(applyStep.Run(&pipeline))
+}
+
+func (s *applyConfigTestSuite) Test_DeployComponentWitImageTagNameInPipelineArgShouldSucceed() {
+	appName := "anyapp"
+	prepareConfigMapName := "preparecm"
+	rr := utils.NewRegistrationBuilder().WithName(appName).BuildRR()
+	_, _ = s.radixClient.RadixV1().RadixRegistrations().Create(context.Background(), rr, metav1.CreateOptions{})
+	ra := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithEnvironment("dev", "anybranch").
+		WithJobComponents(
+			utils.NewApplicationJobComponentBuilder().WithSchedulerPort(pointers.Ptr[int32](9999)).WithName("deployjob").WithImage("any:{imageTagName}"),
+		).
+		BuildRA()
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+
+	pipeline := model.PipelineInfo{
+		PipelineArguments: model.PipelineArguments{
+			PipelineType:  string(radixv1.Deploy),
+			ToEnvironment: "dev",
+			ImageTagNames: map[string]string{"deployjob": "anytag"},
+		},
+		RadixConfigMapName: prepareConfigMapName,
+	}
+
+	applyStep := steps.NewApplyConfigStep()
+	applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
+	s.NoError(applyStep.Run(&pipeline))
+}

--- a/pipeline-runner/steps/build_test.go
+++ b/pipeline-runner/steps/build_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/equinor/radix-common/utils/pointers"
 	"github.com/equinor/radix-common/utils/slice"
 	"github.com/equinor/radix-operator/pipeline-runner/internal/hash"
+	internaltest "github.com/equinor/radix-operator/pipeline-runner/internal/test"
 	internalwait "github.com/equinor/radix-operator/pipeline-runner/internal/wait"
 	"github.com/equinor/radix-operator/pipeline-runner/model"
-	pipelineDefaults "github.com/equinor/radix-operator/pipeline-runner/model/defaults"
 	"github.com/equinor/radix-operator/pipeline-runner/steps"
 	application "github.com/equinor/radix-operator/pkg/apis/applicationconfig"
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
@@ -26,11 +26,9 @@ import (
 	"github.com/golang/mock/gomock"
 	prometheusfake "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	yamlk8s "sigs.k8s.io/yaml"
 )
 
 func Test_RunBuildTestSuite(t *testing.T) {
@@ -118,8 +116,8 @@ func (s *buildTestSuite) Test_BuildDeploy_JobSpecAndDeploymentConsistent() {
 		WithEnvironment("prod", "release").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
-	s.Require().NoError(s.createGitInfoConfigMapResponse(gitConfigMapName, appName, gitHash, gitTags))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreateGitInfoConfigMapResponse(s.kubeClient, gitConfigMapName, appName, gitHash, gitTags))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			PipelineType:      "build-deploy",
@@ -219,7 +217,7 @@ func (s *buildTestSuite) Test_BuildDeploy_JobSpecAndDeploymentConsistent() {
 	expectedRaHash, err := hash.ToHashString(hash.SHA256, ra.Spec)
 	s.Require().NoError(err)
 	s.Equal(expectedRaHash, rd.GetAnnotations()[kube.RadixConfigHash])
-	s.Equal(s.getBuildSecretHash(nil), rd.GetAnnotations()[kube.RadixBuildSecretHash])
+	s.Equal(internaltest.GetBuildSecretHash(nil), rd.GetAnnotations()[kube.RadixBuildSecretHash])
 	s.Greater(len(rd.GetAnnotations()[kube.RadixConfigHash]), 0)
 	s.Require().Len(rd.Spec.Components, 1)
 	s.Equal(compName, rd.Spec.Components[0].Name)
@@ -258,7 +256,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_MultipleComponents() {
 			utils.NewApplicationJobComponentBuilder().WithSchedulerPort(jobPort).WithName("public-job-component").WithImage("job/job:latest"),
 		).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			PipelineType:      "build-deploy",
@@ -397,7 +395,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_MultipleComponents_IgnoreDisabled() {
 				WithEnvironmentConfig(utils.NewJobComponentEnvironmentBuilder().WithEnvironment(envName).WithEnabled(false)),
 		).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			PipelineType:      "build-deploy",
@@ -525,7 +523,7 @@ func (s *buildTestSuite) Test_BuildChangedComponents() {
 		WithDeploymentName("currentrd").
 		WithAppName(appName).
 		WithEnvironment(envName).
-		WithAnnotations(map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(ra), kube.RadixBuildSecretHash: s.getBuildSecretHash(nil)}).
+		WithAnnotations(map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(ra), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(nil)}).
 		WithCondition(radixv1.DeploymentActive).
 		WithComponents(
 			utils.NewDeployComponentBuilder().WithName("comp-changed").WithImage("comp-changed-current:anytag"),
@@ -547,7 +545,7 @@ func (s *buildTestSuite) Test_BuildChangedComponents() {
 			{Environment: envName, Components: []string{"comp-changed", "comp-common1-changed", "comp-common3-changed", "job-changed", "job-common2-changed", "job-common3-changed"}},
 		},
 	}
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, buildCtx))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, buildCtx))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			PipelineType:      "build-deploy",
@@ -697,7 +695,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, component changed, job changed - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-changed-current:anytag")},
@@ -717,7 +715,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, component changed - build component",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -737,7 +735,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, job changed - build job",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -757,7 +755,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, component unchanged, job unchanged - no build job",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -777,7 +775,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, component unchanged, job unchanged, env namespace missing - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -798,7 +796,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, missing prepare context for environment - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -818,7 +816,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash unchanged, component unchanged, job unchanged - no build job",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -838,7 +836,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash changed, buildsecret hash unchanged, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(oldRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(oldRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -858,7 +856,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash missing, buildsecret hash unchanged, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -878,7 +876,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash changed, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(oldBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(oldBuildSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -898,7 +896,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret magic hash, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(nil)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(nil)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -918,7 +916,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret magic hash, no build secret, component unchanged, job unchanged - no build job",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(raWithoutSecret), kube.RadixBuildSecretHash: s.getBuildSecretHash(nil)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(raWithoutSecret), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(nil)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -939,7 +937,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret missing, no build secret, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(raWithoutSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(raWithoutSecret)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -960,7 +958,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "radixconfig hash unchanged, buildsecret hash missing, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa)},
 				radixv1.DeploymentActive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -994,7 +992,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 		{
 			name: "no current RD, component unchanged, job unchanged - build all",
 			existingRd: radixDeploymentFactory(
-				map[string]string{kube.RadixConfigHash: s.getRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: s.getBuildSecretHash(currentBuildSecret)},
+				map[string]string{kube.RadixConfigHash: internaltest.GetRadixApplicationHash(defaultRa), kube.RadixBuildSecretHash: internaltest.GetBuildSecretHash(currentBuildSecret)},
 				radixv1.DeploymentInactive,
 				[]utils.DeployComponentBuilder{utils.NewDeployComponentBuilder().WithName("comp").WithImage("comp-current:anytag")},
 				[]utils.DeployJobComponentBuilder{utils.NewDeployJobComponentBuilder().WithName("job").WithImage("job-current:anytag")},
@@ -1029,7 +1027,7 @@ func (s *buildTestSuite) Test_DetectComponentsToBuild() {
 			if !test.skipEnvNamespace {
 				_, _ = s.kubeClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.GetEnvironmentNamespace(appName, envName)}}, metav1.CreateOptions{})
 			}
-			s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, test.prepareBuildCtx))
+			s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, test.prepareBuildCtx))
 			pipeline := model.PipelineInfo{PipelineArguments: piplineArgs, RadixConfigMapName: prepareConfigMapName}
 			applyStep := steps.NewApplyConfigStep()
 			applyStep.Init(s.kubeClient, s.radixClient, s.kubeUtil, s.promClient, rr)
@@ -1096,7 +1094,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_ImageTagNames() {
 				WithEnvironmentConfig(utils.NewJobComponentEnvironmentBuilder().WithEnvironment(envName).WithImageTagName("job2envtag")),
 		).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			PipelineType:  "deploy",
@@ -1153,7 +1151,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_PushImage() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:    "main",
@@ -1193,7 +1191,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_UseCache() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:   "main",
@@ -1233,7 +1231,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_WithDockerfileName() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName).WithDockerfileName(dockerFileName)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:  "main",
@@ -1272,7 +1270,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_WithSourceFolder() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName).WithSourceFolder(".././path/../../subpath")).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:  "main",
@@ -1312,8 +1310,8 @@ func (s *buildTestSuite) Test_BuildJobSpec_WithBuildSecrets() {
 		WithEnvironment(envName, "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
-	s.Require().NoError(s.createBuildSecret(appName, map[string][]byte{"SECRET1": nil, "SECRET2": nil}))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreateBuildSecret(s.kubeClient, appName, map[string][]byte{"SECRET1": nil, "SECRET2": nil}))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:  "main",
@@ -1367,7 +1365,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_BuildKit() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName).WithDockerfileName(dockerFile).WithSourceFolder(sourceFolder)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:               "main",
@@ -1430,7 +1428,7 @@ func (s *buildTestSuite) Test_BuildJobSpec_BuildKit_PushImage() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName).WithDockerfileName(dockerFile).WithSourceFolder(sourceFolder)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:               "main",
@@ -1501,8 +1499,8 @@ func (s *buildTestSuite) Test_BuildJobSpec_BuildKit_WithBuildSecrets() {
 		WithEnvironment("dev", "main").
 		WithComponent(utils.NewApplicationComponentBuilder().WithPort("any", 8080).WithName(compName).WithDockerfileName(dockerFile).WithSourceFolder(sourceFolder)).
 		BuildRA()
-	s.Require().NoError(s.createPreparePipelineConfigMapResponse(prepareConfigMapName, appName, ra, nil))
-	s.Require().NoError(s.createBuildSecret(appName, map[string][]byte{"SECRET1": nil, "SECRET2": nil}))
+	s.Require().NoError(internaltest.CreatePreparePipelineConfigMapResponse(s.kubeClient, prepareConfigMapName, appName, ra, nil))
+	s.Require().NoError(internaltest.CreateBuildSecret(s.kubeClient, appName, map[string][]byte{"SECRET1": nil, "SECRET2": nil}))
 	pipeline := model.PipelineInfo{
 		PipelineArguments: model.PipelineArguments{
 			Branch:               "main",
@@ -1560,68 +1558,4 @@ func (s *buildTestSuite) Test_BuildJobSpec_BuildKit_WithBuildSecrets() {
 	)
 	expectedCommand := []string{"/bin/bash", "-c", expectedBuildCmd}
 	s.Equal(expectedCommand, job.Spec.Template.Spec.Containers[0].Command)
-}
-
-func (s *buildTestSuite) createPreparePipelineConfigMapResponse(configMapName, appName string, ra *radixv1.RadixApplication, buildCtx *model.PrepareBuildContext) error {
-	raBytes, err := yamlk8s.Marshal(ra)
-	if err != nil {
-		return err
-	}
-	data := map[string]string{
-		pipelineDefaults.PipelineConfigMapContent: string(raBytes),
-	}
-
-	if buildCtx != nil {
-		buildCtxBytes, err := yaml.Marshal(buildCtx)
-		if err != nil {
-			return err
-		}
-		data[pipelineDefaults.PipelineConfigMapBuildContext] = string(buildCtxBytes)
-	}
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: configMapName},
-		Data:       data,
-	}
-	_, err = s.kubeClient.CoreV1().ConfigMaps(utils.GetAppNamespace(appName)).Create(context.Background(), cm, metav1.CreateOptions{})
-	return err
-}
-
-func (s *buildTestSuite) createGitInfoConfigMapResponse(configMapName, appName, gitHash, gitTags string) error {
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: configMapName},
-		Data: map[string]string{
-			defaults.RadixGitCommitHashKey: gitHash,
-			defaults.RadixGitTagsKey:       gitTags,
-		},
-	}
-	_, err := s.kubeClient.CoreV1().ConfigMaps(utils.GetAppNamespace(appName)).Create(context.Background(), cm, metav1.CreateOptions{})
-	return err
-}
-
-func (s *buildTestSuite) createBuildSecret(appName string, data map[string][]byte) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: defaults.BuildSecretsName},
-		Data:       data,
-	}
-
-	_, err := s.kubeClient.CoreV1().Secrets(utils.GetAppNamespace(appName)).Create(context.Background(), secret, metav1.CreateOptions{})
-	return err
-}
-
-func (s *buildTestSuite) getRadixApplicationHash(ra *radixv1.RadixApplication) string {
-	if ra == nil {
-		hash, _ := hash.ToHashString(hash.SHA256, "0nXSg9l6EUepshGFmolpgV3elB0m8Mv7")
-		return hash
-	}
-	hash, _ := hash.ToHashString(hash.SHA256, ra.Spec)
-	return hash
-}
-
-func (s *buildTestSuite) getBuildSecretHash(secret *corev1.Secret) string {
-	if secret == nil {
-		hash, _ := hash.ToHashString(hash.SHA256, "34Wd68DsJRUzrHp2f63o3U5hUD6zl8Tj")
-		return hash
-	}
-	hash, _ := hash.ToHashString(hash.SHA256, secret.Data)
-	return hash
 }

--- a/pipeline-runner/steps/errors.go
+++ b/pipeline-runner/steps/errors.go
@@ -1,15 +1,10 @@
 package steps
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 )
 
 var (
 	ErrDeployOnlyPipelineDoesNotSupportBuild = errors.New("deploy pipeline does not support building components and jobs")
+	ErrMissingRequiredImageTagName           = errors.New("missing required imageTagName in environmentConfig or pipeline argument")
 )
-
-func ErrMissingRequiredImageTagName(componentName, envName string) error {
-	return fmt.Errorf("component %s requires imageTagName to be set in environmentConfig for environment %s or specified as argument to the pipeline job", componentName, envName)
-}

--- a/pipeline-runner/steps/errors.go
+++ b/pipeline-runner/steps/errors.go
@@ -1,0 +1,15 @@
+package steps
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrDeployOnlyPipelineDoesNotSupportBuild = errors.New("deploy pipeline does not support building components and jobs")
+)
+
+func ErrMissingRequiredImageTagName(componentName, envName string) error {
+	return fmt.Errorf("component %s requires imageTagName to be set in environmentConfig for environment %s or specified as argument to the pipeline job", componentName, envName)
+}

--- a/pkg/apis/deployment/radixcommoncomponent.go
+++ b/pkg/apis/deployment/radixcommoncomponent.go
@@ -91,9 +91,6 @@ func getImagePath(componentName string, componentImage pipeline.DeployComponentI
 		// For deploy-only images, we will replace the dynamic tag with the tag from the environment config
 		return strings.ReplaceAll(image, v1.DynamicTagNameInEnvironmentConfig, imageTagName), nil
 	}
-	if len(imageTagName) > 0 {
-		return "", errorNotExpectedImageTagNameInImage(componentName, imageTagName)
-	}
 	return image, nil
 }
 

--- a/pkg/apis/deployment/radixcommoncomponent.go
+++ b/pkg/apis/deployment/radixcommoncomponent.go
@@ -94,10 +94,6 @@ func getImagePath(componentName string, componentImage pipeline.DeployComponentI
 	return image, nil
 }
 
-func errorNotExpectedImageTagNameInImage(componentImageName, imageTagName string) error {
-	return fmt.Errorf("image property for a component %s does not have a dynamic imageTagName but it is provided: %s", componentImageName, imageTagName)
-}
-
 func errorMissingExpectedDynamicImageTagName(componentName string) error {
 	return fmt.Errorf(fmt.Sprintf("component %s is missing an expected dynamic imageTagName for its image", componentName))
 }

--- a/pkg/apis/deployment/radixcomponent_test.go
+++ b/pkg/apis/deployment/radixcomponent_test.go
@@ -834,28 +834,6 @@ func TestGetRadixComponentsForEnv_ImageWithImageTagName(t *testing.T) {
 			expectedError: errorMissingExpectedDynamicImageTagName(componentName1),
 		},
 		{
-			name: "static image name, but component env config image-tags provided",
-			componentImages: map[string]string{
-				componentName1: staticImageName1,
-				componentName2: staticImageName2,
-			},
-			environmentConfigImageTagNames: map[string]string{
-				componentName2: "tag-component-a",
-			},
-			expectedError: errorNotExpectedImageTagNameInImage(componentName2, "tag-component-a"),
-		},
-		{
-			name: "static image name, but external image-tags provided",
-			componentImages: map[string]string{
-				componentName1: staticImageName1,
-				componentName2: staticImageName2,
-			},
-			externalImageTagNames: map[string]string{
-				componentName1: "tag-component-a",
-			},
-			expectedError: errorNotExpectedImageTagNameInImage(componentName1, "tag-component-a"),
-		},
-		{
 			name: "with image-tags",
 			componentImages: map[string]string{
 				componentName1: staticImageName1,

--- a/pkg/apis/deployment/radixjobcomponent_test.go
+++ b/pkg/apis/deployment/radixjobcomponent_test.go
@@ -545,28 +545,6 @@ func TestGetRadixJobComponentsForEnv_ImageWithImageTagName(t *testing.T) {
 			expectedError: errorMissingExpectedDynamicImageTagName(componentName1),
 		},
 		{
-			name: "static image name, but component env config image-tags provided",
-			componentImages: map[string]string{
-				componentName1: staticImageName1,
-				componentName2: staticImageName2,
-			},
-			environmentConfigImageTagNames: map[string]string{
-				componentName2: "tag-component-a",
-			},
-			expectedError: errorNotExpectedImageTagNameInImage(componentName2, "tag-component-a"),
-		},
-		{
-			name: "static image name, but external image-tags provided",
-			componentImages: map[string]string{
-				componentName1: staticImageName1,
-				componentName2: staticImageName2,
-			},
-			externalImageTagNames: map[string]string{
-				componentName1: "tag-component-a",
-			},
-			expectedError: errorNotExpectedImageTagNameInImage(componentName1, "tag-component-a"),
-		},
-		{
 			name: "with image-tags",
 			componentImages: map[string]string{
 				componentName1: staticImageName1,

--- a/pkg/apis/radixvalidators/errors.go
+++ b/pkg/apis/radixvalidators/errors.go
@@ -45,8 +45,6 @@ var (
 	ErrunknownVolumeMountType                                              = errors.New("unknown volume mount type")
 	ErrApplicationNameNotLowercase                                         = errors.New("application name not lowercase")
 	ErrPublicImageComponentCannotHaveSourceOrDockerfileSet                 = errors.New("public image component cannot have source or dockerfile")
-	ErrComponentWithDynamicTagRequiresTagInEnvironmentConfig               = errors.New("component with dynamic tag requires tag in environment")
-	ErrComponentWithDynamicTagRequiresTagInEnvironmentConfigForEnvironment = errors.New("component with dynamic tag requires tag in environment config for")
 	ErrComponentWithTagInEnvironmentConfigForEnvironmentRequiresDynamicTag = errors.New("component with tag in environment config for environment requires dynamic")
 	ErrComponentNameReservedSuffix                                         = errors.New("component name reserved suffix")
 	ErrSecretNameConflictsWithEnvironmentVariable                          = errors.New("secret name conflicts with environment")
@@ -266,17 +264,6 @@ func ApplicationNameNotLowercaseErrorWithMessage(appName string) error {
 // PublicImageComponentCannotHaveSourceOrDockerfileSetWithMessage Error if image is set and radix config contains src or dockerfile
 func PublicImageComponentCannotHaveSourceOrDockerfileSetWithMessage(componentName string) error {
 	return errors.WithMessagef(ErrPublicImageComponentCannotHaveSourceOrDockerfileSet, "component %s cannot have neither 'src' nor 'Dockerfile' set", componentName)
-}
-
-// ComponentWithDynamicTagRequiresTagInEnvironmentConfigWithMessage Error if image is set with dynamic tag and tag is missing
-func ComponentWithDynamicTagRequiresTagInEnvironmentConfigWithMessage(componentName string) error {
-	return errors.WithMessagef(ErrComponentWithDynamicTagRequiresTagInEnvironmentConfig, "component %s with %s on image requires an image tag set on environment config",
-		componentName, radixv1.DynamicTagNameInEnvironmentConfig)
-}
-
-// ComponentWithDynamicTagRequiresTagInEnvironmentConfigForEnvironmentWithMessage Error if image is set with dynamic tag and tag is missing
-func ComponentWithDynamicTagRequiresTagInEnvironmentConfigForEnvironmentWithMessage(componentName, environment string) error {
-	return errors.WithMessagef(ErrComponentWithDynamicTagRequiresTagInEnvironmentConfigForEnvironment, "component %s with %s on image requires an image tag set on environment config for environment %s", componentName, radixv1.DynamicTagNameInEnvironmentConfig, environment)
 }
 
 // ComponentWithTagInEnvironmentConfigForEnvironmentRequiresDynamicTagWithMessage If tag is set then the dynamic tag needs to be set on the image

--- a/pkg/apis/radixvalidators/testdata/radixconfig.yaml
+++ b/pkg/apis/radixvalidators/testdata/radixconfig.yaml
@@ -87,6 +87,20 @@ spec:
       ports:
         - name: http
           port: 8090
+    - name: compimg1
+      image: img:{imageTagName}
+      ports:
+        - name: http
+          port: 8090
+    - name: compimg2
+      image: img:{imageTagName}
+      ports:
+        - name: http
+          port: 8090  
+      environmentConfig:
+        - environment: dev
+        - environment: prod
+          imageTagName: "1.0.0"
   jobs:
     - name: job
       src: job/
@@ -138,6 +152,16 @@ spec:
       ports:
         - name: http
           port: 8099
+    - name: jobimg1
+      schedulerPort: 8000
+      image: img:{imageTagName}
+    - name: jobimg2
+      schedulerPort: 8000
+      image: img:{imageTagName}
+      environmentConfig:
+        - environment: dev
+        - environment: prod
+          imageTagName: "1.0.0"
   dnsAppAlias:
     environment: prod
     component: app

--- a/pkg/apis/radixvalidators/validate_ra_test.go
+++ b/pkg/apis/radixvalidators/validate_ra_test.go
@@ -318,18 +318,6 @@ func Test_invalid_ra(t *testing.T) {
 			ra.Spec.Components[0].SourceFolder = "./api"
 			ra.Spec.Components[0].DockerfileName = ".Dockerfile"
 		}},
-		{"missing environment config for dynamic tag", radixvalidators.ComponentWithDynamicTagRequiresTagInEnvironmentConfigWithMessage(validRAFirstComponentName), func(ra *v1.RadixApplication) {
-			ra.Spec.Components[0].Image = "radixcanary.azurecr.io/my-private-image:{imageTagName}"
-			ra.Spec.Components[0].EnvironmentConfig = []v1.RadixEnvironmentConfig{}
-		}},
-		{"missing dynamic tag config for mapped environment", radixvalidators.ComponentWithDynamicTagRequiresTagInEnvironmentConfigForEnvironmentWithMessage(validRAFirstComponentName, "dev"), func(ra *v1.RadixApplication) {
-			ra.Spec.Components[0].Image = "radixcanary.azurecr.io/my-private-image:{imageTagName}"
-			ra.Spec.Components[0].EnvironmentConfig[0].ImageTagName = ""
-			ra.Spec.Components[0].EnvironmentConfig = append(ra.Spec.Components[0].EnvironmentConfig, v1.RadixEnvironmentConfig{
-				Environment:  "dev",
-				ImageTagName: "",
-			})
-		}},
 		{"inconcistent dynamic tag config for environment", radixvalidators.ComponentWithTagInEnvironmentConfigForEnvironmentRequiresDynamicTagWithMessage(validRAFirstComponentName, "prod"), func(ra *v1.RadixApplication) {
 			ra.Spec.Components[0].Image = "radixcanary.azurecr.io/my-private-image:some-tag"
 			ra.Spec.Components[0].EnvironmentConfig[0].ImageTagName = "any-tag"
@@ -455,18 +443,6 @@ func Test_invalid_ra(t *testing.T) {
 			ra.Spec.Jobs[0].Image = "redis:5.0-alpine"
 			ra.Spec.Jobs[0].SourceFolder = "./api"
 			ra.Spec.Jobs[0].DockerfileName = ".Dockerfile"
-		}},
-		{"job missing environment config for dynamic tag", radixvalidators.ComponentWithDynamicTagRequiresTagInEnvironmentConfigWithMessage(validRAFirstJobName), func(ra *v1.RadixApplication) {
-			ra.Spec.Jobs[0].Image = "radixcanary.azurecr.io/my-private-image:{imageTagName}"
-			ra.Spec.Jobs[0].EnvironmentConfig = []v1.RadixJobComponentEnvironmentConfig{}
-		}},
-		{"job missing dynamic tag config for mapped environment", radixvalidators.ComponentWithDynamicTagRequiresTagInEnvironmentConfigForEnvironmentWithMessage(validRAFirstJobName, "dev"), func(ra *v1.RadixApplication) {
-			ra.Spec.Jobs[0].Image = "radixcanary.azurecr.io/my-private-image:{imageTagName}"
-			ra.Spec.Jobs[0].EnvironmentConfig[0].ImageTagName = ""
-			ra.Spec.Jobs[0].EnvironmentConfig = append(ra.Spec.Jobs[0].EnvironmentConfig, v1.RadixJobComponentEnvironmentConfig{
-				Environment:  "dev",
-				ImageTagName: "",
-			})
 		}},
 		{"job inconcistent dynamic tag config for environment", radixvalidators.ComponentWithTagInEnvironmentConfigForEnvironmentRequiresDynamicTagWithMessage(validRAFirstJobName, "dev"), func(ra *v1.RadixApplication) {
 			ra.Spec.Jobs[0].Image = "radixcanary.azurecr.io/my-private-image:some-tag"


### PR DESCRIPTION
- Do not fail deploy step in pipeline job when component/job image to deploy does not contain {imageTagName} and radixconfig has imageTagName set. This will happen when promoting.
- Fail deploy pipeline if destination environment contains components to build
- Validate components/jobs in buildeploy or deploy pipeline with {imageTagName} has imageTagName set in radixconfig or supplied as pipline argument 