### PR TITLE
fix: grant operator access to RadixApplication status

### DIFF
--- a/charts/radix-operator/templates/radix-operator-rbac.yaml
+++ b/charts/radix-operator/templates/radix-operator-rbac.yaml
@@ -19,6 +19,7 @@ rules:
   - radixregistrations
   - radixregistrations/status
   - radixapplications
+  - radixapplications/status
   - radixenvironments
   - radixenvironments/status
   - radixdeployments


### PR DESCRIPTION
This pull request makes a minor update to the RBAC configuration in `charts/radix-operator/templates/radix-operator-rbac.yaml`. The change adds a new rule for `radixapplications/status`, which allows the operator to manage or access the status subresource of `radixapplications`.

* Added `radixapplications/status` to the RBAC rules to enable status updates or access for `radixapplications`.