### PR TITLE
blobfuse2: set max memory cache for streaming

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.52.2
-appVersion: 1.72.2
+version: 1.52.3
+appVersion: 1.72.3
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/volumemount/defaults.go
+++ b/pkg/apis/volumemount/defaults.go
@@ -11,15 +11,9 @@ const (
 	csiPersistentVolumeClaimNameTemplate = "pvc-%s-%s"              // pvc-<volumename>-<randomstring5>
 	csiPersistentVolumeNameTemplate      = "pv-radixvolumemount-%s" // pv-<guid>
 
-	csiMountOptionGid                       = "gid"                 // Volume mount owner GroupID. Used when drivers do not honor fsGroup securityContext setting
-	csiMountOptionUid                       = "uid"                 // Volume mount owner UserID. Used instead of GroupID
-	csiMountOptionUseAdls                   = "use-adls"            // Use ADLS or Block Blob
-	csiMountOptionStreamingEnabled          = "streaming"           // Enable Streaming
-	csiMountOptionStreamingCache            = "stream-cache-mb"     // Limit total amount of data being cached in memory to conserve memory
-	csiMountOptionStreamingMaxBlocksPerFile = "max-blocks-per-file" // Maximum number of blocks to be cached in memory for streaming
-	csiMountOptionStreamingMaxBuffers       = "max-buffers"         // The total number of buffers to be cached in memory (in MB).
-	csiMountOptionStreamingBlockSize        = "block-size-mb"       // The size of each block to be cached in memory (in MB).
-	csiMountOptionStreamingBufferSize       = "buffer-size-mb"      // The size of each buffer to be cached in memory (in MB).
+	csiMountOptionGid     = "gid"      // Volume mount owner GroupID. Used when drivers do not honor fsGroup securityContext setting
+	csiMountOptionUid     = "uid"      // Volume mount owner UserID. Used instead of GroupID
+	csiMountOptionUseAdls = "use-adls" // Use ADLS or Block Blob
 
 	csiVolumeAttributeProtocolParameterFuse  = "fuse"  // Protocol "blobfuse"
 	csiVolumeAttributeProtocolParameterFuse2 = "fuse2" // Protocol "blobfuse2"

--- a/pkg/apis/volumemount/volumemount.go
+++ b/pkg/apis/volumemount/volumemount.go
@@ -620,7 +620,7 @@ func getStreamingMountOptions(streaming *radixv1.RadixVolumeMountStreaming) []st
 	if streaming != nil && streaming.Enabled != nil && !*streaming.Enabled {
 		return nil
 	}
-	mountOptions = append(mountOptions, fmt.Sprintf("--streaming=%t", true))
+	mountOptions = append(mountOptions, "--streaming=true")
 
 	var streamCache uint64 = 250
 	if streaming != nil && streaming.StreamCache != nil {

--- a/pkg/apis/volumemount/volumemount.go
+++ b/pkg/apis/volumemount/volumemount.go
@@ -620,25 +620,25 @@ func getStreamingMountOptions(streaming *radixv1.RadixVolumeMountStreaming) []st
 	if streaming != nil && streaming.Enabled != nil && !*streaming.Enabled {
 		return nil
 	}
-	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%t", csiMountOptionStreamingEnabled, true))
-	if streaming == nil {
-		return mountOptions
+	mountOptions = append(mountOptions, fmt.Sprintf("--streaming=%t", true))
+
+	var streamCache uint64 = 250
+	if streaming != nil && streaming.StreamCache != nil {
+		streamCache = *streaming.StreamCache
 	}
-	if streaming.StreamCache != nil {
-		mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingCache, *streaming.StreamCache))
-	}
-	if streaming.BlockSize != nil {
-		mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingBlockSize, *streaming.BlockSize))
-	}
-	if streaming.BufferSize != nil {
-		mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingBufferSize, *streaming.BufferSize))
-	}
-	if streaming.MaxBuffers != nil {
-		mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingMaxBuffers, *streaming.MaxBuffers))
-	}
-	if streaming.MaxBlocksPerFile != nil {
-		mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingMaxBlocksPerFile, *streaming.MaxBlocksPerFile))
-	}
+	mountOptions = append(mountOptions, fmt.Sprintf("--block-cache-pool-size=%v", streamCache))
+	// if streaming.BlockSize != nil {
+	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingBlockSize, *streaming.BlockSize))
+	// }
+	// if streaming.BufferSize != nil {
+	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingBufferSize, *streaming.BufferSize))
+	// }
+	// if streaming.MaxBuffers != nil {
+	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingMaxBuffers, *streaming.MaxBuffers))
+	// }
+	// if streaming.MaxBlocksPerFile != nil {
+	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingMaxBlocksPerFile, *streaming.MaxBlocksPerFile))
+	// }
 	return mountOptions
 }
 

--- a/pkg/apis/volumemount/volumemount.go
+++ b/pkg/apis/volumemount/volumemount.go
@@ -627,18 +627,6 @@ func getStreamingMountOptions(streaming *radixv1.RadixVolumeMountStreaming) []st
 		streamCache = *streaming.StreamCache
 	}
 	mountOptions = append(mountOptions, fmt.Sprintf("--block-cache-pool-size=%v", streamCache))
-	// if streaming.BlockSize != nil {
-	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingBlockSize, *streaming.BlockSize))
-	// }
-	// if streaming.BufferSize != nil {
-	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingBufferSize, *streaming.BufferSize))
-	// }
-	// if streaming.MaxBuffers != nil {
-	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingMaxBuffers, *streaming.MaxBuffers))
-	// }
-	// if streaming.MaxBlocksPerFile != nil {
-	// 	mountOptions = append(mountOptions, fmt.Sprintf("--%s=%v", csiMountOptionStreamingMaxBlocksPerFile, *streaming.MaxBlocksPerFile))
-	// }
 	return mountOptions
 }
 

--- a/pkg/apis/volumemount/volumemount_test.go
+++ b/pkg/apis/volumemount/volumemount_test.go
@@ -716,10 +716,6 @@ func (s *volumeMountTestSuite) Test_CreateOrUpdateCsiAzureResources() {
 						pv.Spec.MountOptions = getMountOptions(props,
 							"--streaming=true",
 							"--block-cache-pool-size=101",
-							// "--block-size-mb=102",
-							// "--buffer-size-mb=103",
-							// "--max-buffers=104",
-							// "--max-blocks-per-file=105",
 							"--use-adls=false",
 						)
 					}),

--- a/pkg/apis/volumemount/volumemount_test.go
+++ b/pkg/apis/volumemount/volumemount_test.go
@@ -678,7 +678,7 @@ func (s *volumeMountTestSuite) Test_CreateOrUpdateCsiAzureResources() {
 				existingPvs: []corev1.PersistentVolume{},
 				expectedPvs: []corev1.PersistentVolume{
 					createExpectedPv(props, func(pv *corev1.PersistentVolume) {
-						pv.Spec.MountOptions = getMountOptions(props, "--streaming=true", "--use-adls=false")
+						pv.Spec.MountOptions = getMountOptions(props, "--streaming=true", "--block-cache-pool-size=250", "--use-adls=false")
 					}),
 				},
 			}
@@ -715,12 +715,13 @@ func (s *volumeMountTestSuite) Test_CreateOrUpdateCsiAzureResources() {
 					createExpectedPv(props, func(pv *corev1.PersistentVolume) {
 						pv.Spec.MountOptions = getMountOptions(props,
 							"--streaming=true",
-							"--stream-cache-mb=101",
-							"--block-size-mb=102",
-							"--buffer-size-mb=103",
-							"--max-buffers=104",
-							"--max-blocks-per-file=105",
-							"--use-adls=false")
+							"--block-cache-pool-size=101",
+							// "--block-size-mb=102",
+							// "--buffer-size-mb=103",
+							// "--max-buffers=104",
+							// "--max-blocks-per-file=105",
+							"--use-adls=false",
+						)
 					}),
 				},
 			}


### PR DESCRIPTION
Set max memory cache for streaming to 250MB if not defined in radixconfig
Nobody has set any streming options in radixconfig, so I also removed the other streaming flags