### PR TITLE
use deterministric rand function when trimming environment name in imagetag

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.50.0
-appVersion: 1.70.0
+version: 1.50.1
+appVersion: 1.70.1
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pipeline-runner/steps/applyconfig/step.go
+++ b/pipeline-runner/steps/applyconfig/step.go
@@ -360,7 +360,7 @@ func setPipelineBuildComponentImages(pipelineInfo *model.PipelineInfo, component
 func getLengthLimitedName(name string) string {
 	validatedName := strings.ToLower(name)
 	if len(validatedName) > 10 {
-		return fmt.Sprintf("%s-%s", validatedName[:5], strings.ToLower(commonutils.RandString(4)))
+		return fmt.Sprintf("%s-%s", validatedName[:5], strings.ToLower(commonutils.RandStringStrSeed(4, name)))
 	}
 	return validatedName
 }

--- a/pipeline-runner/steps/applyconfig/step.go
+++ b/pipeline-runner/steps/applyconfig/step.go
@@ -360,7 +360,7 @@ func setPipelineBuildComponentImages(pipelineInfo *model.PipelineInfo, component
 func getLengthLimitedName(name string) string {
 	validatedName := strings.ToLower(name)
 	if len(validatedName) > 10 {
-		return fmt.Sprintf("%s-%s", validatedName[:5], strings.ToLower(commonutils.RandStringStrSeed(4, name)))
+		return fmt.Sprintf("%s-%s", validatedName[:5], strings.ToLower(commonutils.RandStringStrSeed(4, validatedName)))
 	}
 	return validatedName
 }


### PR DESCRIPTION
radix-pipeline uses environment name as part of imagename when building components. If environment name exceeds 10 chars, it is trimmed to 5 chars and suffixed with a random 4 char string. This will generate a new image name for every build, causing ACR to be filled up with a lot of repositories.

This change will use a the environment name as seed to the rand function, and the value will therefore be deterministic, and not produce a new image name for every build