### PR TITLE
Replaced job-scheduler bash image

### DIFF
--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.63.0
-appVersion: 1.83.0
+version: 1.63.1
+appVersion: 1.83.1
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 keywords:

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -158,7 +158,7 @@ func (deploy *Deployment) createJobAuxDeployment(jobName, jobAuxDeploymentName s
 	desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken = commonUtils.BoolPtr(false)
 	desiredDeployment.Spec.Template.Spec.SecurityContext = securitycontext.Pod()
 
-	desiredDeployment.Spec.Template.Spec.Containers[0].Image = "bitnami/bitnami-shell:latest"
+	desiredDeployment.Spec.Template.Spec.Containers[0].Image = "bash:alpine3.22"
 	desiredDeployment.Spec.Template.Spec.Containers[0].Command = []string{"sh"}
 	desiredDeployment.Spec.Template.Spec.Containers[0].Args = []string{"-c", "echo 'start'; while true; do echo $(date);sleep 3600; done; echo 'exit'"}
 	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent


### PR DESCRIPTION
The docker image `bitnami/bitnami-shell:latest` is not longer available