### PR TITLE
fix: unable to promote RD when imageTagName is missing in target environment

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.60.0
-appVersion: 1.80.1
+version: 1.60.2
+appVersion: 1.80.2
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pipeline-runner/steps/applyconfig/step.go
+++ b/pipeline-runner/steps/applyconfig/step.go
@@ -61,17 +61,17 @@ func (step *ApplyConfigStepImplementation) Run(ctx context.Context, pipelineInfo
 	if err := step.setBuildSecret(pipelineInfo); err != nil {
 		return err
 	}
-	if err := step.setBuildAndDeployImages(ctx, pipelineInfo); err != nil {
-		return err
-	}
-	if err := step.validatePipelineInfo(pipelineInfo); err != nil {
-		return err
-	}
+
 	if slice.Any([]radixv1.RadixPipelineType{radixv1.Build, radixv1.BuildDeploy, radixv1.Deploy}, pipelineInfo.IsPipelineType) {
 		if err := step.setBuildAndDeployImages(ctx, pipelineInfo); err != nil {
 			return err
 		}
 	}
+
+	if err := step.validatePipelineInfo(pipelineInfo); err != nil {
+		return err
+	}
+
 	return step.applyRadixApplication(ctx, pipelineInfo)
 }
 


### PR DESCRIPTION
This was previously fixed in https://github.com/equinor/radix-operator/issues/1351, but due to missing tests, the changes were reverted/reintroduced in https://github.com/equinor/radix-operator/pull/1354