### PR TITLE
change default poolSize minimum diskSize for block cache 

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.55.0
-appVersion: 1.75.0
+version: 1.55.1
+appVersion: 1.75.1
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/charts/radix-operator/templates/radixapplication.yaml
+++ b/charts/radix-operator/templates/radixapplication.yaml
@@ -1449,7 +1449,7 @@ spec:
                                         diskSize:
                                           description: |-
                                             Size (in MB) of total disk capacity that block cache can use.
-                                            0 (default) disables disk caching
+                                            0 (default) disables disk caching.
                                           format: int32
                                           minimum: 0
                                           type: integer
@@ -1469,9 +1469,7 @@ spec:
                                         poolSize:
                                           description: |-
                                             Size (in MB) of total memory preallocated for block-cache.
-                                            Minimum value:
-                                            - if prefetchCount > 0: prefetchCount * blockSize
-                                            - if prefetchCount = 0: blockSize
+                                            Minimum value = (prefetchCount + 1) * blockSize
                                           format: int32
                                           minimum: 1
                                           type: integer
@@ -2696,7 +2694,7 @@ spec:
                                   diskSize:
                                     description: |-
                                       Size (in MB) of total disk capacity that block cache can use.
-                                      0 (default) disables disk caching
+                                      0 (default) disables disk caching.
                                     format: int32
                                     minimum: 0
                                     type: integer
@@ -2715,9 +2713,7 @@ spec:
                                   poolSize:
                                     description: |-
                                       Size (in MB) of total memory preallocated for block-cache.
-                                      Minimum value:
-                                      - if prefetchCount > 0: prefetchCount * blockSize
-                                      - if prefetchCount = 0: blockSize
+                                      Minimum value = (prefetchCount + 1) * blockSize
                                     format: int32
                                     minimum: 1
                                     type: integer
@@ -3622,7 +3618,7 @@ spec:
                                         diskSize:
                                           description: |-
                                             Size (in MB) of total disk capacity that block cache can use.
-                                            0 (default) disables disk caching
+                                            0 (default) disables disk caching.
                                           format: int32
                                           minimum: 0
                                           type: integer
@@ -3642,9 +3638,7 @@ spec:
                                         poolSize:
                                           description: |-
                                             Size (in MB) of total memory preallocated for block-cache.
-                                            Minimum value:
-                                            - if prefetchCount > 0: prefetchCount * blockSize
-                                            - if prefetchCount = 0: blockSize
+                                            Minimum value = (prefetchCount + 1) * blockSize
                                           format: int32
                                           minimum: 1
                                           type: integer
@@ -4243,7 +4237,7 @@ spec:
                                   diskSize:
                                     description: |-
                                       Size (in MB) of total disk capacity that block cache can use.
-                                      0 (default) disables disk caching
+                                      0 (default) disables disk caching.
                                     format: int32
                                     minimum: 0
                                     type: integer
@@ -4262,9 +4256,7 @@ spec:
                                   poolSize:
                                     description: |-
                                       Size (in MB) of total memory preallocated for block-cache.
-                                      Minimum value:
-                                      - if prefetchCount > 0: prefetchCount * blockSize
-                                      - if prefetchCount = 0: blockSize
+                                      Minimum value = (prefetchCount + 1) * blockSize
                                     format: int32
                                     minimum: 1
                                     type: integer

--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -1234,7 +1234,7 @@ spec:
                                   diskSize:
                                     description: |-
                                       Size (in MB) of total disk capacity that block cache can use.
-                                      0 (default) disables disk caching
+                                      0 (default) disables disk caching.
                                     format: int32
                                     minimum: 0
                                     type: integer
@@ -1253,9 +1253,7 @@ spec:
                                   poolSize:
                                     description: |-
                                       Size (in MB) of total memory preallocated for block-cache.
-                                      Minimum value:
-                                      - if prefetchCount > 0: prefetchCount * blockSize
-                                      - if prefetchCount = 0: blockSize
+                                      Minimum value = (prefetchCount + 1) * blockSize
                                     format: int32
                                     minimum: 1
                                     type: integer
@@ -1886,7 +1884,7 @@ spec:
                                   diskSize:
                                     description: |-
                                       Size (in MB) of total disk capacity that block cache can use.
-                                      0 (default) disables disk caching
+                                      0 (default) disables disk caching.
                                     format: int32
                                     minimum: 0
                                     type: integer
@@ -1905,9 +1903,7 @@ spec:
                                   poolSize:
                                     description: |-
                                       Size (in MB) of total memory preallocated for block-cache.
-                                      Minimum value:
-                                      - if prefetchCount > 0: prefetchCount * blockSize
-                                      - if prefetchCount = 0: blockSize
+                                      Minimum value = (prefetchCount + 1) * blockSize
                                     format: int32
                                     minimum: 1
                                     type: integer

--- a/json-schema/radixapplication.json
+++ b/json-schema/radixapplication.json
@@ -1413,7 +1413,7 @@
                                     "type": "integer"
                                   },
                                   "diskSize": {
-                                    "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching",
+                                    "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching.",
                                     "format": "int32",
                                     "minimum": 0,
                                     "type": "integer"
@@ -1431,7 +1431,7 @@
                                     "type": "integer"
                                   },
                                   "poolSize": {
-                                    "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value:\n- if prefetchCount > 0: prefetchCount * blockSize\n- if prefetchCount = 0: blockSize",
+                                    "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value = (prefetchCount + 1) * blockSize",
                                     "format": "int32",
                                     "minimum": 1,
                                     "type": "integer"
@@ -2692,7 +2692,7 @@
                               "type": "integer"
                             },
                             "diskSize": {
-                              "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching",
+                              "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching.",
                               "format": "int32",
                               "minimum": 0,
                               "type": "integer"
@@ -2710,7 +2710,7 @@
                               "type": "integer"
                             },
                             "poolSize": {
-                              "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value:\n- if prefetchCount > 0: prefetchCount * blockSize\n- if prefetchCount = 0: blockSize",
+                              "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value = (prefetchCount + 1) * blockSize",
                               "format": "int32",
                               "minimum": 1,
                               "type": "integer"
@@ -3653,7 +3653,7 @@
                                     "type": "integer"
                                   },
                                   "diskSize": {
-                                    "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching",
+                                    "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching.",
                                     "format": "int32",
                                     "minimum": 0,
                                     "type": "integer"
@@ -3671,7 +3671,7 @@
                                     "type": "integer"
                                   },
                                   "poolSize": {
-                                    "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value:\n- if prefetchCount > 0: prefetchCount * blockSize\n- if prefetchCount = 0: blockSize",
+                                    "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value = (prefetchCount + 1) * blockSize",
                                     "format": "int32",
                                     "minimum": 1,
                                     "type": "integer"
@@ -4283,7 +4283,7 @@
                               "type": "integer"
                             },
                             "diskSize": {
-                              "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching",
+                              "description": "Size (in MB) of total disk capacity that block cache can use.\n0 (default) disables disk caching.",
                               "format": "int32",
                               "minimum": 0,
                               "type": "integer"
@@ -4301,7 +4301,7 @@
                               "type": "integer"
                             },
                             "poolSize": {
-                              "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value:\n- if prefetchCount > 0: prefetchCount * blockSize\n- if prefetchCount = 0: blockSize",
+                              "description": "Size (in MB) of total memory preallocated for block-cache.\nMinimum value = (prefetchCount + 1) * blockSize",
                               "format": "int32",
                               "minimum": 1,
                               "type": "integer"

--- a/pkg/apis/radix/v1/radixapptypes.go
+++ b/pkg/apis/radix/v1/radixapptypes.go
@@ -1187,15 +1187,13 @@ type BlobFuse2BlockCacheOptions struct {
 	BlockSize *uint32 `json:"blockSize,omitempty"`
 
 	// Size (in MB) of total memory preallocated for block-cache.
-	// Minimum value:
-	// - if prefetchCount > 0: prefetchCount * blockSize
-	// - if prefetchCount = 0: blockSize
+	// Minimum value = (prefetchCount + 1) * blockSize
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	PoolSize *uint32 `json:"poolSize,omitempty"`
 
 	// Size (in MB) of total disk capacity that block cache can use.
-	// 0 (default) disables disk caching
+	// 0 (default) disables disk caching.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	DiskSize *uint32 `json:"diskSize,omitempty"`

--- a/pkg/apis/volumemount/persistentvolumebuilder.go
+++ b/pkg/apis/volumemount/persistentvolumebuilder.go
@@ -313,15 +313,17 @@ func (b *blobfuse2PersistentVolumeSpecBuilder) blockCacheMountOptions() []string
 		}
 	}
 
+	minPoolSize := (prefetchCount + 1) * blockSize // Memory pool must be set to fit at least the block we read + blocks read by prefetch
 	opts = append(opts, fmt.Sprintf("--block-cache-block-size=%d", blockSize))
-	opts = append(opts, fmt.Sprintf("--block-cache-pool-size=%d", max(poolSize, max(1, prefetchCount)*blockSize)))
+	opts = append(opts, fmt.Sprintf("--block-cache-pool-size=%d", max(poolSize, minPoolSize)))
 	opts = append(opts, fmt.Sprintf("--block-cache-prefetch=%d", prefetchCount))
 	opts = append(opts, fmt.Sprintf("--block-cache-prefetch-on-open=%t", prefetchOnOpen && prefetchCount > 0))
 	opts = append(opts, fmt.Sprintf("--block-cache-parallelism=%d", parallelism))
 
 	if diskSize > 0 {
+		minDiskSize := (prefetchCount + 1) * blockSize // Disk dize must be set to fit at least the block we read + blocks read by prefetch
 		opts = append(opts, fmt.Sprintf("--block-cache-path=%s", fmt.Sprintf("/mnt/%s#blockcache", b.getVolumeHandle())))
-		opts = append(opts, fmt.Sprintf("--block-cache-disk-size=%d", max(diskSize, max(1, prefetchCount)*blockSize)))
+		opts = append(opts, fmt.Sprintf("--block-cache-disk-size=%d", max(diskSize, minDiskSize)))
 		opts = append(opts, fmt.Sprintf("--block-cache-disk-timeout=%d", diskTimeout))
 	}
 

--- a/pkg/apis/volumemount/volumemount_test.go
+++ b/pkg/apis/volumemount/volumemount_test.go
@@ -1281,7 +1281,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
@@ -1309,7 +1309,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--read-only=true",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
@@ -1430,7 +1430,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
@@ -1463,7 +1463,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
 				"--block-cache-block-size=16",
-				"--block-cache-pool-size=320",
+				"--block-cache-pool-size=336",
 				"--block-cache-prefetch=20",
 			},
 		},
@@ -1476,7 +1476,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 					CacheMode: pointers.Ptr(radixv1.BlobFuse2CacheModeBlock),
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](16),
-						PoolSize:      pointers.Ptr[uint32](319),
+						PoolSize:      pointers.Ptr[uint32](335),
 						PrefetchCount: pointers.Ptr[uint32](20),
 					},
 				},
@@ -1495,7 +1495,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
 				"--block-cache-block-size=16",
-				"--block-cache-pool-size=320",
+				"--block-cache-pool-size=336",
 				"--block-cache-prefetch=20",
 			},
 		},
@@ -1508,7 +1508,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 					CacheMode: pointers.Ptr(radixv1.BlobFuse2CacheModeBlock),
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](16),
-						PoolSize:      pointers.Ptr[uint32](321),
+						PoolSize:      pointers.Ptr[uint32](337),
 						PrefetchCount: pointers.Ptr[uint32](20),
 					},
 				},
@@ -1527,7 +1527,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
 				"--block-cache-block-size=16",
-				"--block-cache-pool-size=321",
+				"--block-cache-pool-size=337",
 				"--block-cache-prefetch=20",
 			},
 		},
@@ -1586,7 +1586,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-parallelism=8",
 				"--block-cache-prefetch-on-open=true",
@@ -1616,7 +1616,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=1337",
@@ -1646,7 +1646,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
@@ -1682,7 +1682,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=4",
-				"--block-cache-pool-size=44",
+				"--block-cache-pool-size=48",
 				"--block-cache-prefetch=11",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
@@ -1719,11 +1719,11 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVSpec_MountOptions() {
 				"--attr-cache-timeout=0",
 				"--block-cache",
 				"--block-cache-block-size=16",
-				"--block-cache-pool-size=320",
+				"--block-cache-pool-size=336",
 				"--block-cache-prefetch=20",
 				"--block-cache-prefetch-on-open=false",
 				"--block-cache-parallelism=8",
-				"--block-cache-disk-size=320",
+				"--block-cache-disk-size=336",
 				"--block-cache-disk-timeout=120",
 			},
 			expectedMountOptionsArgNameOnly: []string{
@@ -2341,7 +2341,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: set StorageAccount should recreate PV and PVCx": {
+		"blobfuse2: set StorageAccount should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2357,7 +2357,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: change StorageAccount should recreate PV and PVCx": {
+		"blobfuse2: change StorageAccount should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2374,7 +2374,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: set UseAzureIdentity to the defined default should not recreate PV and PVCx": {
+		"blobfuse2: set UseAzureIdentity to the defined default should not recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2390,7 +2390,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: false,
 		},
-		"blobfuse2: set UseAzureIdentity to non-default should recreate PV and PVCx": {
+		"blobfuse2: set UseAzureIdentity to non-default should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2406,7 +2406,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: set ResourceGroup when UseAzureIdentity=false should not recreate PV and PVCx": {
+		"blobfuse2: set ResourceGroup when UseAzureIdentity=false should not recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2425,7 +2425,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: false,
 		},
-		"blobfuse2: change ResourceGroup when UseAzureIdentity=true should recreate PV and PVCx": {
+		"blobfuse2: change ResourceGroup when UseAzureIdentity=true should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2444,7 +2444,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: change SubscriptionId when UseAzureIdentity=false should not recreate PV and PVCx": {
+		"blobfuse2: change SubscriptionId when UseAzureIdentity=false should not recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2463,7 +2463,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: false,
 		},
-		"blobfuse2: change SubscriptionId when UseAzureIdentity=true should recreate PV and PVCx": {
+		"blobfuse2: change SubscriptionId when UseAzureIdentity=true should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2482,7 +2482,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: change TenantId when UseAzureIdentity=false should not recreate PV and PVCx": {
+		"blobfuse2: change TenantId when UseAzureIdentity=false should not recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2501,7 +2501,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: false,
 		},
-		"blobfuse2: change TenantId when UseAzureIdentity=true should recreate PV and PVCx": {
+		"blobfuse2: change TenantId when UseAzureIdentity=true should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2520,7 +2520,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			},
 			expectRecreate: true,
 		},
-		"blobfuse2: change Identity.Azure.ClientID when UseAzureIdentity=false should not recreate PV and PVCx": {
+		"blobfuse2: change Identity.Azure.ClientID when UseAzureIdentity=false should not recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -2539,7 +2539,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 			changedIdentity: &radixv1.Identity{Azure: &radixv1.AzureIdentity{ClientId: "change"}},
 			expectRecreate:  false,
 		},
-		"blobfuse2: change Identity.Azure.ClientID when UseAzureIdentity=true should recreate PV and PVCx": {
+		"blobfuse2: change Identity.Azure.ClientID when UseAzureIdentity=true should recreate PV and PVC": {
 			initialVolumeMount: radixv1.RadixVolumeMount{
 				Name: "any",
 				BlobFuse2: &radixv1.RadixBlobFuse2VolumeMount{
@@ -3086,7 +3086,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](8),
 						PrefetchCount: pointers.Ptr[uint32](20),
-						PoolSize:      pointers.Ptr[uint32](160),
+						PoolSize:      pointers.Ptr[uint32](168),
 					},
 				},
 			},
@@ -3112,7 +3112,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](8),
 						PrefetchCount: pointers.Ptr[uint32](20),
-						PoolSize:      pointers.Ptr[uint32](161),
+						PoolSize:      pointers.Ptr[uint32](169),
 					},
 				},
 			},
@@ -3138,7 +3138,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](8),
 						PrefetchCount: pointers.Ptr[uint32](20),
-						PoolSize:      pointers.Ptr[uint32](159),
+						PoolSize:      pointers.Ptr[uint32](167),
 					},
 				},
 			},
@@ -3324,7 +3324,6 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](8),
 						PrefetchCount: pointers.Ptr[uint32](20),
-						DiskSize:      pointers.Ptr[uint32](160),
 					},
 				},
 			},
@@ -3336,7 +3335,7 @@ func (s *volumeMountTestSuite) Test_RadixVolumeMountPVAndPVCRecreateOnChange() {
 					BlockCacheOptions: &radixv1.BlobFuse2BlockCacheOptions{
 						BlockSize:     pointers.Ptr[uint32](8),
 						PrefetchCount: pointers.Ptr[uint32](20),
-						DiskSize:      pointers.Ptr[uint32](161),
+						DiskSize:      pointers.Ptr[uint32](169),
 					},
 				},
 			},


### PR DESCRIPTION
Set default (and min allowed) poolSize to (prefetch + 1) * blockSize, and minimum diskSize, when set, to the same.

This is because the blob csi driver will read one block from the current file position + prefetch x number of blocks. Both the current block and prefetched blocks must be stored in memory, and poolSize must therefore be set to a value that fits both.