### PR TITLE
add cert-manager crd to radix-operator clusterrole

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: radix-operator
-version: 1.31.0
+version: 1.31.1
 appVersion: 1.51.0
 kubeVersion: ">=1.24.0"
 description: Radix Operator

--- a/charts/radix-operator/templates/radix-operator-rbac.yaml
+++ b/charts/radix-operator/templates/radix-operator-rbac.yaml
@@ -174,6 +174,13 @@ rules:
     - create
     - update
     - delete
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificaterequests
+  verbs:
+  - get
+  - list    
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Add get and list permissions on certificaterequest to radix-operator because radix-api clusterrole also has this permission, and operator cannot bind the radix-api service account to the clusterrole if operator does not possess the same permission as it tries to grant through the clusterrolebinding