### PR TITLE
fix: Add ServiceMonitor for API server

### DIFF
--- a/charts/radix-operator/templates/radix-api-servicemonitor.yaml
+++ b/charts/radix-operator/templates/radix-api-servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.radixApiServer.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: server
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - interval: {{ .Values.radixApiServer.serviceMonitor.interval }}
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "radix-api-server.selectorLabels" . | nindent 6 }}
+
+{{- end }}

--- a/charts/radix-operator/templates/radix-api-servicemonitor.yaml
+++ b/charts/radix-operator/templates/radix-api-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.radixApiServer.serviceMonitor.enabled }}
----
+
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -261,6 +261,10 @@ radixApiServer:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
 
+  serviceMonitor:
+    enabled: true
+    interval: 5s
+
   podDisruptionBudget:
     enabled: true
     minAvailable: 1


### PR DESCRIPTION
Introduce a ServiceMonitor configuration for the API server to enable monitoring of metrics. This includes enabling the ServiceMonitor and setting a default interval for metric collection.