### PR TITLE
feat: Add radixdeployment crd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ code-gen: bootstrap
 	./hack/update-codegen.sh
 
 .PHONY: crds
-crds: temp-crds radixapplication-crd radixbatch-crd radixdnsalias-crd delete-temp-crds
+crds: temp-crds radixapplication-crd radixbatch-crd radixdnsalias-crd radixdeployment-crd delete-temp-crds
 
 .PHONY: radixapplication-crd
 radixapplication-crd: temp-crds
@@ -137,6 +137,10 @@ radixapplication-crd: temp-crds
 .PHONY: radixbatch-crd
 radixbatch-crd: temp-crds
 	cp $(CRD_TEMP_DIR)radix.equinor.com_radixbatches.yaml $(CRD_CHART_DIR)radixbatch.yaml
+
+.PHONY: radixdeployment-crd
+radixdeployment-crd: temp-crds
+	cp $(CRD_TEMP_DIR)radix.equinor.com_radixdeployments.yaml $(CRD_CHART_DIR)radixdeployment.yaml
 
 .PHONY: radixdnsalias-crd
 radixdnsalias-crd: temp-crds

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.45.1
-appVersion: 1.65.1
+version: 1.46.0
+appVersion: 1.66.0
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.46.0
-appVersion: 1.66.0
+version: 1.46.1
+appVersion: 1.66.1
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -1563,7 +1563,6 @@ spec:
             - components
             - environment
             - imagePullSecrets
-            - jobs
             type: object
           status:
             description: RadixDeployStatus is the status for a rd
@@ -1582,9 +1581,7 @@ spec:
                 type: string
             required:
             - activeFrom
-            - activeTo
             - condition
-            - reconciled
             type: object
         required:
         - spec

--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -978,7 +978,6 @@ spec:
                   - image
                   - monitoring
                   - name
-                  - ports
                   - public
                   type: object
                 type: array
@@ -1563,14 +1562,11 @@ spec:
                   - image
                   - monitoring
                   - name
-                  - ports
                   type: object
                 type: array
             required:
             - appname
-            - components
             - environment
-            - imagePullSecrets
             type: object
           status:
             description: RadixDeployStatus is the status for a rd
@@ -1592,8 +1588,8 @@ spec:
             - condition
             type: object
         required:
+        - metadata
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -19,16 +19,24 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.activeFrom
       name: Active From
-      type: date
+      type: string
     - jsonPath: .status.activeTo
       name: Active To
-      type: date
+      type: string
     - jsonPath: .status.condition
       name: Condition
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.reconciled
+      name: Reconciled
+      priority: 1
+      type: date
+    - jsonPath: .metadata.annotations.radix-branch
+      name: Branch
+      priority: 1
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -1,31 +1,1596 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: radixdeployments.radix.equinor.com
-  labels:
-    {{- include "radix-operator.labels" . | nindent 4 }}
 spec:
   group: radix.equinor.com
   names:
     kind: RadixDeployment
+    listKind: RadixDeploymentList
     plural: radixdeployments
-    singular: radixdeployment
     shortNames:
-      - rd
+    - rd
+    singular: radixdeployment
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.activeFrom
+      name: Active From
+      type: date
+    - jsonPath: .status.activeTo
+      name: Active To
+      type: date
+    - jsonPath: .status.condition
+      name: Condition
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RadixDeployment describe a deployment
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RadixDeploymentSpec is the spec for a deployment
+            properties:
+              appname:
+                type: string
+              components:
+                items:
+                  description: RadixDeployComponent defines a single component within
+                    a RadixDeployment - maps to single deployment/service/ingress
+                    etc
+                  properties:
+                    alwaysPullImageOnDeploy:
+                      type: boolean
+                    authentication:
+                      description: Authentication describes authentication options.
+                      properties:
+                        clientCertificate:
+                          description: |-
+                            Configuration for TLS client certificate authentication.
+                            More info: https://www.radix.equinor.com/references/reference-radix-config/#clientcertificate
+                          properties:
+                            passCertificateToUpstream:
+                              description: |-
+                                Pass client certificate to backend in header ssl-client-cert.
+                                This setting has no effect if verification is set to off.
+                              type: boolean
+                            verification:
+                              description: Defines how the client certificate shall
+                                be verified.
+                              enum:
+                              - "on"
+                              - "off"
+                              - optional
+                              - optional_no_ca
+                              type: string
+                          type: object
+                        oauth2:
+                          description: |-
+                            Configuration for OAuth2 authentication.
+                            More info: https://www.radix.equinor.com/references/reference-radix-config/#oauth2
+                          properties:
+                            clientId:
+                              description: Client ID of the application.
+                              type: string
+                            cookie:
+                              description: Session cookie settings.
+                              properties:
+                                expire:
+                                  description: Defines the expire timeframe for the
+                                    session cookie.
+                                  type: string
+                                name:
+                                  description: Defines the name of the OAuth session
+                                    cookie.
+                                  type: string
+                                refresh:
+                                  description: |-
+                                    The interval between cookie refreshes.
+                                    The value must be a shorter timeframe than values set in Expire.
+                                  type: string
+                                sameSite:
+                                  description: Defines the samesite cookie attribute
+                                  enum:
+                                  - strict
+                                  - lax
+                                  - none
+                                  - ""
+                                  type: string
+                              type: object
+                            cookieStore:
+                              description: Settings for the cookie that stores session
+                                data when SessionStoreType is cookie.
+                              properties:
+                                minimal:
+                                  description: |-
+                                    Strips OAuth tokens from cookies if they are not needed.
+                                    Cookie.Refresh must be 0, and both SetXAuthRequestHeaders and SetAuthorizationHeader must be false if this setting is true.
+                                  type: boolean
+                              type: object
+                            loginUrl:
+                              description: |-
+                                Defines the authentication endpoint of the identity provider.
+                                Must be set if OIDC.SkipDiscovery is true
+                              type: string
+                            oidc:
+                              description: OIDC settings.
+                              properties:
+                                insecureSkipVerifyNonce:
+                                  description: Skip verifying the OIDC ID Token's
+                                    nonce claim
+                                  type: boolean
+                                issuerUrl:
+                                  description: Defines the OIDC issuer URL.
+                                  type: string
+                                jwksUrl:
+                                  description: |-
+                                    Defines the OIDC JWKS URL for token verification.
+                                    Required if OIDC discovery is disabled.
+                                  type: string
+                                skipDiscovery:
+                                  description: |-
+                                    Defines if OIDC endpoint discovery should be bypassed.
+                                    LoginURL, RedeemURL, JWKSURL must be configured if discovery is disabled.
+                                  type: boolean
+                              type: object
+                            proxyPrefix:
+                              description: Defines the url root path that OAuth Proxy
+                                should be nested under.
+                              type: string
+                            redeemUrl:
+                              description: |-
+                                Defines the endpoint to redeem the authorization code received from the OAuth code flow.
+                                Must be set if OIDC.SkipDiscovery is true
+                              type: string
+                            redisStore:
+                              description: Settings for Redis store when SessionStoreType
+                                is redis.
+                              properties:
+                                connectionUrl:
+                                  description: Defines the URL for the Redis server.
+                                  type: string
+                              required:
+                              - connectionUrl
+                              type: object
+                            scope:
+                              description: Requested scopes.
+                              type: string
+                            sessionStoreType:
+                              description: Defines where to store session data.
+                              enum:
+                              - cookie
+                              - redis
+                              - ""
+                              type: string
+                            setAuthorizationHeader:
+                              description: Defines if the IDToken received by the
+                                OAuth Proxy should be added to the Authorization header.
+                              type: boolean
+                            setXAuthRequestHeaders:
+                              description: |-
+                                Defines if claims from the access token is added to the X-Auth-Request-User, X-Auth-Request-Groups,
+                                X-Auth-Request-Email and X-Auth-Request-Preferred-Username request headers.
+                                The access token is passed in the X-Auth-Request-Access-Token header.
+                              type: boolean
+                          type: object
+                      type: object
+                    dnsAppAlias:
+                      type: boolean
+                    dnsExternalAlias:
+                      description: 'Deprecated: For backward compatibility we must
+                        still support this field. New code should use ExternalDNS
+                        instead.'
+                      items:
+                        type: string
+                      type: array
+                    environmentVariables:
+                      additionalProperties:
+                        type: string
+                      description: 'Map of environment variables in the form ''<envvarname>:
+                        <value>'''
+                      type: object
+                    externalDNS:
+                      items:
+                        description: RadixDeployExternalDNS is the spec for an external
+                          DNS alias
+                        properties:
+                          fqdn:
+                            description: Fully qualified domain name (FQDN), e.g.
+                              myapp.example.com.
+                            maxLength: 255
+                            minLength: 4
+                            pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
+                            type: string
+                          useCertificateAutomation:
+                            default: false
+                            description: Enable automatic issuing and renewal of TLS
+                              certificate
+                            type: boolean
+                        required:
+                        - fqdn
+                        type: object
+                      type: array
+                    horizontalScaling:
+                      description: RadixHorizontalScaling defines configuration for
+                        horizontal pod autoscaler.
+                      properties:
+                        cooldownPeriod:
+                          description: CooldownPeriod to wait after the last trigger
+                            reported active before scaling the resource back to 0.
+                            Defaults to 5min
+                          format: int32
+                          minimum: 15
+                          type: integer
+                        maxReplicas:
+                          description: Defines the maximum number of replicas.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        minReplicas:
+                          default: 1
+                          description: Defines the minimum number of replicas.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        pollingInterval:
+                          description: PollingInterval configures how often to check
+                            each trigger on. Defaults to 30sec
+                          format: int32
+                          minimum: 15
+                          type: integer
+                        resources:
+                          description: |-
+                            Deprecated: Use CPU and/or Memory triggers instead
+                            Defines the resource usage parameters for the horizontal pod autoscaler.
+                          properties:
+                            cpu:
+                              description: Defines the CPU usage parameters for the
+                                horizontal pod autoscaler.
+                              properties:
+                                averageUtilization:
+                                  description: Defines the resource usage which triggers
+                                    scaling for the horizontal pod autoscaler.
+                                  format: int32
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - averageUtilization
+                              type: object
+                            memory:
+                              description: Defines the memory usage parameters for
+                                the horizontal pod autoscaler.
+                              properties:
+                                averageUtilization:
+                                  description: Defines the resource usage which triggers
+                                    scaling for the horizontal pod autoscaler.
+                                  format: int32
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - averageUtilization
+                              type: object
+                          type: object
+                        triggers:
+                          description: Defines a list of triggers the component replicas
+                            will scale on. Defaults to 80% CPU.
+                          items:
+                            description: RadixHorizontalScalingTrigger defines configuration
+                              for a specific trigger.
+                            maxProperties: 2
+                            minProperties: 2
+                            properties:
+                              azureServiceBus:
+                                description: AzureServiceBus defines a trigger that
+                                  scales based on number of messages in queue
+                                properties:
+                                  activationMessageCount:
+                                    description: 'ActivationMessageCount = Target
+                                      value for activating the scaler. (Default: 0,
+                                      Optional)'
+                                    minimum: 0
+                                    type: integer
+                                  authentication:
+                                    description: Azure Service Bus requires Workload
+                                      Identity configured with a ClientID
+                                    properties:
+                                      identity:
+                                        description: RadixHorizontalScalingRequiredIdentity
+                                          configuration for federation with required
+                                          azure identity providers.
+                                        properties:
+                                          azure:
+                                            description: Azure identity configuration
+                                            properties:
+                                              clientId:
+                                                description: Defines the Client ID
+                                                  for a user defined managed identity
+                                                  or application ID for an application
+                                                  registration.
+                                                type: string
+                                            required:
+                                            - clientId
+                                            type: object
+                                        required:
+                                        - azure
+                                        type: object
+                                    required:
+                                    - identity
+                                    type: object
+                                  messageCount:
+                                    description: |-
+                                      MessageCount  - Amount of active messages in your Azure Service Bus queue or topic to scale on. Defaults to 5 messages
+                                      DesiredReplicas Number of replicas to which the resource has to be scaled between the start and end of the cron schedule.
+                                    minimum: 1
+                                    type: integer
+                                  namespace:
+                                    description: Namespace - Name of the Azure Service
+                                      Bus namespace that contains your queue or topic.
+                                      Required when using workload identity
+                                    maxLength: 50
+                                    minLength: 6
+                                    pattern: ^(([a-z][-a-z0-9]*)?[a-z0-9])?$
+                                    type: string
+                                  queueName:
+                                    description: QueueName selects the target queue.
+                                      QueueName wil take precedence over TopicName.
+                                    maxLength: 260
+                                    minLength: 1
+                                    pattern: ^(([a-z0-9][-_a-z0-9./]*)?[a-z0-9])?$
+                                    type: string
+                                  subscriptionName:
+                                    description: SubscriptionName is required when
+                                      TopicName is set.
+                                    maxLength: 50
+                                    minLength: 1
+                                    pattern: ^(([a-z0-9][-_a-z0-9./]*)?[a-z0-9])?$
+                                    type: string
+                                  topicName:
+                                    description: TopicName selectes the target topic,
+                                      requires SubscriptionName to be set.
+                                    maxLength: 260
+                                    minLength: 1
+                                    pattern: ^(([a-z0-9][-_a-z0-9./]*)?[a-z0-9])?$
+                                    type: string
+                                required:
+                                - authentication
+                                - namespace
+                                type: object
+                              cpu:
+                                description: Cpu defines a trigger based on CPU usage
+                                properties:
+                                  value:
+                                    description: Value - the target value is the average
+                                      of the resource metric across all relevant pods,
+                                      represented as a percentage of the requested
+                                      value of the resource for the pods.
+                                    minimum: 15
+                                    type: integer
+                                required:
+                                - value
+                                type: object
+                              cron:
+                                description: Cron defines a trigger that scales based
+                                  on start and end times
+                                properties:
+                                  desiredReplicas:
+                                    description: DesiredReplicas Number of replicas
+                                      to which the resource has to be scaled between
+                                      the start and end of the cron schedule.
+                                    minimum: 1
+                                    type: integer
+                                  end:
+                                    description: End is a Cron expression indicating
+                                      the End of the cron schedule.
+                                    pattern: ^((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)
+                                      ?){5})$
+                                    type: string
+                                  start:
+                                    description: Start is a Cron expression indicating
+                                      the start of the cron schedule.
+                                    pattern: ^((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*)
+                                      ?){5})$
+                                    type: string
+                                  timezone:
+                                    description: Timezone One of the acceptable values
+                                      from the IANA Time Zone Database. The list of
+                                      timezones can be found at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+                                    type: string
+                                required:
+                                - desiredReplicas
+                                - end
+                                - start
+                                - timezone
+                                type: object
+                              memory:
+                                description: Memory defines a trigger based on memory
+                                  usage
+                                properties:
+                                  value:
+                                    description: Value - the target value is the average
+                                      of the resource metric across all relevant pods,
+                                      represented as a percentage of the requested
+                                      value of the resource for the pods.
+                                    minimum: 15
+                                    type: integer
+                                required:
+                                - value
+                                type: object
+                              name:
+                                description: Name of trigger, must be unique
+                                maxLength: 50
+                                minLength: 1
+                                pattern: ^(([a-z0-9][-a-z0-9]*)?[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      required:
+                      - maxReplicas
+                      type: object
+                    identity:
+                      description: Identity configuration for federation with external
+                        identity providers.
+                      properties:
+                        azure:
+                          description: Azure identity configuration
+                          properties:
+                            clientId:
+                              description: Defines the Client ID for a user defined
+                                managed identity or application ID for an application
+                                registration.
+                              type: string
+                          required:
+                          - clientId
+                          type: object
+                      type: object
+                    image:
+                      type: string
+                    ingressConfiguration:
+                      items:
+                        type: string
+                      type: array
+                    monitoring:
+                      type: boolean
+                    monitoringConfig:
+                      description: MonitoringConfig Monitoring configuration
+                      properties:
+                        path:
+                          description: Defines the path where metrics is served.
+                          type: string
+                        portName:
+                          description: Defines which port in the ports list where
+                            metrics is served.
+                          maxLength: 15
+                          pattern: ^(([a-z0-9][-a-z0-9]*)?[a-z0-9])?$
+                          type: string
+                      type: object
+                    name:
+                      type: string
+                    network:
+                      description: |-
+                        Network defines settings for network traffic.
+                        Currently, only public ingress traffic is supported
+                      properties:
+                        ingress:
+                          description: Ingress defines settings for ingress traffic.
+                          properties:
+                            public:
+                              description: Public defines settings for public traffic.
+                              properties:
+                                allow:
+                                  description: |-
+                                    Allow defines a list of public IP addresses or CIDRs which are allowed to access the component.
+                                    All IP addresses are allowed if this field is empty or not set.
+                                  items:
+                                    description: IP address or CIDR.
+                                    pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\/([0-9]|[1-2][0-9]|3[0-2]))?$
+                                    type: string
+                                  type: array
+                                proxyBodySize:
+                                  description: |-
+                                    Sets the maximum allowed size of the client request body.
+                                    Sizes can be specified in bytes, kilobytes (suffixes k and K), megabytes (suffixes m and M), or gigabytes (suffixes g and G) for example, "1024", "64k", "32m", "2g"
+                                    If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client.
+                                    Setting size to 0 disables checking of client request body size.
+                                  pattern: ^(?:0|[1-9][0-9]*[kKmMgG]?)$
+                                  type: string
+                                proxyReadTimeout:
+                                  description: |-
+                                    Defines a timeout, in seconds, for reading a response from the proxied server.
+                                    The timeout is set only between two successive read operations, not for the transmission of the whole response.
+                                    If the proxied server does not transmit anything within this time, the connection is closed.
+                                  minimum: 0
+                                  type: integer
+                                proxySendTimeout:
+                                  description: |-
+                                    Defines a timeout, in seconds, for transmitting a request to the proxied server.
+                                    The timeout is set only between two successive write operations, not for the transmission of the whole request.
+                                    If the proxied server does not receive anything within this time, the connection is closed.
+                                  minimum: 0
+                                  type: integer
+                              type: object
+                          type: object
+                      type: object
+                    node:
+                      description: RadixNode defines node attributes, where container
+                        should be scheduled
+                      properties:
+                        gpu:
+                          description: |-
+                            Defines rules for allowed GPU types.
+                            More info: https://www.radix.equinor.com/references/reference-radix-config/#gpu
+                          type: string
+                        gpuCount:
+                          description: Defines minimum number of required GPUs.
+                          type: string
+                      type: object
+                    ports:
+                      items:
+                        description: ComponentPort defines a named port.
+                        properties:
+                          name:
+                            description: Name of the port.
+                            maxLength: 15
+                            minLength: 1
+                            pattern: ^(([a-z0-9][-a-z0-9]*)?[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port number.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1024
+                            type: integer
+                        required:
+                        - name
+                        - port
+                        type: object
+                      type: array
+                    public:
+                      description: 'Deprecated: For backwards compatibility Public
+                        is still supported, new code should use PublicPort instead'
+                      type: boolean
+                    publicPort:
+                      type: string
+                    readOnlyFileSystem:
+                      type: boolean
+                    replicas:
+                      type: integer
+                    replicasOverride:
+                      type: integer
+                    resources:
+                      description: |-
+                        ResourceRequirements describes the compute resource requirements.
+                        More info: https://www.radix.equinor.com/references/reference-radix-config/#resources-common
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: Limits describes the maximum amount of compute
+                            resources allowed.
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if
+                            that is explicitly specified, otherwise to an implementation-defined value.
+                          type: object
+                      type: object
+                    runtime:
+                      description: Runtime defines the component or job's target runtime
+                        requirements
+                      properties:
+                        architecture:
+                          default: amd64
+                          description: CPU architecture target for the component or
+                            job. Defaults to amd64.
+                          enum:
+                          - amd64
+                          - arm64
+                          type: string
+                      type: object
+                    secretRefs:
+                      description: RadixSecretRefs defines secret vault
+                      properties:
+                        azureKeyVaults:
+                          description: List of Azure Key Vaults to get secrets from.
+                          items:
+                            description: RadixAzureKeyVault defines an Azure keyvault.
+                            properties:
+                              items:
+                                description: List of keyvault items (secrets, keys
+                                  and certificates).
+                                items:
+                                  description: 'RadixAzureKeyVaultItem defines Azure
+                                    Key Vault setting: secrets, keys, certificates'
+                                  properties:
+                                    alias:
+                                      description: Alias overrides the default file
+                                        name used when mounting the secret, key or
+                                        certificate.
+                                      minLength: 1
+                                      type: string
+                                    encoding:
+                                      description: |-
+                                        Encoding defines the encoding of a keyvault item when stored in the container.
+                                        Setting encoding to base64 and format to pfx will fetch and write the base64 decoded pfx binary.
+                                      enum:
+                                      - base64
+                                      type: string
+                                    envVar:
+                                      description: Defines the name of the environment
+                                        variable that will contain the value of the
+                                        secret, key or certificate.
+                                      type: string
+                                    format:
+                                      description: |-
+                                        Defines the format of the keyvault item.
+                                        pfx is only supported with type secret and PKCS12 or ECC certificate.
+                                        Default format for certificates is pem.
+                                      enum:
+                                      - pem
+                                      - pfx
+                                      type: string
+                                    k8sSecretType:
+                                      description: |-
+                                        K8sSecretType defines the type of Kubernetes secret the keyvault item will be stored in.
+                                        opaque corresponds to "Opaque" and "kubernetes.io/tls" secret types: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
+                                      enum:
+                                      - opaque
+                                      - tls
+                                      type: string
+                                    name:
+                                      description: Name of a secret, key or certificate
+                                        in the keyvault.
+                                      maxLength: 127
+                                      minLength: 1
+                                      type: string
+                                    type:
+                                      description: Type of item in the keyvault referenced
+                                        by the name.
+                                      enum:
+                                      - secret
+                                      - key
+                                      - cert
+                                      type: string
+                                    version:
+                                      description: |-
+                                        Defines that a specific version of a keyvault item should be loaded.
+                                        The latest version is loaded when this field is not set.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                minItems: 1
+                                type: array
+                              name:
+                                description: Name of the Azure keyvault.
+                                maxLength: 24
+                                minLength: 3
+                                type: string
+                              path:
+                                description: Path where secrets from the keyvault
+                                  is mounted.
+                                minLength: 1
+                                type: string
+                              useAzureIdentity:
+                                description: UseAzureIdentity defines that credentials
+                                  for accessing Azure Key Vault will be acquired using
+                                  Azure Workload Identity instead of using a ClientID
+                                  and Secret.
+                                type: boolean
+                            required:
+                            - items
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    secrets:
+                      items:
+                        type: string
+                      type: array
+                    volumeMounts:
+                      items:
+                        description: RadixVolumeMount defines an external storage
+                          resource.
+                        properties:
+                          accessMode:
+                            description: |-
+                              Access mode from a container to an external storage. ReadOnlyMany (default), ReadWriteOnce, ReadWriteMany.
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            enum:
+                            - ReadOnlyMany
+                            - ReadWriteOnce
+                            - ReadWriteMany
+                            - ""
+                            type: string
+                          azureFile:
+                            description: AzureFile settings for Azure File CSI driver
+                            properties:
+                              accessMode:
+                                description: |-
+                                  Access mode from a container to an external storage. ReadOnlyMany (default), ReadWriteOnce, ReadWriteMany.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - ReadOnlyMany
+                                - ReadWriteOnce
+                                - ReadWriteMany
+                                - ""
+                                type: string
+                              bindingMode:
+                                description: |-
+                                  Binding mode from a container to an external storage. Immediate (default), WaitForFirstConsumer.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - Immediate
+                                - WaitForFirstConsumer
+                                - ""
+                                type: string
+                              gid:
+                                description: GID defines the group ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                              requestsStorage:
+                                description: |-
+                                  Requested size (opens new window)of allocated mounted volume. Default value is set to "1Mi" (1 megabyte). Current version of the driver does not affect mounted volume size
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim
+                                type: string
+                              share:
+                                description: Share. Name of the file share in the
+                                  external storage resource.
+                                type: string
+                              skuName:
+                                description: |-
+                                  SKU Type of Azure storage.
+                                  More info: https://learn.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
+                                type: string
+                              uid:
+                                description: UID defines the user ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                            type: object
+                          bindingMode:
+                            description: |-
+                              Binding mode from a container to an external storage. Immediate (default), WaitForFirstConsumer.
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            enum:
+                            - Immediate
+                            - WaitForFirstConsumer
+                            - ""
+                            type: string
+                          blobFuse2:
+                            description: BlobFuse2 settings for Azure Storage FUSE
+                              CSI driver
+                            properties:
+                              accessMode:
+                                description: |-
+                                  Access mode from a container to an external storage. ReadOnlyMany (default), ReadWriteOnce, ReadWriteMany.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - ReadOnlyMany
+                                - ReadWriteOnce
+                                - ReadWriteMany
+                                - ""
+                                type: string
+                              bindingMode:
+                                description: |-
+                                  Binding mode from a container to an external storage. Immediate (default), WaitForFirstConsumer.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - Immediate
+                                - WaitForFirstConsumer
+                                - ""
+                                type: string
+                              container:
+                                description: Container. Name of the container in the
+                                  external storage resource.
+                                type: string
+                              gid:
+                                description: GID defines the group ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                              protocol:
+                                description: Holds protocols of BlobFuse2 Azure Storage
+                                  FUSE driver. Default is fuse2.
+                                enum:
+                                - fuse2
+                                - nfs
+                                - ""
+                                type: string
+                              requestsStorage:
+                                description: |-
+                                  Requested size (opens new window)of allocated mounted volume. Default value is set to "1Mi" (1 megabyte). Current version of the driver does not affect mounted volume size
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim
+                                type: string
+                              skuName:
+                                description: |-
+                                  SKU Type of Azure storage.
+                                  More info: https://learn.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
+                                enum:
+                                - Standard_LRS
+                                - Premium_LRS
+                                - Standard_GRS
+                                - Standard_RAGRS
+                                - ""
+                                type: string
+                              streaming:
+                                description: |-
+                                  Configure Streaming mode. Used for blobfuse2.
+                                  More info: https://github.com/Azure/azure-storage-fuse/blob/main/STREAMING.md
+                                properties:
+                                  blockSize:
+                                    description: Optional. The size of each block
+                                      to be cached in memory (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  bufferSize:
+                                    description: Optional. The size of each buffer
+                                      to be cached in memory (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  enabled:
+                                    description: Enable streaming mode. Default true.
+                                    type: boolean
+                                  maxBlocksPerFile:
+                                    description: Optional. The maximum number of blocks
+                                      to be cached in memory.
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  maxBuffers:
+                                    description: Optional. The total number of buffers
+                                      to be cached in memory (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  streamCache:
+                                    description: Optional. Limit total amount of data
+                                      being cached in memory to conserve memory footprint
+                                      of blobfuse (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              uid:
+                                description: UID defines the user ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                              useAdls:
+                                description: |-
+                                  Enables blobfuse to access Azure DataLake storage account. When set to false, blobfuse will access Azure Block Blob storage account, hierarchical file system is not supported.
+                                  Default false. This must be turned on when HNS enabled account is mounted.
+                                type: boolean
+                            required:
+                            - container
+                            type: object
+                          container:
+                            description: 'Deprecated. Only required by the deprecated
+                              type: blob.'
+                            type: string
+                          emptyDir:
+                            description: EmptyDir settings for EmptyDir volume
+                            properties:
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: SizeLimit defines the size of the emptyDir
+                                  volume
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - sizeLimit
+                            type: object
+                          gid:
+                            description: |-
+                              GID defines the group ID (number) which will be set as owner of the mounted volume.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          name:
+                            description: |-
+                              User-defined name of the volume mount.
+                              Must be unique for the component.
+                            maxLength: 40
+                            minLength: 1
+                            type: string
+                          path:
+                            description: Path defines in which directory the external
+                              storage is mounted.
+                            minLength: 1
+                            type: string
+                          requestsStorage:
+                            description: |-
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          skuName:
+                            description: |-
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          storage:
+                            description: |-
+                              Storage defines the name of the container in the external storage resource.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          type:
+                            description: |-
+                              Type defines the storage type.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            enum:
+                            - blob
+                            - azure-blob
+                            - azure-file
+                            - ""
+                            type: string
+                          uid:
+                            description: |-
+                              UID defines the user ID (number) which will be set as owner of the mounted volume.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                        required:
+                        - name
+                        - path
+                        type: object
+                      type: array
+                  required:
+                  - alwaysPullImageOnDeploy
+                  - image
+                  - monitoring
+                  - name
+                  - ports
+                  - public
+                  type: object
+                type: array
+              environment:
+                type: string
+              imagePullSecrets:
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              jobs:
+                items:
+                  description: |-
+                    RadixDeployJobComponent defines a single job component within a RadixDeployment
+                    The job component is used by the radix-job-scheduler to create Kubernetes Job objects
+                  properties:
+                    alwaysPullImageOnDeploy:
+                      type: boolean
+                    backoffLimit:
+                      format: int32
+                      type: integer
+                    batchStatusRules:
+                      description: BatchStatusRules Rules define how a batch status
+                        is set corresponding to batch job statuses
+                      items:
+                        description: BatchStatusRule Rule how to set a batch status
+                          by job statuses
+                        properties:
+                          batchStatus:
+                            description: BatchStatus The status of the batch corresponding
+                              to job statuses
+                            enum:
+                            - Running
+                            - Succeeded
+                            - Failed
+                            - Waiting
+                            - Stopping
+                            - Stopped
+                            - Active
+                            - Completed
+                            type: string
+                          condition:
+                            description: Condition of a rule
+                            enum:
+                            - All
+                            - Any
+                            type: string
+                          jobStatuses:
+                            description: JobStatuses Matching job statuses within
+                              the rule
+                            items:
+                              description: RadixBatchJobPhase represents the phase
+                                of the job
+                              enum:
+                              - Waiting
+                              - Active
+                              - Running
+                              - Succeeded
+                              - Failed
+                              - Stopped
+                              type: string
+                            type: array
+                          operator:
+                            description: Operator of a rule
+                            enum:
+                            - In
+                            - NotIn
+                            type: string
+                        required:
+                        - batchStatus
+                        - condition
+                        - jobStatuses
+                        - operator
+                        type: object
+                      type: array
+                    environment:
+                      type: string
+                    environmentVariables:
+                      additionalProperties:
+                        type: string
+                      description: 'Map of environment variables in the form ''<envvarname>:
+                        <value>'''
+                      type: object
+                    identity:
+                      description: Identity configuration for federation with external
+                        identity providers.
+                      properties:
+                        azure:
+                          description: Azure identity configuration
+                          properties:
+                            clientId:
+                              description: Defines the Client ID for a user defined
+                                managed identity or application ID for an application
+                                registration.
+                              type: string
+                          required:
+                          - clientId
+                          type: object
+                      type: object
+                    image:
+                      type: string
+                    monitoring:
+                      type: boolean
+                    monitoringConfig:
+                      description: MonitoringConfig Monitoring configuration
+                      properties:
+                        path:
+                          description: Defines the path where metrics is served.
+                          type: string
+                        portName:
+                          description: Defines which port in the ports list where
+                            metrics is served.
+                          maxLength: 15
+                          pattern: ^(([a-z0-9][-a-z0-9]*)?[a-z0-9])?$
+                          type: string
+                      type: object
+                    name:
+                      type: string
+                    node:
+                      description: RadixNode defines node attributes, where container
+                        should be scheduled
+                      properties:
+                        gpu:
+                          description: |-
+                            Defines rules for allowed GPU types.
+                            More info: https://www.radix.equinor.com/references/reference-radix-config/#gpu
+                          type: string
+                        gpuCount:
+                          description: Defines minimum number of required GPUs.
+                          type: string
+                      type: object
+                    notifications:
+                      description: Notifications is the spec for notification about
+                        internal events or changes
+                      properties:
+                        webhook:
+                          description: Webhook is a URL for notification about internal
+                            events or changes. The URL should be of a Radix component
+                            or job-component, with not public port.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      type: object
+                    payload:
+                      description: |-
+                        RadixJobComponentPayload defines the path and where the payload received
+                        by radix-job-scheduler will be mounted to the job container
+                      properties:
+                        path:
+                          description: Path to the folder where payload is mounted
+                          minLength: 1
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    ports:
+                      items:
+                        description: ComponentPort defines a named port.
+                        properties:
+                          name:
+                            description: Name of the port.
+                            maxLength: 15
+                            minLength: 1
+                            pattern: ^(([a-z0-9][-a-z0-9]*)?[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port number.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1024
+                            type: integer
+                        required:
+                        - name
+                        - port
+                        type: object
+                      type: array
+                    readOnlyFileSystem:
+                      type: boolean
+                    resources:
+                      description: |-
+                        ResourceRequirements describes the compute resource requirements.
+                        More info: https://www.radix.equinor.com/references/reference-radix-config/#resources-common
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: Limits describes the maximum amount of compute
+                            resources allowed.
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if
+                            that is explicitly specified, otherwise to an implementation-defined value.
+                          type: object
+                      type: object
+                    runtime:
+                      description: Runtime defines the component or job's target runtime
+                        requirements
+                      properties:
+                        architecture:
+                          default: amd64
+                          description: CPU architecture target for the component or
+                            job. Defaults to amd64.
+                          enum:
+                          - amd64
+                          - arm64
+                          type: string
+                      type: object
+                    schedulerPort:
+                      format: int32
+                      type: integer
+                    secretRefs:
+                      description: RadixSecretRefs defines secret vault
+                      properties:
+                        azureKeyVaults:
+                          description: List of Azure Key Vaults to get secrets from.
+                          items:
+                            description: RadixAzureKeyVault defines an Azure keyvault.
+                            properties:
+                              items:
+                                description: List of keyvault items (secrets, keys
+                                  and certificates).
+                                items:
+                                  description: 'RadixAzureKeyVaultItem defines Azure
+                                    Key Vault setting: secrets, keys, certificates'
+                                  properties:
+                                    alias:
+                                      description: Alias overrides the default file
+                                        name used when mounting the secret, key or
+                                        certificate.
+                                      minLength: 1
+                                      type: string
+                                    encoding:
+                                      description: |-
+                                        Encoding defines the encoding of a keyvault item when stored in the container.
+                                        Setting encoding to base64 and format to pfx will fetch and write the base64 decoded pfx binary.
+                                      enum:
+                                      - base64
+                                      type: string
+                                    envVar:
+                                      description: Defines the name of the environment
+                                        variable that will contain the value of the
+                                        secret, key or certificate.
+                                      type: string
+                                    format:
+                                      description: |-
+                                        Defines the format of the keyvault item.
+                                        pfx is only supported with type secret and PKCS12 or ECC certificate.
+                                        Default format for certificates is pem.
+                                      enum:
+                                      - pem
+                                      - pfx
+                                      type: string
+                                    k8sSecretType:
+                                      description: |-
+                                        K8sSecretType defines the type of Kubernetes secret the keyvault item will be stored in.
+                                        opaque corresponds to "Opaque" and "kubernetes.io/tls" secret types: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
+                                      enum:
+                                      - opaque
+                                      - tls
+                                      type: string
+                                    name:
+                                      description: Name of a secret, key or certificate
+                                        in the keyvault.
+                                      maxLength: 127
+                                      minLength: 1
+                                      type: string
+                                    type:
+                                      description: Type of item in the keyvault referenced
+                                        by the name.
+                                      enum:
+                                      - secret
+                                      - key
+                                      - cert
+                                      type: string
+                                    version:
+                                      description: |-
+                                        Defines that a specific version of a keyvault item should be loaded.
+                                        The latest version is loaded when this field is not set.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                minItems: 1
+                                type: array
+                              name:
+                                description: Name of the Azure keyvault.
+                                maxLength: 24
+                                minLength: 3
+                                type: string
+                              path:
+                                description: Path where secrets from the keyvault
+                                  is mounted.
+                                minLength: 1
+                                type: string
+                              useAzureIdentity:
+                                description: UseAzureIdentity defines that credentials
+                                  for accessing Azure Key Vault will be acquired using
+                                  Azure Workload Identity instead of using a ClientID
+                                  and Secret.
+                                type: boolean
+                            required:
+                            - items
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    secrets:
+                      items:
+                        type: string
+                      type: array
+                    timeLimitSeconds:
+                      format: int64
+                      type: integer
+                    volumeMounts:
+                      items:
+                        description: RadixVolumeMount defines an external storage
+                          resource.
+                        properties:
+                          accessMode:
+                            description: |-
+                              Access mode from a container to an external storage. ReadOnlyMany (default), ReadWriteOnce, ReadWriteMany.
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            enum:
+                            - ReadOnlyMany
+                            - ReadWriteOnce
+                            - ReadWriteMany
+                            - ""
+                            type: string
+                          azureFile:
+                            description: AzureFile settings for Azure File CSI driver
+                            properties:
+                              accessMode:
+                                description: |-
+                                  Access mode from a container to an external storage. ReadOnlyMany (default), ReadWriteOnce, ReadWriteMany.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - ReadOnlyMany
+                                - ReadWriteOnce
+                                - ReadWriteMany
+                                - ""
+                                type: string
+                              bindingMode:
+                                description: |-
+                                  Binding mode from a container to an external storage. Immediate (default), WaitForFirstConsumer.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - Immediate
+                                - WaitForFirstConsumer
+                                - ""
+                                type: string
+                              gid:
+                                description: GID defines the group ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                              requestsStorage:
+                                description: |-
+                                  Requested size (opens new window)of allocated mounted volume. Default value is set to "1Mi" (1 megabyte). Current version of the driver does not affect mounted volume size
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim
+                                type: string
+                              share:
+                                description: Share. Name of the file share in the
+                                  external storage resource.
+                                type: string
+                              skuName:
+                                description: |-
+                                  SKU Type of Azure storage.
+                                  More info: https://learn.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
+                                type: string
+                              uid:
+                                description: UID defines the user ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                            type: object
+                          bindingMode:
+                            description: |-
+                              Binding mode from a container to an external storage. Immediate (default), WaitForFirstConsumer.
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            enum:
+                            - Immediate
+                            - WaitForFirstConsumer
+                            - ""
+                            type: string
+                          blobFuse2:
+                            description: BlobFuse2 settings for Azure Storage FUSE
+                              CSI driver
+                            properties:
+                              accessMode:
+                                description: |-
+                                  Access mode from a container to an external storage. ReadOnlyMany (default), ReadWriteOnce, ReadWriteMany.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - ReadOnlyMany
+                                - ReadWriteOnce
+                                - ReadWriteMany
+                                - ""
+                                type: string
+                              bindingMode:
+                                description: |-
+                                  Binding mode from a container to an external storage. Immediate (default), WaitForFirstConsumer.
+                                  More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                                enum:
+                                - Immediate
+                                - WaitForFirstConsumer
+                                - ""
+                                type: string
+                              container:
+                                description: Container. Name of the container in the
+                                  external storage resource.
+                                type: string
+                              gid:
+                                description: GID defines the group ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                              protocol:
+                                description: Holds protocols of BlobFuse2 Azure Storage
+                                  FUSE driver. Default is fuse2.
+                                enum:
+                                - fuse2
+                                - nfs
+                                - ""
+                                type: string
+                              requestsStorage:
+                                description: |-
+                                  Requested size (opens new window)of allocated mounted volume. Default value is set to "1Mi" (1 megabyte). Current version of the driver does not affect mounted volume size
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolumeclaim
+                                type: string
+                              skuName:
+                                description: |-
+                                  SKU Type of Azure storage.
+                                  More info: https://learn.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
+                                enum:
+                                - Standard_LRS
+                                - Premium_LRS
+                                - Standard_GRS
+                                - Standard_RAGRS
+                                - ""
+                                type: string
+                              streaming:
+                                description: |-
+                                  Configure Streaming mode. Used for blobfuse2.
+                                  More info: https://github.com/Azure/azure-storage-fuse/blob/main/STREAMING.md
+                                properties:
+                                  blockSize:
+                                    description: Optional. The size of each block
+                                      to be cached in memory (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  bufferSize:
+                                    description: Optional. The size of each buffer
+                                      to be cached in memory (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  enabled:
+                                    description: Enable streaming mode. Default true.
+                                    type: boolean
+                                  maxBlocksPerFile:
+                                    description: Optional. The maximum number of blocks
+                                      to be cached in memory.
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  maxBuffers:
+                                    description: Optional. The total number of buffers
+                                      to be cached in memory (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                  streamCache:
+                                    description: Optional. Limit total amount of data
+                                      being cached in memory to conserve memory footprint
+                                      of blobfuse (in MB).
+                                    format: int64
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              uid:
+                                description: UID defines the user ID (number) which
+                                  will be set as owner of the mounted volume.
+                                type: string
+                              useAdls:
+                                description: |-
+                                  Enables blobfuse to access Azure DataLake storage account. When set to false, blobfuse will access Azure Block Blob storage account, hierarchical file system is not supported.
+                                  Default false. This must be turned on when HNS enabled account is mounted.
+                                type: boolean
+                            required:
+                            - container
+                            type: object
+                          container:
+                            description: 'Deprecated. Only required by the deprecated
+                              type: blob.'
+                            type: string
+                          emptyDir:
+                            description: EmptyDir settings for EmptyDir volume
+                            properties:
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: SizeLimit defines the size of the emptyDir
+                                  volume
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - sizeLimit
+                            type: object
+                          gid:
+                            description: |-
+                              GID defines the group ID (number) which will be set as owner of the mounted volume.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          name:
+                            description: |-
+                              User-defined name of the volume mount.
+                              Must be unique for the component.
+                            maxLength: 40
+                            minLength: 1
+                            type: string
+                          path:
+                            description: Path defines in which directory the external
+                              storage is mounted.
+                            minLength: 1
+                            type: string
+                          requestsStorage:
+                            description: |-
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          skuName:
+                            description: |-
+                              More info: https://www.radix.equinor.com/guides/volume-mounts/optional-settings/
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          storage:
+                            description: |-
+                              Storage defines the name of the container in the external storage resource.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                          type:
+                            description: |-
+                              Type defines the storage type.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            enum:
+                            - blob
+                            - azure-blob
+                            - azure-file
+                            - ""
+                            type: string
+                          uid:
+                            description: |-
+                              UID defines the user ID (number) which will be set as owner of the mounted volume.
+                              Deprecated, use BlobFuse2 or AzureFile instead.
+                            type: string
+                        required:
+                        - name
+                        - path
+                        type: object
+                      type: array
+                  required:
+                  - alwaysPullImageOnDeploy
+                  - environment
+                  - image
+                  - monitoring
+                  - name
+                  - ports
+                  type: object
+                type: array
+            required:
+            - appname
+            - components
+            - environment
+            - imagePullSecrets
+            - jobs
+            type: object
+          status:
+            description: RadixDeployStatus is the status for a rd
+            properties:
+              activeFrom:
+                format: date-time
+                type: string
+              activeTo:
+                format: date-time
+                type: string
+              condition:
+                description: RadixDeployCondition Holds the condition of a component
+                type: string
+              reconciled:
+                format: date-time
+                type: string
+            required:
+            - activeFrom
+            - activeTo
+            - condition
+            - reconciled
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
     subresources:
       status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/equinor/radix-common/utils/slice"
-	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // +genclient
@@ -22,10 +22,10 @@ import (
 
 // RadixDeployment describe a deployment
 type RadixDeployment struct {
-	meta_v1.TypeMeta   `json:",inline"`
-	meta_v1.ObjectMeta `json:"metadata,omitempty"`
-	Spec               RadixDeploymentSpec `json:"spec"`
-	Status             RadixDeployStatus   `json:"status"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              RadixDeploymentSpec `json:"spec"`
+	Status            RadixDeployStatus   `json:"status"`
 }
 
 // GetComponentByName returns the component matching the name parameter, or nil if not found
@@ -59,12 +59,12 @@ func (rd *RadixDeployment) GetCommonComponentByName(name string) RadixCommonDepl
 
 // RadixDeployStatus is the status for a rd
 type RadixDeployStatus struct {
-	ActiveFrom meta_v1.Time `json:"activeFrom"`
+	ActiveFrom metav1.Time `json:"activeFrom"`
 	// +optional
-	ActiveTo  meta_v1.Time         `json:"activeTo,omitempty"`
+	ActiveTo  metav1.Time          `json:"activeTo,omitempty"`
 	Condition RadixDeployCondition `json:"condition"`
 	// +optional
-	Reconciled meta_v1.Time `json:"reconciled"`
+	Reconciled metav1.Time `json:"reconciled"`
 }
 
 // RadixDeployCondition Holds the condition of a component
@@ -80,20 +80,20 @@ const (
 
 // RadixDeploymentSpec is the spec for a deployment
 type RadixDeploymentSpec struct {
-	AppName          string                         `json:"appname"`
-	Components       []RadixDeployComponent         `json:"components"`
-	Jobs             []RadixDeployJobComponent      `json:"jobs,omitempty"`
-	Environment      string                         `json:"environment"`
-	ImagePullSecrets []core_v1.LocalObjectReference `json:"imagePullSecrets"`
+	AppName          string                        `json:"appname"`
+	Components       []RadixDeployComponent        `json:"components"`
+	Jobs             []RadixDeployJobComponent     `json:"jobs,omitempty"`
+	Environment      string                        `json:"environment"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RadixDeploymentList is a list of Radix deployments
 type RadixDeploymentList struct {
-	meta_v1.TypeMeta `json:",inline"`
-	meta_v1.ListMeta `json:"metadata"`
-	Items            []RadixDeployment `json:"items"`
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []RadixDeployment `json:"items"`
 }
 
 // RadixDeployExternalDNS is the spec for an external DNS alias

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -60,7 +60,7 @@ type RadixDeployStatus struct {
 	ActiveFrom meta_v1.Time         `json:"activeFrom"`
 	ActiveTo   meta_v1.Time         `json:"activeTo"`
 	Condition  RadixDeployCondition `json:"condition"`
-	Reconciled meta_v1.Time         `json:"reconciled"`
+	Reconciled meta_v1.Time         `json:"reconciled,omitempty"`
 }
 
 // RadixDeployCondition Holds the condition of a component
@@ -78,7 +78,7 @@ const (
 type RadixDeploymentSpec struct {
 	AppName          string                         `json:"appname"`
 	Components       []RadixDeployComponent         `json:"components"`
-	Jobs             []RadixDeployJobComponent      `json:"jobs"`
+	Jobs             []RadixDeployJobComponent      `json:"jobs,omitempty"`
 	Environment      string                         `json:"environment"`
 	ImagePullSecrets []core_v1.LocalObjectReference `json:"imagePullSecrets"`
 }

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -23,9 +23,9 @@ import (
 // RadixDeployment describe a deployment
 type RadixDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 	Spec              RadixDeploymentSpec `json:"spec"`
-	Status            RadixDeployStatus   `json:"status"`
+	Status            RadixDeployStatus   `json:"status,omitempty"`
 }
 
 // GetComponentByName returns the component matching the name parameter, or nil if not found
@@ -81,10 +81,10 @@ const (
 // RadixDeploymentSpec is the spec for a deployment
 type RadixDeploymentSpec struct {
 	AppName          string                        `json:"appname"`
-	Components       []RadixDeployComponent        `json:"components"`
+	Components       []RadixDeployComponent        `json:"components,omitempty"`
 	Jobs             []RadixDeployJobComponent     `json:"jobs,omitempty"`
 	Environment      string                        `json:"environment"`
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -114,7 +114,7 @@ type RadixDeployExternalDNS struct {
 type RadixDeployComponent struct {
 	Name             string          `json:"name"`
 	Image            string          `json:"image"`
-	Ports            []ComponentPort `json:"ports"`
+	Ports            []ComponentPort `json:"ports,omitempty"`
 	Replicas         *int            `json:"replicas,omitempty"`
 	ReplicasOverride *int            `json:"replicasOverride,omitempty"`
 	// Deprecated: For backwards compatibility Public is still supported, new code should use PublicPort instead
@@ -402,7 +402,7 @@ type RadixDeployJobComponent struct {
 	Name                    string                    `json:"name"`
 	Environment             string                    `json:"environment"`
 	Image                   string                    `json:"image"`
-	Ports                   []ComponentPort           `json:"ports"`
+	Ports                   []ComponentPort           `json:"ports,omitempty"`
 	EnvironmentVariables    EnvVarsMap                `json:"environmentVariables,omitempty"`
 	Secrets                 []string                  `json:"secrets,omitempty"`
 	SecretRefs              RadixSecretRefs           `json:"secretRefs,omitempty"`

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -11,6 +11,12 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:name="Active From",type="date",JSONPath=".status.activeFrom"
+// +kubebuilder:printcolumn:name="Active To",type="date",JSONPath=".status.activeTo"
+// +kubebuilder:printcolumn:name="Condition",type="string",JSONPath=".status.condition"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:resource:path=radixdeployments,shortName=rd
+// +kubebuilder:subresource:status
 
 // RadixDeployment describe a deployment
 type RadixDeployment struct {
@@ -105,7 +111,7 @@ type RadixDeployComponent struct {
 	Name             string          `json:"name"`
 	Image            string          `json:"image"`
 	Ports            []ComponentPort `json:"ports"`
-	Replicas         *int            `json:"replicas"`
+	Replicas         *int            `json:"replicas,omitempty"`
 	ReplicasOverride *int            `json:"replicasOverride,omitempty"`
 	// Deprecated: For backwards compatibility Public is still supported, new code should use PublicPort instead
 	Public               bool                     `json:"public"`

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -11,10 +11,12 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:printcolumn:name="Active From",type="date",JSONPath=".status.activeFrom"
-// +kubebuilder:printcolumn:name="Active To",type="date",JSONPath=".status.activeTo"
+// +kubebuilder:printcolumn:name="Active From",type="string",JSONPath=".status.activeFrom"
+// +kubebuilder:printcolumn:name="Active To",type="string",JSONPath=".status.activeTo"
 // +kubebuilder:printcolumn:name="Condition",type="string",JSONPath=".status.condition"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Reconciled",type="date",JSONPath=".status.reconciled",priority=1
+// +kubebuilder:printcolumn:name="Branch",type="string",JSONPath=".metadata.annotations.radix-branch",priority=1
 // +kubebuilder:resource:path=radixdeployments,shortName=rd
 // +kubebuilder:subresource:status
 

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -57,10 +57,12 @@ func (rd *RadixDeployment) GetCommonComponentByName(name string) RadixCommonDepl
 
 // RadixDeployStatus is the status for a rd
 type RadixDeployStatus struct {
-	ActiveFrom meta_v1.Time         `json:"activeFrom"`
-	ActiveTo   meta_v1.Time         `json:"activeTo"`
-	Condition  RadixDeployCondition `json:"condition"`
-	Reconciled meta_v1.Time         `json:"reconciled,omitempty"`
+	ActiveFrom meta_v1.Time `json:"activeFrom"`
+	// +optional
+	ActiveTo  meta_v1.Time         `json:"activeTo,omitempty"`
+	Condition RadixDeployCondition `json:"condition"`
+	// +optional
+	Reconciled meta_v1.Time `json:"reconciled"`
 }
 
 // RadixDeployCondition Holds the condition of a component


### PR DESCRIPTION
First version, I tested a random radixdeployment from Kubernetes, and tested it against the schema generated 

`yq  '.spec.versions[0].schema.openAPIV3Schema' charts/radix-operator/templates/radixdeployment.yaml -o=json | clip.exe`

## It failed with these errors:
![image](https://github.com/user-attachments/assets/13d7f03a-bcfa-4583-9aac-df4f66d0c303)
(source: https://www.jsonschemavalidator.net/)

##
But I think its not a problem, with the schema, the fields are marked with `omitempty`, so the fields should not have been returned if the new CRD had been installed (**I think!!***)

- How can we validate this properly?