### PR TITLE
fix batch status incorrectly transitioning to Waiting

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.43.1
-appVersion: 1.63.1
+version: 1.43.2
+appVersion: 1.63.2
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:


### PR DESCRIPTION
A RadixBatch will temporary transition from Active to Waiting when the Pod is finished (success or failed) in which k8s Job has status.active unset. To fix this we will reuse the last know RadixBatchJobStatus.Phas for the job instead of defaulting to  BatchJobPhaseWaiting.

This change will also inspect the k8s job's Status.UncountedTerminatedPods to transtition to completed or failed faster, and thereby preventing on unnecessary update of RadixBatch status, which will trigger an unnecessary informer event to the job scheduler webhook.
