### PR TITLE
Fix restart batchjob infinite loop

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.46.2
-appVersion: 1.66.2
+version: 1.46.3
+appVersion: 1.66.3
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/batch/kubejob.go
+++ b/pkg/apis/batch/kubejob.go
@@ -36,11 +36,12 @@ func (s *syncer) reconcileKubeJob(ctx context.Context, batchJob *radixv1.RadixBa
 	}
 
 	requiresRestart := s.jobRequiresRestart(*batchJob)
-	if !requiresRestart && (isBatchJobDone(s.radixBatch, batchJob.Name) || len(batchJobKubeJobs) > 0) {
+	if !requiresRestart && (s.isBatchJobDone(batchJob.Name) || len(batchJobKubeJobs) > 0) {
 		return nil
 	}
 
 	if requiresRestart {
+		s.restartedJobs[batchJob.Name] = *batchJob
 		if err := s.deleteJobs(ctx, batchJobKubeJobs); err != nil {
 			return err
 		}

--- a/pkg/apis/batch/service.go
+++ b/pkg/apis/batch/service.go
@@ -16,7 +16,7 @@ func (s *syncer) reconcileService(ctx context.Context, batchJob *radixv1.RadixBa
 		return nil
 	}
 
-	if isBatchJobStopRequested(batchJob) || isBatchJobDone(s.radixBatch, batchJob.Name) {
+	if isBatchJobStopRequested(batchJob) || s.isBatchJobDone(batchJob.Name) {
 		return nil
 	}
 

--- a/pkg/apis/batch/status.go
+++ b/pkg/apis/batch/status.go
@@ -142,6 +142,7 @@ func (s *syncer) buildBatchJobStatus(ctx context.Context, batchJob *radixv1.Radi
 
 	if hasCurrentStatus && !isRestartedJob {
 		status.Phase = currentStatus.Phase
+		status.Restart = currentStatus.Restart
 	}
 
 	if isBatchJobStopRequested(batchJob) {

--- a/pkg/apis/batch/syncer.go
+++ b/pkg/apis/batch/syncer.go
@@ -16,6 +16,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	syncStatusForEveryNumberOfBatchJobsReconciled = 10
+)
+
 // Syncer of  RadixBatch
 type Syncer interface {
 	// OnSync Syncs RadixBatch
@@ -25,20 +29,22 @@ type Syncer interface {
 // NewSyncer Constructor os RadixBatches Syncer
 func NewSyncer(kubeclient kubernetes.Interface, kubeUtil *kube.Kube, radixClient radixclient.Interface, radixBatch *radixv1.RadixBatch, config *config.Config) Syncer {
 	return &syncer{
-		kubeClient:  kubeclient,
-		kubeUtil:    kubeUtil,
-		radixClient: radixClient,
-		radixBatch:  radixBatch,
-		config:      config,
+		kubeClient:    kubeclient,
+		kubeUtil:      kubeUtil,
+		radixClient:   radixClient,
+		radixBatch:    radixBatch,
+		config:        config,
+		restartedJobs: map[string]radixv1.RadixBatchJob{},
 	}
 }
 
 type syncer struct {
-	kubeClient  kubernetes.Interface
-	kubeUtil    *kube.Kube
-	radixClient radixclient.Interface
-	radixBatch  *radixv1.RadixBatch
-	config      *config.Config
+	kubeClient    kubernetes.Interface
+	kubeUtil      *kube.Kube
+	radixClient   radixclient.Interface
+	radixBatch    *radixv1.RadixBatch
+	config        *config.Config
+	restartedJobs map[string]radixv1.RadixBatchJob
 }
 
 // OnSync Syncs RadixBatches
@@ -50,7 +56,7 @@ func (s *syncer) OnSync(ctx context.Context) error {
 		return err
 	}
 
-	if isBatchDone(s.radixBatch) && !slice.Any(s.radixBatch.Spec.Jobs, s.jobRequiresRestart) {
+	if s.isBatchDone() && !s.isRestartRequestedForAnyBatchJob() {
 		return nil
 	}
 
@@ -58,8 +64,6 @@ func (s *syncer) OnSync(ctx context.Context) error {
 }
 
 func (s *syncer) reconcile(ctx context.Context) error {
-	const syncStatusForEveryNumberOfBatchJobsReconciled = 10
-
 	rd, jobComponent, err := s.getRadixDeploymentAndJobComponent(ctx)
 	if err != nil {
 		return err
@@ -84,7 +88,7 @@ func (s *syncer) reconcile(ctx context.Context) error {
 			return fmt.Errorf("batchjob %s: failed to reconcile kubejob: %w", batchJob.Name, err)
 		}
 
-		if i%syncStatusForEveryNumberOfBatchJobsReconciled == 0 {
+		if i%syncStatusForEveryNumberOfBatchJobsReconciled == (syncStatusForEveryNumberOfBatchJobsReconciled - 1) {
 			if err := s.syncStatus(ctx, nil); err != nil {
 				return fmt.Errorf("batchjob %s: failed to sync status: %w", batchJob.Name, err)
 			}
@@ -141,4 +145,19 @@ func (s *syncer) jobRequiresRestart(job radixv1.RadixBatchJob) bool {
 	})
 
 	return !found || job.Restart != currentStatus.Restart
+}
+
+func (s *syncer) isBatchDone() bool {
+	return s.radixBatch.Status.Condition.Type == radixv1.BatchConditionTypeCompleted
+}
+
+func (s *syncer) isBatchJobDone(batchJobName string) bool {
+	return slice.Any(s.radixBatch.Status.JobStatuses,
+		func(jobStatus radixv1.RadixBatchJobStatus) bool {
+			return jobStatus.Name == batchJobName && isJobStatusDone(jobStatus)
+		})
+}
+
+func (s *syncer) isRestartRequestedForAnyBatchJob() bool {
+	return slice.Any(s.radixBatch.Spec.Jobs, s.jobRequiresRestart)
 }

--- a/pkg/apis/batch/utils.go
+++ b/pkg/apis/batch/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/equinor/radix-common/utils"
-	"github.com/equinor/radix-common/utils/slice"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	radixlabels "github.com/equinor/radix-operator/pkg/apis/utils/labels"
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,21 +31,10 @@ func isJobStatusWaiting(jobStatus radixv1.RadixBatchJobStatus) bool {
 	return jobStatus.Phase == radixv1.BatchJobPhaseWaiting
 }
 
-func isBatchDone(batch *radixv1.RadixBatch) bool {
-	return batch.Status.Condition.Type == radixv1.BatchConditionTypeCompleted
-}
-
 func isJobStatusDone(jobStatus radixv1.RadixBatchJobStatus) bool {
 	return jobStatus.Phase == radixv1.BatchJobPhaseSucceeded ||
 		jobStatus.Phase == radixv1.BatchJobPhaseFailed ||
 		jobStatus.Phase == radixv1.BatchJobPhaseStopped
-}
-
-func isBatchJobDone(batch *radixv1.RadixBatch, batchJobName string) bool {
-	return slice.Any(batch.Status.JobStatuses,
-		func(jobStatus radixv1.RadixBatchJobStatus) bool {
-			return jobStatus.Name == batchJobName && isJobStatusDone(jobStatus)
-		})
 }
 
 func ownerReference(job *radixv1.RadixBatch) []metav1.OwnerReference {


### PR DESCRIPTION
A bug in RadixBatch status update function caused jobStatus.Phase to be set to empty string. Since this is not an allowed values, the update failed causing the RB to be resynced over and over because the jobStatus.Restart was not updated either. 