### PR TITLE
Grant radix-api access to cert-manager resources

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.30.8
-appVersion: 1.50.8
+version: 1.30.9
+appVersion: 1.50.9
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/radix-apps-rbac.yaml
+++ b/charts/radix-operator/templates/radix-apps-rbac.yaml
@@ -125,6 +125,15 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - 'cert-manager.io'
+  resources:
+  - certificates
+  - certificaterequests
+  verbs:
+  - get
+  - list
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Grant Radix API access to get a list certificaterequests and certificates objects in the cert-manager.io api group.
Required to allow Radix API to provide status about certificate automation for external aliases to the users, ref PR https://github.com/equinor/radix-api/pull/613