### PR TITLE
fix: Always keep CRDs

### DIFF
--- a/charts/radix-operator/templates/radixalert.yaml
+++ b/charts/radix-operator/templates/radixalert.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixalerts.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixapplication.yaml
+++ b/charts/radix-operator/templates/radixapplication.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixapplications.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixbatch.yaml
+++ b/charts/radix-operator/templates/radixbatch.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixbatches.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixdeployment.yaml
+++ b/charts/radix-operator/templates/radixdeployment.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixdeployments.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixdnsalias.yaml
+++ b/charts/radix-operator/templates/radixdnsalias.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixdnsaliases.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixenvironment.yaml
+++ b/charts/radix-operator/templates/radixenvironment.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixenvironments.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixjob.yaml
+++ b/charts/radix-operator/templates/radixjob.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixjobs.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/charts/radix-operator/templates/radixregistration.yaml
+++ b/charts/radix-operator/templates/radixregistration.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
   name: radixregistrations.radix.equinor.com
 spec:
   group: radix.equinor.com

--- a/pkg/apis/radix/v1/radixalerttypes.go
+++ b/pkg/apis/radix/v1/radixalerttypes.go
@@ -8,6 +8,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=radixalerts,shortName=ral
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 
 // RadixAlert describes configuration for setting up alerts for environments or pipeline jobs
 type RadixAlert struct {

--- a/pkg/apis/radix/v1/radixapptypes.go
+++ b/pkg/apis/radix/v1/radixapptypes.go
@@ -32,6 +32,7 @@ const DynamicTagNameInEnvironmentConfig = "{imageTagName}"
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=radixapplications,shortName=ra
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 // RadixApplication describes an application
 type RadixApplication struct {

--- a/pkg/apis/radix/v1/radixbatchtypes.go
+++ b/pkg/apis/radix/v1/radixbatchtypes.go
@@ -10,6 +10,7 @@ import (
 // +kubebuilder:printcolumn:name="Condition",type="string",JSONPath=".status.condition.type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=radixbatches,shortName=rb
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 
 // RadixBatch enables batch execution of Radix job components.

--- a/pkg/apis/radix/v1/radixdeploytypes.go
+++ b/pkg/apis/radix/v1/radixdeploytypes.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:printcolumn:name="Reconciled",type="date",JSONPath=".status.reconciled",priority=1
 // +kubebuilder:printcolumn:name="Branch",type="string",JSONPath=".metadata.annotations.radix-branch",priority=1
 // +kubebuilder:resource:path=radixdeployments,shortName=rd
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 
 // RadixDeployment describe a deployment

--- a/pkg/apis/radix/v1/radixdnsaliastypes.go
+++ b/pkg/apis/radix/v1/radixdnsaliastypes.go
@@ -9,6 +9,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.condition"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=radixdnsaliases,scope=Cluster,shortName=rda
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 
 // RadixDNSAlias is a Custom Resource Definition

--- a/pkg/apis/radix/v1/radixenvironmenttypes.go
+++ b/pkg/apis/radix/v1/radixenvironmenttypes.go
@@ -8,6 +8,7 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=radixenvironments,scope=Cluster,shortName=re
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 
 // RadixEnvironment is a Custom Resource Definition

--- a/pkg/apis/radix/v1/radixjobtypes.go
+++ b/pkg/apis/radix/v1/radixjobtypes.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="Reconciled",type="string",JSONPath=".status.reconciled",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=radixjobs,shortName=rj
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 
 // RadixJob describe a Radix job

--- a/pkg/apis/radix/v1/radixregistrationtypes.go
+++ b/pkg/apis/radix/v1/radixregistrationtypes.go
@@ -13,6 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Reconciled",type="date",JSONPath=".status.reconciled"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=radixregistrations,scope=Cluster,shortName=rr
+// +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +kubebuilder:subresource:status
 
 // RadixRegistration describe an application


### PR DESCRIPTION
Ensure that Custom Resource Definitions (CRDs) are not removed by adding the `helm.sh/resource-policy: keep` annotation to each CRD. This change maintains the integrity of the CRDs during Helm operations.