### PR TITLE
fix: use go-git checkout with force: true to discard local changes

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.61.2
-appVersion: 1.81.2
+version: 1.61.3
+appVersion: 1.81.3
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pipeline-runner/utils/git/git_test.go
+++ b/pipeline-runner/utils/git/git_test.go
@@ -296,17 +296,6 @@ func Test_Checkout(t *testing.T) {
 	}
 }
 
-func Test_Checkout_FailsIfDirty(t *testing.T) {
-	gitWorkspacePath := setupGitTest("test-data-git-commits.zip", "test-data-git-commits")
-	defer tearDownGitTest()
-	repo, err := git.Open(gitWorkspacePath)
-	require.NoError(t, err)
-	err = os.WriteFile(path.Join(gitWorkspacePath, "radixconfig.yaml"), []byte("newdata"), 0664)
-	require.NoError(t, err)
-	err = repo.Checkout("feature")
-	assert.ErrorIs(t, err, git.ErrUnstagedChanges)
-}
-
 func Test_ResolveCommitForReference(t *testing.T) {
 	tests := map[string]struct {
 		reference      string


### PR DESCRIPTION
Setting `Force: true` in Checkout discards local changes. This prevents "worktree contains unstaged changes" error usually caused by files defined in .gitattributes