### PR TITLE
fix: remove deprecated chart values

### DIFF
--- a/charts/radix-operator/templates/deployment.yaml
+++ b/charts/radix-operator/templates/deployment.yaml
@@ -31,8 +31,6 @@ spec:
               containerPort: {{ .Values.service.internalPort }}
               protocol: TCP
           env:
-            - name: LABEL_PROMETHEUS_INSTANCE
-              value: {{ .Values.prometheusName }}
             - name: DNS_ZONE
               value: {{ .Values.dnsZone }}
             - name: RADIX_ZONE
@@ -83,12 +81,8 @@ spec:
               value: {{ .Values.pipelineJobsHistoryLimit | quote }}
             - name: RADIX_PIPELINE_JOBS_HISTORY_PERIOD_LIMIT
               value: {{ .Values.pipelineJobsHistoryPeriodLimit | quote }}
-            - name: RADIX_IMAGE_BUILDER # deprecated issue #1388
-              value: {{ .Values.imageBuilder }}
             - name: RADIX_IMAGE_BUILDER_IMAGE
               value: {{ .Values.radixImageBuilder.image.repository }}:{{ .Values.radixImageBuilder.image.tag | default "master-latest" }}
-            - name: RADIXOPERATOR_JOB_SCHEDULER # deprecated issue #1388
-              value: {{ .Values.jobScheduler }}
             - name: RADIXOPERATOR_JOB_SCHEDULER_IMAGE
               value: {{ .Values.radixJobScheduler.image.repository }}:{{ .Values.radixJobScheduler.image.tag | default .Chart.AppVersion }}
             - name: LOG_LEVEL
@@ -153,16 +147,10 @@ spec:
             {{- end }}
             - name: SECCOMP_PROFILE_FILENAME
               value: {{ .Values.seccompProfile.fileNameOnNode }}
-            - name: RADIX_BUILDKIT_IMAGE_BUILDER # deprecated issue #1388
-              value: {{ .Values.buildKitImageBuilder }}
             - name: RADIX_BUILDKIT_IMAGE_BUILDER_IMAGE
               value: {{ .Values.radixBuildKitImageBuilder.image.repository }}:{{ .Values.radixBuildKitImageBuilder.image.tag | default "main-latest" }}
-            - name: RADIX_PIPELINE_GIT_CLONE_NSLOOKUP_IMAGE # deprecated issue #1388
-              value: {{ .Values.gitCloneNsLookupImage }}
             - name: RADIX_PIPELINE_GIT_CLONE_GIT_IMAGE
               value: {{ .Values.gitClone.image.repository }}:{{ .Values.gitClone.image.tag | default "latest" }}
-            - name: RADIX_PIPELINE_GIT_CLONE_BASH_IMAGE # deprecated issue #1388
-              value: {{ .Values.gitCloneBashImage }}
             - name: RADIX_RESERVED_APP_DNS_ALIASES
               value: {{ include "helm-toolkit.utils.joinMapWithComma" .Values.reservedAppDNSAlias | quote }}
             - name: RADIX_RESERVED_DNS_ALIASES
@@ -179,8 +167,6 @@ spec:
               value: {{ .Values.task.orphanedEnvironmentsRetentionPeriod }}
             - name: RADIXOPERATOR_ORPHANED_ENVIRONMENTS_CLEANUP_CRON
               value: {{ .Values.task.orphanedEnvironmentsCleanupCron }}
-            - name: RADIXOPERATOR_PIPELINE_IMAGE_TAG # deprecated issue #1388
-              value: {{ .Values.pipelineImageTag }}
             - name: RADIXOPERATOR_PIPELINE_IMAGE
               value: {{ .Values.radixPipelineRunner.image.repository }}:{{ .Values.radixPipelineRunner.image.tag | default .Chart.AppVersion }}
           livenessProbe:

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -12,15 +12,6 @@ alertControllerThreads: 1
 kubeClientRateLimitBurst: 5
 kubeClientRateLimitQPS: 5
 
-imageBuilder: radix-image-builder:master-latest # deprecated issue #1388
-buildKitImageBuilder: radix-buildkit-builder:main-latest # deprecated issue #1388 # TODO: Configure in radix-flux
-jobScheduler: radix-job-scheduler:main-latest # deprecated issue #1388
-
-# Images used by git clone init containers in pipeline
-gitCloneNsLookupImage: "" # deprecated issue #1388 # Image containing nslookup, e.g. "alpine:3.20". Defaults to "alpine:latest" if not set
-gitCloneGitImage: "" # deprecated issue #1388 # Image containing git, e.g. "alpine/git:2.45.2". Defaults to "alpine/git:latest" if not set
-gitCloneBashImage: "" # deprecated issue #1388 # Image containing bash, e.g. "bash:5.2". Defaults to "bash:latest" if not set
-
 reservedAppDNSAlias:
   api: radix-api
   canary: radix-canary-golang
@@ -151,8 +142,6 @@ volumes: []
 # Additional volume mounts to add to the radix-cost-allocation container.
 volumeMounts: []
 
-prometheusName: kube-prometheus # TODO: Remove as it is no longer used
-
 clusterType: development
 
 rbac:
@@ -162,7 +151,6 @@ rbac:
 deploymentsPerEnvironmentHistoryLimit: 10
 pipelineJobsHistoryLimit: 5
 pipelineJobsHistoryPeriodLimit: "720h"
-pipelineImageTag: master-latest # deprecated issue #1388
 logLevel: "INFO"
 logPretty: false
 oauthProxyDefaultIssuerUrl: https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -30,10 +30,6 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-const (
-	prometheusInstanceLabel = "LABEL_PROMETHEUS_INSTANCE"
-)
-
 // DeploymentSyncer defines interface for syncing a RadixDeployment
 type DeploymentSyncer interface {
 	OnSync(ctx context.Context) error

--- a/pkg/apis/deployment/servicemonitor.go
+++ b/pkg/apis/deployment/servicemonitor.go
@@ -3,7 +3,6 @@ package deployment
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
@@ -70,12 +69,6 @@ func (deploy *Deployment) garbageCollectServiceMonitorsNoLongerInSpec(ctx contex
 }
 
 func (deploy *Deployment) isEligibleForGarbageCollectServiceMonitorsForComponent(serviceMonitor *monitoringv1.ServiceMonitor, componentName RadixComponentName) bool {
-	// Handle servicemonitors with prometheus=radix_stage1 label only for backward compatibility
-	// Code can be removed when all servicemonitors has radix-component label
-	labelValue, ok := serviceMonitor.Labels["prometheus"]
-	if ok && labelValue == os.Getenv(prometheusInstanceLabel) && len(serviceMonitor.Labels) == 1 {
-		return true
-	}
 	return !componentName.ExistInDeploymentSpec(deploy.radixDeployment)
 }
 


### PR DESCRIPTION
This pull request removes deprecated configuration options and legacy code related to Prometheus instance labeling and image references in the Radix Operator Helm chart and Go codebase. The changes streamline environment variable usage, clean up values files, and eliminate backward compatibility code that is no longer needed.

**Helm chart configuration cleanup:**

* Removed deprecated environment variables and their corresponding values from `charts/radix-operator/templates/deployment.yaml`, including `LABEL_PROMETHEUS_INSTANCE`, legacy image references (e.g., `RADIX_IMAGE_BUILDER`, `RADIXOPERATOR_JOB_SCHEDULER`, `RADIX_BUILDKIT_IMAGE_BUILDER`, `RADIX_PIPELINE_GIT_CLONE_NSLOOKUP_IMAGE`, `RADIX_PIPELINE_GIT_CLONE_BASH_IMAGE`, `RADIXOPERATOR_PIPELINE_IMAGE_TAG`). [[1]](diffhunk://#diff-e25f45e6da2f74f05f63830c41b7bf60d2b1e129a535611d7b3dc0da65372c3cL34-L35) [[2]](diffhunk://#diff-e25f45e6da2f74f05f63830c41b7bf60d2b1e129a535611d7b3dc0da65372c3cL86-L91) [[3]](diffhunk://#diff-e25f45e6da2f74f05f63830c41b7bf60d2b1e129a535611d7b3dc0da65372c3cL156-L165) [[4]](diffhunk://#diff-e25f45e6da2f74f05f63830c41b7bf60d2b1e129a535611d7b3dc0da65372c3cL182-L183)
* Removed deprecated values from `charts/radix-operator/values.yaml`, including image references, Prometheus name, and pipeline image tag. [[1]](diffhunk://#diff-94d0b33fd2a6b8d04ed23b74e75ce42290476a52311806ca55230e3d6be5ab7dL15-L23) [[2]](diffhunk://#diff-94d0b33fd2a6b8d04ed23b74e75ce42290476a52311806ca55230e3d6be5ab7dL154-L155) [[3]](diffhunk://#diff-94d0b33fd2a6b8d04ed23b74e75ce42290476a52311806ca55230e3d6be5ab7dL165)

**Go codebase cleanup:**

* Removed the constant `prometheusInstanceLabel` and related import from `pkg/apis/deployment/deployment.go`. [[1]](diffhunk://#diff-f1e3507e5920dacad5325c7a67d6a298c2a3cfab205a502a81701b69ae9aaf2eL33-L36) [[2]](diffhunk://#diff-c972564b0b27b09d408b3aaf796ac0b9a67cbbc841f9f296998cbe025e96ba1aL6)
* Removed legacy logic for handling ServiceMonitor resources with the `prometheus` label from `pkg/apis/deployment/servicemonitor.go`.

These changes help keep the codebase and chart configuration up-to-date, reducing confusion and maintenance overhead.