### PR TITLE
chore: Update README And Catalog-Info for Radix API Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ The radix-operator is the central piece of the [Radix platform](https://github.c
 
 The `radix-operator` and `radix-pipeline` are built using Github actions, then the `radix-operator` is deployed to cluster through a Helm release using the [Flux Operator](https://github.com/weaveworks/flux) whenever a new image is pushed to the container registry for the corresponding branch. Build and push to container registry is done using Github actions.
 
+## Repository layout
+
+- `operator` - The Radix Operator watches changes of radix CRDs and reconciles related native kubernetes resources, like converting a `RadixDeployment` to a kubernetes `Deployment`
+- `pipeline-runner` - The Pipeline Runners responsibility is to run pipeline jobs, like build-deploys or promote. Usually produces a new `RadixDeployment`. Is created whenever the Operator and the `RadixJob` resource.
+- `api-server` - The Radix API Server is the main entrypoint for our users via either `radix-cli` or `radix-web-console`, usually changes Radix CRDs (like creating a `RadixJob` resource, or changing desired replicas on a `RadixDeployment` resource).
+- `job-scheduler` - A Job Scheduler component that is run in user namespaces whenever  a user wants to run Job Components. It creates a new API in their namespace they can query to read status, or create the actuall jobs.
+- `webhook` - The Webhook configures kubernetes to validate Radix CRDs whenever they are created or updated, before they are persistent and allowed to trigger changes.
+
+- `e2e` - Itnegration tests that starts a real kubernets cluster with Kind, installs Radix, and runs a few smoketests that are not covered by Unit tests.
+- `hack` - misc. build scripts
+- `json-schema` - Allows end users to validate their `radixconfig.yaml` schema.
+- `pkg` - Shared libraries that other components in this repo depend on. Includes generated static Client APIs.
 
 ## Development Process
 
@@ -57,9 +69,11 @@ The CRD schema generates use comment markers. Read more about supported markers 
 Generate CRD yaml files whenever you make changes to any of the types in `pkg/apis/radix/v1/`.
 
 Currently, only the CRD for RadixBatch and RadixApplication is generated.
+
 ```shell
 make crds
 ```
+
 This will also regenerate a json schema for RadixApplication into ./json-schema/radixapplication.json.
 This schema can be used in code editors like VS Code to get auto complete and validation when editing a radixconfig.yaml file.
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -11,46 +11,15 @@ The Radix API is meant to be the single point of entry for platform users to the
 
 Authentication and authorisation are performed through an HTTP bearer token, which is relayed to the Kubernetes API. The Kubernetes AAD integration then performs its authentication and resource authorisation checks, and the result is relayed to the user.
 
-## Developing
-
-You need Go installed. Make sure `GOPATH` and `GOROOT` are properly set up.
-
-Also needed:
-
-- [`go-swagger`](https://github.com/go-swagger/go-swagger) (install with `make bootstrap`.)
-- [`golangci-lint`](https://golangci-lint.run/) (install with `make bootstrap`)
-- [`gomock`](https://github.com/uber-go/mock) (install with `make bootstrap`)
-
-Clone the repo into your `GOPATH` and run `go mod download`.
-
-### Dependencies - go modules
-
-Go modules are used for dependency management. See [link](https://blog.golang.org/using-go-modules) for information how to add, upgrade and remove dependencies. E.g. To update `radix-operator` dependency:
-
-- list versions: `go list -m -versions github.com/equinor/radix-operator`
-- update: `go get github.com/equinor/radix-operator@v1.3.1`
-
-### Generating mocks
-We use gomock to generate mocks used in unit test.
-You need to regenerate mocks if you make changes to any of the interface types used by the application.
-```
-make mocks
-```
-
 ### Running locally
 
 The following env vars are needed. Useful default values in brackets.
 
 - `RADIX_CONTAINER_REGISTRY` - (`radixdev.azurecr.io`)
-- `PROMETHEUS_URL` - `http://localhost:9091` use this to get Prometheus metrics running the following command (the local port 9090 is used by the API server `/metrics` endpoint, in-cluster URL is http://prometheus-operator-prometheus.monitor.svc.cluster.local:9090): 
+- `PROMETHEUS_URL` - `http://localhost:9091` use this to get Prometheus metrics running the following command (the local port 9090 is used by the API server `/metrics` endpoint, in-cluster URL is <http://prometheus-operator-prometheus.monitor.svc.cluster.local:9090>):
+
   ```
   kubectl -n monitor port-forward svc/prometheus-operator-prometheus 9091:9090
-  ``` 
+  ```
 
 If you are using VSCode, there is a convenient launch configuration in `.vscode`.
-
-#### Validate code
-
-- run `make lint`
-- run `make test`
-- run `make swagger-api-server`

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -41,3 +41,36 @@ spec:
   lifecycle: production
   owner: team-radix
   system: Radix
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: radix-api-server
+  title: Radix API Server
+  description: "Radix API Server"
+  annotations:
+    github.com/project-slug: equinor/radix-operator
+spec:
+  type: openapi
+  lifecycle: production
+  owner: team-radix
+  system: system:default/Radix
+  definition:
+    $text: "./api-server/swaggerui/html/swagger.json"
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: radix-api-server
+  title: Radix API Server
+  description: "Radix API Server"
+  annotations:
+    github.com/project-slug: equinor/radix-operator
+spec:
+  type: service
+  lifecycle: production
+  owner: team-radix
+  system: system:default/Radix
+  providesApis:
+    - radix-api-server


### PR DESCRIPTION
Revise the README to enhance clarity on the repository layout and development process for the Radix API Server. Remove outdated sections and improve instructions for local setup and dependencies.