### PR TITLE
fix: remove RADIX_ACTIVE_CLUSTER_EGRESS_IPS handling from configuration and tests

### DIFF
--- a/charts/radix-operator/templates/radix-config.yaml
+++ b/charts/radix-operator/templates/radix-config.yaml
@@ -8,4 +8,3 @@ metadata:
 data:
   clustername: {{ .Values.clusterName }}
   subscriptionId: {{ .Values.subscriptionId }}
-  clusterActiveEgressIps: {{ .Values.clusterActiveEgressIps }}

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -2,7 +2,6 @@
 nameOverride: ""
 fullnameOverride: ""
 clusterName: xx
-clusterActiveEgressIps: xx
 
 registrationControllerThreads: 1
 applicationControllerThreads: 1

--- a/operator/deployment/controller_test.go
+++ b/operator/deployment/controller_test.go
@@ -35,7 +35,7 @@ func setupTest(t *testing.T) (*test.Utils, *kubefake.Clientset, *kube.Kube, *fak
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	kubeUtil, _ := kube.New(client, radixClient, kedaClient, secretproviderclient)
 	handlerTestUtils := test.NewTestUtils(client, radixClient, kedaClient, secretproviderclient)
-	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	require.NoError(t, err)
 	prometheusClient := prometheusfake.NewSimpleClientset()
 	certClient := certfake.NewSimpleClientset()

--- a/operator/job/controller_test.go
+++ b/operator/job/controller_test.go
@@ -50,7 +50,7 @@ func (s *jobTestSuite) SetupTest() {
 	s.kubeUtil, _ = kube.New(fake.NewSimpleClientset(), fakeradix.NewSimpleClientset(), kedaClient, secretProviderClient)
 	s.promClient = prometheusfake.NewSimpleClientset()
 	s.tu = test.NewTestUtils(s.kubeUtil.KubeClient(), s.kubeUtil.RadixClient(), kedaClient, secretProviderClient)
-	err := s.tu.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := s.tu.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	s.Require().NoError(err)
 }
 

--- a/operator/registration/controller_test.go
+++ b/operator/registration/controller_test.go
@@ -30,7 +30,7 @@ func setupTest(t *testing.T) (kubernetes.Interface, *kube.Kube, radixclient.Inte
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	kubeUtil, _ := kube.New(client, radixClient, kedaClient, secretproviderclient)
 	handlerTestUtils := test.NewTestUtils(client, radixClient, kedaClient, secretproviderclient)
-	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	require.NoError(t, err)
 	return client, kubeUtil, radixClient
 }

--- a/pipeline-runner/internal/runner/app_test.go
+++ b/pipeline-runner/internal/runner/app_test.go
@@ -25,7 +25,7 @@ func setupTest(t *testing.T) (*kubernetes.Clientset, *radix.Clientset, *kedafake
 	kedaClient := kedafake.NewSimpleClientset()
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	testUtils := commonTest.NewTestUtils(kubeclient, radixclient, kedaClient, secretproviderclient)
-	err := testUtils.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := testUtils.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	require.NoError(t, err)
 	return kubeclient, radixclient, kedaClient, secretproviderclient, testUtils
 }

--- a/pipeline-runner/steps/promote/step_test.go
+++ b/pipeline-runner/steps/promote/step_test.go
@@ -38,7 +38,7 @@ func setupTest(t *testing.T) (*kubernetes.Clientset, *kube.Kube, *radix.Clientse
 	kedaClient := kedafake.NewSimpleClientset()
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	testUtils := commonTest.NewTestUtils(kubeclient, radixclient, kedaClient, secretproviderclient)
-	err := testUtils.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := testUtils.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	require.NoError(t, err)
 	kubeUtil, _ := kube.New(kubeclient, radixclient, kedaClient, secretproviderclient)
 

--- a/pkg/apis/application/application_test.go
+++ b/pkg/apis/application/application_test.go
@@ -32,7 +32,7 @@ func setupTest(t *testing.T) (test.Utils, kubernetes.Interface, *kube.Kube, radi
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	kubeUtil, _ := kube.New(client, radixClient, kedaClient, secretproviderclient)
 	handlerTestUtils := test.NewTestUtils(client, radixClient, kedaClient, secretproviderclient)
-	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	require.NoError(t, err)
 	return handlerTestUtils, client, kubeUtil, radixClient, kedaClient
 }

--- a/pkg/apis/applicationconfig/applicationconfig_test.go
+++ b/pkg/apis/applicationconfig/applicationconfig_test.go
@@ -42,7 +42,7 @@ func setupTest(t *testing.T) (*test.Utils, kubernetes.Interface, *kube.Kube, rad
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	kubeUtil, _ := kube.New(kubeClient, radixClient, kedaClient, secretproviderclient)
 	handlerTestUtils := test.NewTestUtils(kubeClient, radixClient, kedaClient, secretproviderclient)
-	err := handlerTestUtils.CreateClusterPrerequisites(clusterName, "0.0.0.0", "anysubid")
+	err := handlerTestUtils.CreateClusterPrerequisites(clusterName, "anysubid")
 	require.NoError(t, err)
 	return &handlerTestUtils, kubeClient, kubeUtil, radixClient
 }

--- a/pkg/apis/defaults/environment_variables.go
+++ b/pkg/apis/defaults/environment_variables.go
@@ -106,9 +106,6 @@ const (
 	// RadixImageTagNameEnvironmentVariable Image tag name for Radix application components
 	RadixImageTagNameEnvironmentVariable = "IMAGE_TAG_NAME"
 
-	// RadixActiveClusterEgressIpsEnvironmentVariable IPs assigned to the cluster
-	RadixActiveClusterEgressIpsEnvironmentVariable = "RADIX_ACTIVE_CLUSTER_EGRESS_IPS"
-
 	// RadixOAuthProxyDefaultOIDCIssuerURLEnvironmentVariable Default OIDC issuer URL for OAuth Proxy
 	RadixOAuthProxyDefaultOIDCIssuerURLEnvironmentVariable = "RADIX_OAUTH_PROXY_DEFAULT_OIDC_ISSUER_URL"
 

--- a/pkg/apis/environment/environment_test.go
+++ b/pkg/apis/environment/environment_test.go
@@ -44,7 +44,7 @@ func setupTest(t *testing.T) (test.Utils, kubernetes.Interface, *kube.Kube, radi
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	kubeUtil, _ := kube.New(fakekube, fakeradix, kedaClient, secretproviderclient)
 	handlerTestUtils := test.NewTestUtils(fakekube, fakeradix, kedaClient, secretproviderclient)
-	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "0.0.0.0", "anysubid")
+	err := handlerTestUtils.CreateClusterPrerequisites("AnyClusterName", "anysubid")
 	require.NoError(t, err)
 
 	_ = os.Setenv(defaults.OperatorEnvLimitDefaultRequestCPUEnvironmentVariable, limitDefaultReqestCPU)

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -41,7 +41,6 @@ type RadixJobTestSuiteBase struct {
 	radixClient radixclient.Interface
 	config      struct {
 		clusterName    string
-		egressIps      string
 		builderImage   string
 		buildkitImage  string
 		buildahSecComp string
@@ -57,7 +56,6 @@ type RadixJobTestSuiteBase struct {
 func (s *RadixJobTestSuiteBase) SetupSuite() {
 	s.config = struct {
 		clusterName    string
-		egressIps      string
 		builderImage   string
 		buildkitImage  string
 		buildahSecComp string
@@ -69,7 +67,6 @@ func (s *RadixJobTestSuiteBase) SetupSuite() {
 		subscriptionID string
 	}{
 		clusterName:    "AnyClusterName",
-		egressIps:      "0.0.0.0",
 		builderImage:   "docker.io/builder:any",
 		buildkitImage:  "docker.io/buildkit:any",
 		buildahSecComp: "anyseccomp",
@@ -94,7 +91,7 @@ func (s *RadixJobTestSuiteBase) setupTest() {
 	secretproviderclient := secretproviderfake.NewSimpleClientset()
 	kubeUtil, _ := kube.New(kubeClient, radixClient, kedaClient, secretproviderclient)
 	handlerTestUtils := test.NewTestUtils(kubeClient, radixClient, kedaClient, secretproviderclient)
-	err := handlerTestUtils.CreateClusterPrerequisites(s.config.clusterName, s.config.egressIps, s.config.subscriptionID)
+	err := handlerTestUtils.CreateClusterPrerequisites(s.config.clusterName, s.config.subscriptionID)
 	s.Require().NoError(err)
 	s.testUtils, s.kubeClient, s.kubeUtils, s.radixClient = &handlerTestUtils, kubeClient, kubeUtil, radixClient
 

--- a/pkg/apis/kube/radix_config.go
+++ b/pkg/apis/kube/radix_config.go
@@ -8,10 +8,9 @@ import (
 )
 
 const (
-	configMapName          = "radix-config"
-	clusterNameConfig      = "clustername"
-	subscriptionIdConfig   = "subscriptionId"
-	clusterActiveEgressIps = "clusterActiveEgressIps"
+	configMapName        = "radix-config"
+	clusterNameConfig    = "clustername"
+	subscriptionIdConfig = "subscriptionId"
 )
 
 // GetClusterName Gets the global name of the cluster from config map in default namespace
@@ -22,11 +21,6 @@ func (kubeutil *Kube) GetClusterName(ctx context.Context) (string, error) {
 // GetSubscriptionId Gets the subscription-id from config map in default namespace
 func (kubeutil *Kube) GetSubscriptionId(ctx context.Context) (string, error) {
 	return kubeutil.getRadixConfigFromMap(ctx, subscriptionIdConfig)
-}
-
-// GetClusterActiveEgressIps Gets cluster active ips from config map in default namespace
-func (kubeutil *Kube) GetClusterActiveEgressIps(ctx context.Context) (string, error) {
-	return kubeutil.getRadixConfigFromMap(ctx, clusterActiveEgressIps)
 }
 
 func (kubeutil *Kube) getRadixConfigFromMap(ctx context.Context, config string) (string, error) {

--- a/pkg/apis/test/utils.go
+++ b/pkg/apis/test/utils.go
@@ -307,7 +307,7 @@ func SetRequiredEnvironmentVariables() {
 }
 
 // CreateClusterPrerequisites Will do the needed setup which is part of radix boot
-func (tu *Utils) CreateClusterPrerequisites(clustername, egressIps, subscriptionId string) error {
+func (tu *Utils) CreateClusterPrerequisites(clustername, subscriptionId string) error {
 	SetRequiredEnvironmentVariables()
 
 	var errs []error
@@ -334,9 +334,8 @@ func (tu *Utils) CreateClusterPrerequisites(clustername, egressIps, subscription
 				Namespace: corev1.NamespaceDefault,
 			},
 			Data: map[string]string{
-				"clustername":            clustername,
-				"clusterActiveEgressIps": egressIps,
-				"subscriptionId":         subscriptionId,
+				"clustername":    clustername,
+				"subscriptionId": subscriptionId,
 			},
 		},
 		metav1.CreateOptions{})


### PR DESCRIPTION
This pull request removes support for the `RADIX_ACTIVE_CLUSTER_EGRESS_IPS` environment variable throughout the codebase.

**Environment variable support removal:**

* Removed the `RADIX_ACTIVE_CLUSTER_EGRESS_IPS` constant from `pkg/apis/defaults/environment_variables.go` and its usage from environment variable source decorators and environment variable generation logic in `pkg/apis/deployment/environmentvariables.go`. [[1]](diffhunk://#diff-363eab80e50076591556a86f099ed45e2121f8abe4f35f2e10c44cefda3d5bebL109-L111) [[2]](diffhunk://#diff-8fc64626165dbb70f08d2b2dccaa4fe8b9aff040d2741b5875d0e45a1d073ce8L24) [[3]](diffhunk://#diff-8fc64626165dbb70f08d2b2dccaa4fe8b9aff040d2741b5875d0e45a1d073ce8L48-L51) [[4]](diffhunk://#diff-8fc64626165dbb70f08d2b2dccaa4fe8b9aff040d2741b5875d0e45a1d073ce8L76-L83) [[5]](diffhunk://#diff-8fc64626165dbb70f08d2b2dccaa4fe8b9aff040d2741b5875d0e45a1d073ce8L235-L242)

**Configuration cleanup:**

* Removed the `clusterActiveEgressIps` field from `charts/radix-operator/templates/radix-config.yaml` and `charts/radix-operator/values.yaml`. [[1]](diffhunk://#diff-e60ee5a9ff55b3739e7e3f9d5ad7c0c788017d5a1b01b96e4a39e98a40768874L11) [[2]](diffhunk://#diff-94d0b33fd2a6b8d04ed23b74e75ce42290476a52311806ca55230e3d6be5ab7dL5)

**Test code updates:**

* Updated test setups across multiple test files to remove references to cluster egress IPs, including removing the argument from `CreateClusterPrerequisites` calls and related struct fields and variables. [[1]](diffhunk://#diff-0ff49d4e68ef3d0d91e7b65f3cef1ef0d4d6d4b54578f964c0be034c59e38ff4L38-R38) [[2]](diffhunk://#diff-00b124cda1cbaff8cc8105f83527b41f2988c1f5ee97a67ab835f0f20227cc78L53-R53) [[3]](diffhunk://#diff-c95330377dcb7b3fcec249eb09dc8f6c2aac4780ec0d5a261df2cce04f4d2f6cL33-R33) [[4]](diffhunk://#diff-636617ba8b923ba9ca1477652bd00e69adab89243c211de0d0f93407ea4b1170L28-R28) [[5]](diffhunk://#diff-88147985850bf7beeaa20d3643e7db15ce9606e12c6404170d0de4a8d74c70e1L41-R41) [[6]](diffhunk://#diff-24ba218d40b3acba0cd4f2b0ded07a190b8c8741f59e9da912847832afc2b8f4L35-R35) [[7]](diffhunk://#diff-a803340a8e220b95889b40025b23b5fc59687342d7a6f96f083533af1bedb218L45-R45) [[8]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L64) [[9]](diffhunk://#diff-1d083212619115275d405064ebfc7d6a9a185063cdd106efdba3492aa496212dL44) [[10]](diffhunk://#diff-1d083212619115275d405064ebfc7d6a9a185063cdd106efdba3492aa496212dL60) [[11]](diffhunk://#diff-1d083212619115275d405064ebfc7d6a9a185063cdd106efdba3492aa496212dL72) [[12]](diffhunk://#diff-3f3dc6e3d42a76b39f49ded416478f5321719f1c827c8d1fe55da85027ad0570L47-R47)

**Test assertions and environment variable checks:**

* Removed assertions and checks for the egress IP environment variable in deployment and job tests, and updated expected environment variable counts accordingly. [[1]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L95-R94) [[2]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L252-R251) [[3]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L261) [[4]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L292-R290) [[5]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L632-R630) [[6]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L643) [[7]](diffhunk://#diff-228d23f2638f2ec4f5383dc2d69674df1a9888c3e1dcd64fc5e1ad8c9c13dc33L1870-L1878)