### PR TITLE
fix: remove preload directive from Strict-Transport-Security header

### DIFF
--- a/pkg/apis/deployment/gateway.go
+++ b/pkg/apis/deployment/gateway.go
@@ -150,7 +150,7 @@ func (deploy *Deployment) reconcileHTTPRoute(ctx context.Context, component radi
 						{
 							Type: gatewayapiv1.HTTPRouteFilterResponseHeaderModifier,
 							ResponseHeaderModifier: &gatewayapiv1.HTTPHeaderFilter{
-								Add: []gatewayapiv1.HTTPHeader{{Name: "Strict-Transport-Security", Value: "max-age=31536000; includeSubDomains; preload"}},
+								Add: []gatewayapiv1.HTTPHeader{{Name: "Strict-Transport-Security", Value: "max-age=31536000; includeSubDomains"}},
 							},
 						},
 					},

--- a/pkg/apis/deployment/gateway_test.go
+++ b/pkg/apis/deployment/gateway_test.go
@@ -228,6 +228,7 @@ func (s *GatewayTestSuite) TestHTTPRouteAndListenerSetCreated_PublicComponentWit
 	s.Require().NotNil(route.Spec.Rules[0].Filters[0].ResponseHeaderModifier)
 	s.Require().Len(route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add, 1)
 	s.Equal(gatewayapiv1.HTTPHeaderName("Strict-Transport-Security"), route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add[0].Name)
+	s.Equal("max-age=31536000; includeSubDomains", route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add[0].Value)
 
 	// Verify path match
 	s.Require().Len(route.Spec.Rules[0].Matches, 1)

--- a/pkg/apis/dnsalias/gateway.go
+++ b/pkg/apis/dnsalias/gateway.go
@@ -83,7 +83,7 @@ func (s *syncer) reconcileHTTPRoute(ctx context.Context) error {
 						{
 							Type: gatewayapiv1.HTTPRouteFilterResponseHeaderModifier,
 							ResponseHeaderModifier: &gatewayapiv1.HTTPHeaderFilter{
-								Add: []gatewayapiv1.HTTPHeader{{Name: "Strict-Transport-Security", Value: "max-age=31536000; includeSubDomains; preload"}},
+								Add: []gatewayapiv1.HTTPHeader{{Name: "Strict-Transport-Security", Value: "max-age=31536000; includeSubDomains"}},
 							},
 						},
 					},

--- a/pkg/apis/dnsalias/syncer_test.go
+++ b/pkg/apis/dnsalias/syncer_test.go
@@ -822,7 +822,7 @@ func (s *syncerTestSuite) Test_OnSync_HTTPRoute_Created_ForPublicComponent() {
 	s.Require().NotNil(route.Spec.Rules[0].Filters[0].ResponseHeaderModifier)
 	s.Require().Len(route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add, 1)
 	s.Equal(gatewayapiv1.HTTPHeaderName("Strict-Transport-Security"), route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add[0].Name)
-	s.Equal("max-age=31536000; includeSubDomains; preload", route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add[0].Value)
+	s.Equal("max-age=31536000; includeSubDomains", route.Spec.Rules[0].Filters[0].ResponseHeaderModifier.Add[0].Value)
 }
 
 func (s *syncerTestSuite) Test_OnSync_HTTPRoute_Created_WithOAuth2() {


### PR DESCRIPTION
We do not want to include domains the the HSTS preload list, ref https://hstspreload.org/