### PR TITLE
Refactor user and admin rbac

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.50.2
-appVersion: 1.70.2
+version: 1.51.0
+appVersion: 1.71.0
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/aggregate-rbac.yaml
+++ b/charts/radix-operator/templates/aggregate-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "radix-operator.fullname" . }}-view
+  labels:
+    {{- include "radix-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - radix.equinor.com
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "radix-operator.fullname" . }}-edit
+  labels:
+    {{- include "radix-operator.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - radix.equinor.com
+  resources:
+  - "*"
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/charts/radix-operator/templates/deployment.yaml
+++ b/charts/radix-operator/templates/deployment.yaml
@@ -41,13 +41,8 @@ spec:
               value: {{ .Values.appAliasBaseURL }}
             - name: RADIXOPERATOR_CLUSTER_TYPE
               value: {{ .Values.clusterType }}
-            {{if eq .Values.clusterType "playground"}}
             - name: RADIXOPERATOR_DEFAULT_USER_GROUP
-              value: "{{ .Values.radixGroups.playground }}"
-            {{else}}
-            - name: RADIXOPERATOR_DEFAULT_USER_GROUP
-              value: "{{ .Values.radixGroups.user }}"
-            {{end}}
+              value: "{{ required ".Values.radixGroups.user is required" .Values.radixGroups.user }}"
             # For configuring limit ranges on app namespaces
             - name: RADIXOPERATOR_APP_LIMITS_DEFAULT_MEMORY
               value: {{ .Values.app.limitrange.default.memory | quote }}

--- a/charts/radix-operator/templates/radix-user-groups-rbac.yaml
+++ b/charts/radix-operator/templates/radix-user-groups-rbac.yaml
@@ -1,19 +1,3 @@
-# defines roles for different user groups (e.g. admin or platform users)
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: radix-cluster-admins
-  labels:
-    {{- include "radix-operator.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: "{{ .Values.radixGroups.clusterAdmin }}"
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -41,12 +25,7 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
-  name: "{{ .Values.radixGroups.user }}"
-{{if eq .Values.clusterType "playground"}}
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: "{{ .Values.radixGroups.playground }}"
-{{end}}
+  name: "{{ required ".Values.radixGroups.user is required" .Values.radixGroups.user }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -152,14 +152,12 @@ volumes: []
 # Additional volume mounts to add to the radix-cost-allocation container.
 volumeMounts: []
 
-prometheusName: kube-prometheus
+prometheusName: kube-prometheus # TODO: Remove as it is no longer used
 
 clusterType: development
 
 radixGroups:
-  clusterAdmin: "a5dfa635-dc00-4a28-9ad9-9e7f1e56919d"
-  user: "64b28659-4fe4-4222-8497-85dd7e43e25b"
-  playground: "4b8ec60e-714c-4a9d-8e0a-3e4cfb3c3d31"
+  user: "" # The groupid granting users access to the Radix platform
 
 deploymentsPerEnvironmentHistoryLimit: 10
 pipelineJobsHistoryLimit: 5

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -70,11 +70,7 @@ See table 1.3 for complete listing of permissions
 
 See table 1.3 for complete listing of permissions
 
-### Clusterrole bindings
-
-- radix-cluster-admins
-  - Purpose: Grants full access to administer cluster through the cluster-admin clusterrole for the platform developer
-  - Lives in: default namespace
+Two cluster roles are created for administrative purposes: `radix-operator-view` and `radix-operator-edit`. Rules defined in these roles are aggregated to the built-in cluster roles `view` and `edit`. These cluster roles are intended to be used for granting cluster administrators access to all Radix custom resources. The Helm chart does not define any cluster role bindings to these roles.
 
 ## System User (Service Account) perspective
 
@@ -204,8 +200,6 @@ application|`application`-machine-user|`application`-machine-user-token|role|app
 ||AD-groups|radix-private-image-hubs|role|application|radix-private-image-hubs|rolebinding
 ||AD-groups|radix-app-admin-build-secrets|role|application|radix-app-admin-build-secrets|rolebinding
 ||AD-groups|`application`-machine-user-token|role|application|`application`-machine-user-token|rolebinding
-||radixGroups.clusterAdmin|cluster-admin|clusterrole|global|radix-cluster-admins|clusterrolebinding
-||radixGroups.playground|radix-platform-user|clusterrole|global|radix-platform-user-binding|clusterrolebinding
 ||radixGroups.user|radix-platform-user|clusterrole|global|radix-platform-user-binding|clusterrolebinding
 environment|radix-api|radix-api|clusterrole|global|`environment`-radix-api|clusterrolebinding
 application|radix-tekton|radix-tekton|role|application|radix-tekton|rolebinding
@@ -225,7 +219,6 @@ Source|Type|Resource Name
 charts/radix-operator/templates/radix-user-groups-rbac.yaml|clusterrole|radix-platform-user
 charts/radix-operator/templates/radix-user-groups-rbac.yaml|clusterrole|radix-app-admin
 charts/radix-operator/templates/radix-user-groups-rbac.yaml|clusterrole|radix-app-admin-envs
-charts/radix-operator/templates/radix-user-groups-rbac.yaml|clusterrolebinding|radix-cluster-admins
 charts/radix-operator/templates/radix-user-groups-rbac.yaml|clusterrolebinding|radix-platform-user-binding
 charts/radix-operator/templates/radix-pipeline-rbac.yaml|clusterrole|radix-pipeline-app
 charts/radix-operator/templates/radix-pipeline-rbac.yaml|clusterrole|radix-pipeline-env
@@ -234,6 +227,8 @@ charts/radix-operator/templates/radix-operator-rbac.yaml|clusterrole|radix-opera
 charts/radix-operator/templates/radix-operator-rbac.yaml|clusterrolebinding|radix-operator-new
 charts/radix-operator/templates/radix-apps-rbac.yaml|clusterrole|radix-webhook
 charts/radix-operator/templates/radix-apps-rbac.yaml|clusterrole|radix-api
+charts/radix-operator/templates/aggregate-rbac.yaml|clusterrole|radix-operator-view
+charts/radix-operator/templates/aggregate-rbac.yaml|clusterrole|radix-operator-edit
 pkg/apis/application/serviceaccount.go:applyPipelineServiceAccount|serviceaccount|radix-pipeline
 pkg/apis/application/serviceaccount.go:applyRadixTektonServiceAccount|serviceaccount|radix-tekton
 pkg/apis/application/roles.go:rrUserClusterRole|clusterrole|radix-platform-user-rr-`application`


### PR DESCRIPTION
Remove radix-cluster-admin clusterrole
Refactor hardcoded group id for playground cluster
Configure clusterroles for view and edit all radix resources. Labels on these roles will be picked up by Kubernetes, and rules are copied into the built-in roles `view` and `edit`, which we later can use for just-in-time access to clusters.