### PR TITLE
fix incorrect adgroups for reader role bindings

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.29.2
-appVersion: 1.49.1
+version: 1.29.3
+appVersion: 1.49.3
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.29.3
-appVersion: 1.49.3
+version: 1.29.4
+appVersion: 1.49.4
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/radix-operator/registration/controller_test.go
+++ b/radix-operator/registration/controller_test.go
@@ -46,6 +46,13 @@ func Test_Controller_Calls_Handler(t *testing.T) {
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(client, 0)
 	radixInformerFactory := informers.NewSharedInformerFactory(radixClient, 0)
 
+	// Create registration should sync
+	registration, err := utils.GetRadixRegistrationFromFile("testdata/sampleregistration.yaml")
+	if err != nil {
+		log.Fatalf("Could not read configuration data: %v", err)
+	}
+	registeredApp, err := radixClient.RadixV1().RadixRegistrations().Create(context.TODO(), registration, metav1.CreateOptions{})
+
 	registrationHandler := NewHandler(
 		client,
 		kubeUtil,
@@ -60,14 +67,6 @@ func Test_Controller_Calls_Handler(t *testing.T) {
 	}()
 
 	// Test
-
-	// Create registration should sync
-	registration, err := utils.GetRadixRegistrationFromFile("testdata/sampleregistration.yaml")
-	if err != nil {
-		log.Fatalf("Could not read configuration data: %v", err)
-	}
-
-	registeredApp, err := radixClient.RadixV1().RadixRegistrations().Create(context.TODO(), registration, metav1.CreateOptions{})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, registeredApp)


### PR DESCRIPTION
Fixes bug where RR adGroups (admin) was used as subjects for both adm and reader rolebindings for component secrets