### PR TITLE
fix: remove environment from radixdeployjob

### DIFF
--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -1701,8 +1701,6 @@ spec:
                       items:
                         type: string
                       type: array
-                    environment:
-                      type: string
                     environmentVariables:
                       additionalProperties:
                         type: string

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -340,10 +340,6 @@ func (deployJobComponent *RadixDeployJobComponent) GetVolumeMounts() []RadixVolu
 	return deployJobComponent.VolumeMounts
 }
 
-func (deployJobComponent *RadixDeployJobComponent) GetEnvironment() string {
-	return deployJobComponent.Environment
-}
-
 func (deployJobComponent *RadixDeployJobComponent) IsAlwaysPullImageOnDeploy() bool {
 	return deployJobComponent.AlwaysPullImageOnDeploy
 }
@@ -442,7 +438,6 @@ func (deployComponent *RadixDeployComponent) GetNrOfReplicas() int32 {
 // The job component is used by the radix-job-scheduler to create Kubernetes Job objects
 type RadixDeployJobComponent struct {
 	Name                    string                    `json:"name"`
-	Environment             string                    `json:"environment,omitempty"`
 	Image                   string                    `json:"image"`
 	Ports                   []ComponentPort           `json:"ports,omitempty"`
 	EnvironmentVariables    EnvVarsMap                `json:"environmentVariables,omitempty"`


### PR DESCRIPTION
Release **AFTER** radix-api has been updated with operator version 1.103.0 or later