### PR TITLE
set certificate private key rotation policy to always

### DIFF
--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -4034,6 +4034,7 @@ func Test_ExternalDNS_Legacy_ResourcesMigrated(t *testing.T) {
 		SecretTemplate: &cmv1.CertificateSecretTemplate{
 			Labels: map[string]string{kube.RadixAppLabel: appName, kube.RadixExternalAliasFQDNLabel: fqdnAutomation},
 		},
+		PrivateKey: &cmv1.CertificatePrivateKey{RotationPolicy: cmv1.RotationPolicyAlways},
 	}
 	assert.Equal(t, expectedCertSpec, cert.Spec)
 }
@@ -4097,6 +4098,7 @@ func Test_ExternalDNS_ContainsAllResources(t *testing.T) {
 			SecretTemplate: &cmv1.CertificateSecretTemplate{
 				Labels: map[string]string{kube.RadixAppLabel: appName, kube.RadixExternalAliasFQDNLabel: fqdn},
 			},
+			PrivateKey: &cmv1.CertificatePrivateKey{RotationPolicy: cmv1.RotationPolicyAlways},
 		}
 		assert.Equal(t, expectedCertSpec, cert.Spec)
 	}

--- a/pkg/apis/deployment/externaldns.go
+++ b/pkg/apis/deployment/externaldns.go
@@ -162,6 +162,9 @@ func (deploy *Deployment) createOrUpdateExternalDnsCertificate(externalDns radix
 			SecretTemplate: &cmv1.CertificateSecretTemplate{
 				Labels: radixlabels.ForExternalDNSTLSSecret(deploy.registration.Name, externalDns),
 			},
+			PrivateKey: &cmv1.CertificatePrivateKey{
+				RotationPolicy: cmv1.RotationPolicyAlways,
+			},
 		},
 	}
 


### PR DESCRIPTION
Setting rotation policy to Always will generate a new private key when the certificate needs be be reissued.

This fixes the issue where an existing TLS secret has a private key (tls.key) with incompatible type or length compared to what is the default in the certificate spec.

I have not bumped the chart version for the small change. It is not urgent to release this, and we can include it with other changes.