### PR TITLE
feat: replace bitnami/redis image

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -164,7 +164,7 @@
 				"RADIX_APP_CONTAINER_REGISTRY": "radixdevapp.azurecr.io",
 				"RADIX_OAUTH_PROXY_DEFAULT_OIDC_ISSUER_URL": "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0",
 				"RADIX_OAUTH_PROXY_IMAGE": "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0",
-                "RADIX_OAUTH_REDIS_IMAGE": "bitnami/redis:8.0",
+                "RADIX_OAUTH_REDIS_IMAGE": "docker.io/library/redis:8.0",
                 "RADIXOPERATOR_TENANT_ID": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
 				"KUBERNETES_SERVICE_PORT": "443",
 				"REGISTRATION_CONTROLLER_THREADS": "10",

--- a/charts/radix-operator/Chart.yaml
+++ b/charts/radix-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radix-operator
-version: 1.67.1
-appVersion: 1.87.1
+version: 1.67.2
+appVersion: 1.87.2
 kubeVersion: ">=1.24.0"
 description: Radix Operator
 icon:  https://radix.equinor.com/images/logos/logo.svg

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -168,7 +168,7 @@ logLevel: "INFO"
 logPretty: false
 oauthProxyDefaultIssuerUrl: https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0
 oauthProxyImage: quay.io/oauth2-proxy/oauth2-proxy:v7.2.0
-oauthRedisImage: bitnami/redis:8.0
+oauthRedisImage: docker.io/redis:8.0
 externalRegistryDefaultAuthSecret: "" # Name of the secret containing default container registry credentials for pulling images when building with buildah and pulling external images for components and jobs
 
 seccompProfile:


### PR DESCRIPTION
## TODO:
- [x] bitnami/redis

How to release/sync operator deployment with updated chart?

- Suspend GitRepo `radix-operator` (avoid syncing chart prematurely)
- Suspend flux-system ks to avoid updating radix-operator image prematurely
- Suspend Flux until both chart and docker images is ready

Suspend everything?