### PR TITLE
Add radix-tekton image tag to RadixJob

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.26.1
-appVersion: 1.46.1
+version: 1.26.2
+appVersion: 1.46.2
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -271,7 +271,7 @@ func (s *RadixJobTestSuite) TestObjectSynced_PipelineJobCreatedWithTektonImageTa
 	job := jobs.Items[0]
 	podTemplate := job.Spec.Template
 
-	expected := fmt.Sprintf("--%s=anyregistry/radix-tekton:%s", defaults.RadixTektonPipelineImageEnvironmentVariable, "test-tekton-image")
+	expected := fmt.Sprintf("--%s=radix-tekton:%s", defaults.RadixTektonPipelineImageEnvironmentVariable, "test-tekton-image")
 	actualArgs := podTemplate.Spec.Containers[0].Args
 	assert.Contains(s.T(), actualArgs, expected)
 }

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -147,7 +147,7 @@ func (job *Job) getPipelineJobArguments(appName, jobName string, jobSpec v1.Radi
 	// TODO: Remove fallback to Operator GetEnv when Radix-API is upgrade
 	radixTektonImage := os.Getenv(defaults.RadixTektonPipelineImageEnvironmentVariable)
 	if job.radixJob.Spec.TektonImage != "" {
-		radixTektonImage = fmt.Sprintf("%s/%s:%s", containerRegistry, tektonImage, job.radixJob.Spec.TektonImage)
+		radixTektonImage = fmt.Sprintf("%s:%s", tektonImage, job.radixJob.Spec.TektonImage)
 	}
 
 	// Base arguments for all types of pipeline

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -144,6 +144,7 @@ func (job *Job) getPipelineJobArguments(appName, jobName string, jobSpec v1.Radi
 		return nil, fmt.Errorf("invalid or missing app builder resources")
 	}
 
+	// TODO: Remove fallback to Operator GetEnv when Radix-API is upgrade
 	radixTektonImage := os.Getenv(defaults.RadixTektonPipelineImageEnvironmentVariable)
 	if job.radixJob.Spec.TektonImage != "" {
 		radixTektonImage = fmt.Sprintf("%s/%s:%s", containerRegistry, tektonImage, job.radixJob.Spec.TektonImage)

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	tektonImage = "radix-tekton"
 	workerImage = "radix-pipeline"
 	// ResultContent of the pipeline job, passed via ConfigMap as v1.RadixJobResult structure
 	ResultContent = "ResultContent"
@@ -143,6 +144,11 @@ func (job *Job) getPipelineJobArguments(appName, jobName string, jobSpec v1.Radi
 		return nil, fmt.Errorf("invalid or missing app builder resources")
 	}
 
+	radixTektonImage := os.Getenv(defaults.RadixTektonPipelineImageEnvironmentVariable)
+	if job.radixJob.Spec.TektonImage != "" {
+		radixTektonImage = fmt.Sprintf("%s/%s:%s", containerRegistry, tektonImage, job.radixJob.Spec.TektonImage)
+	}
+
 	// Base arguments for all types of pipeline
 	args := []string{
 		fmt.Sprintf("--%s=%s", defaults.RadixAppEnvironmentVariable, appName),
@@ -153,7 +159,7 @@ func (job *Job) getPipelineJobArguments(appName, jobName string, jobSpec v1.Radi
 		fmt.Sprintf("--%s=%s", defaults.OperatorAppBuilderResourcesLimitsMemoryEnvironmentVariable, job.config.AppBuilderResourcesLimitsMemory.String()),
 
 		// Pass tekton and builder images
-		fmt.Sprintf("--%s=%s", defaults.RadixTektonPipelineImageEnvironmentVariable, os.Getenv(defaults.RadixTektonPipelineImageEnvironmentVariable)),
+		fmt.Sprintf("--%s=%s", defaults.RadixTektonPipelineImageEnvironmentVariable, radixTektonImage),
 		fmt.Sprintf("--%s=%s", defaults.RadixImageBuilderEnvironmentVariable, os.Getenv(defaults.RadixImageBuilderEnvironmentVariable)),
 		fmt.Sprintf("--%s=%s", defaults.RadixBuildahImageBuilderEnvironmentVariable, os.Getenv(defaults.RadixBuildahImageBuilderEnvironmentVariable)),
 		fmt.Sprintf("--%s=%s", defaults.SeccompProfileFileNameEnvironmentVariable, os.Getenv(defaults.SeccompProfileFileNameEnvironmentVariable)),

--- a/pkg/apis/radix/v1/radixjobtypes.go
+++ b/pkg/apis/radix/v1/radixjobtypes.go
@@ -49,6 +49,7 @@ const (
 type RadixJobSpec struct {
 	AppName             string            `json:"appName" yaml:"appName"`
 	CloneURL            string            `json:"cloneURL" yaml:"cloneURL"`
+	TektonImage         string            `json:"tektonImage" yaml:"tektonImage"`
 	PipeLineType        RadixPipelineType `json:"pipeLineType" yaml:"pipeLineType"`
 	PipelineImage       string            `json:"pipelineImage" yaml:"pipelineImage"`
 	Build               RadixBuildSpec    `json:"build" yaml:"build"`

--- a/pkg/apis/utils/job_builder.go
+++ b/pkg/apis/utils/job_builder.go
@@ -45,6 +45,7 @@ type JobBuilderStruct struct {
 	created            time.Time
 	pipelineImageTag   string
 	pushImage          bool
+	tektonImageTag     string
 }
 
 // WithRadixApplication Links to RA builder
@@ -79,6 +80,10 @@ func (jb *JobBuilderStruct) WithPipelineType(pipeline v1.RadixPipelineType) JobB
 // WithPipelineImageTag Sets the pipeline image tag
 func (jb *JobBuilderStruct) WithPipelineImageTag(imageTag string) JobBuilder {
 	jb.pipelineImageTag = imageTag
+	return jb
+}
+func (jb *JobBuilderStruct) WithTektonImageTag(imageTag string) JobBuilder {
+	jb.tektonImageTag = imageTag
 	return jb
 }
 
@@ -169,6 +174,7 @@ func (jb *JobBuilderStruct) BuildRJ() *v1.RadixJob {
 			AppName:       jb.appName,
 			PipeLineType:  jb.pipeline,
 			PipelineImage: jb.pipelineImageTag,
+			TektonImage:   jb.tektonImageTag,
 			Build: v1.RadixBuildSpec{
 				Branch:    jb.branch,
 				ImageTag:  jb.imageTag,

--- a/pkg/apis/utils/job_builder.go
+++ b/pkg/apis/utils/job_builder.go
@@ -19,6 +19,7 @@ type JobBuilder interface {
 	WithBranch(string) JobBuilder
 	WithCommitID(string) JobBuilder
 	WithPushImage(bool) JobBuilder
+	WithTektonImageTag(string) JobBuilder
 	WithImageTag(string) JobBuilder
 	WithDeploymentName(string) JobBuilder
 	WithStatusOnAnnotation(JobStatusBuilder) JobBuilder


### PR DESCRIPTION
Tested with this Yaml (with and wihout tektonImage):
` k replace --force -f test-job.yaml`
```yaml
apiVersion: radix.equinor.com/v1
kind: RadixJob
metadata:
  annotations:
    radix-branch: main
  labels:
    radix-app: edc2023-radix-wi-rihag
  name: radix-pipeline-test
  namespace: edc2023-radix-wi-rihag-app
spec:
  appName: edc2023-radix-wi-rihag
  build:
    branch: main
    commitID: null
    imageTag: abcd
    pushImage: true
  cloneURL: git@github.com:Equinor-Playground/rihag-edc23-radix-1.git
  deploy:
    commitID: ""
    imageTagNames: null
    toEnvironment: ""
  pipeLineType: build-deploy
  pipelineImage: master-latest
  tektonImage: tekton-wi-dev # enables Workload Identity on pods when using the label "azure.workload.identity/use: "true"
  promote:
    commitID: ""
    deploymentName: ""
    fromEnvironment: ""
    toEnvironment: ""
  radixConfigFullName: /workspace/radixconfig.yaml
  stop: false
  triggeredBy: DEV

```