### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.metadata.outputs.version }}
       release-exist: ${{ steps.metadata.outputs.release_exist }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Metadata
         id: metadata
         env:
@@ -52,7 +52,7 @@ jobs:
           - file: job-scheduler.Dockerfile
             repository: /equinor/radix/job-scheduler
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
@@ -88,7 +88,7 @@ jobs:
     env:
       HELM_CHART_REGISTRY: oci://ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -53,20 +53,20 @@ jobs:
             repository: /equinor/radix/job-scheduler
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Container metadata
         id: container-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: "${{ env.CONTAINER_REGISTRY }}${{ matrix.container.repository }}"
           tags: ${{ needs.metadata.outputs.version }}
       - name: Build and push container images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           file: ${{ matrix.container.file }}

--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -4,6 +4,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+' # semver stable
       - 'v[0-9]+.[0-9]+.[0-9]+-*' # semver with prerelease suffix
+permissions: {}
 jobs:
   metadata:
     runs-on: ubuntu-latest
@@ -13,7 +14,7 @@ jobs:
       version: ${{ steps.metadata.outputs.version }}
       release-exist: ${{ steps.metadata.outputs.release_exist }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Metadata
         id: metadata
         env:
@@ -52,21 +53,21 @@ jobs:
           - file: job-scheduler.Dockerfile
             repository: /equinor/radix/job-scheduler
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Container metadata
         id: container-metadata
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: "${{ env.CONTAINER_REGISTRY }}${{ matrix.container.repository }}"
           tags: ${{ needs.metadata.outputs.version }}
       - name: Build and push container images
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ${{ matrix.container.file }}
@@ -88,9 +89,9 @@ jobs:
     env:
       HELM_CHART_REGISTRY: oci://ghcr.io
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.18.3
       - name: Helm login

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [master]
 
+permissions: {}
 jobs:
   unreleased-prs-metadata:
     name: Get list of pending release pull requests

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   unreleased-prs-metadata:
     name: Get list of pending release pull requests
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
     permissions:
       pull-requests: read
       contents: read
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         pr-number: ${{ fromJson(needs.unreleased-prs-metadata.outputs.unreleased-pull-requests) }}
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ permissions: {}
 jobs:
   unreleased-prs-metadata:
     name: Get list of pending release pull requests
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     permissions:
       pull-requests: read
       contents: read
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         pr-number: ${{ fromJson(needs.unreleased-prs-metadata.outputs.unreleased-pull-requests) }}
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Build container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
           - webhook.Dockerfile
           - job-scheduler.Dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build container
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
@@ -53,7 +53,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v5
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
@@ -104,7 +104,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: azure/setup-helm@v4
       - name: Helm Lint
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+permissions: {}
 jobs:
   build:
     name: Build container images
@@ -17,11 +18,11 @@ jobs:
           - webhook.Dockerfile
           - job-scheduler.Dockerfile
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build container
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ${{ matrix.file }}
@@ -36,8 +37,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - name: Install dependencies
@@ -53,8 +54,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - name: Install dependencies
@@ -73,14 +74,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.10.1
 
@@ -90,8 +91,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - name: Verify Code Generation
@@ -104,8 +105,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: azure/setup-helm@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Helm Lint
         run: |
           helm lint charts/radix-operator --set rbac.createApp.groups[0]="group1"

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -7,6 +7,7 @@ on:
       - '**'
   workflow_dispatch:
 
+permissions: {}
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   prepare-release-pr:
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Update deprecated GitHub Actions to versions compatible with Node.js 24.\n\n- Update actions/checkout to v6\n- Update radix-reusable-workflows to v1.1.0\n\nNode.js 20 actions are deprecated and will be forced to run with Node.js 24 by default starting June 2nd, 2026.