### PR TITLE
fix: shell injection vulnerabilities in git clone commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -129,7 +129,7 @@
 				"USE_PROFILER": "true",
 				"APP_ALIAS_BASE_URL": "app.dev.radix.equinor.com",
 				"DNS_ZONE": "dev.radix.equinor.com",
-				"RADIX_CLUSTERNAME": "weekly-dev",
+				"RADIX_CLUSTERNAME": "weekly-23",
 				"RADIXOPERATOR_CLUSTER_TYPE": "development",
 				"RADIXOPERATOR_DEFAULT_APP_ADMIN_GROUPS": "64b28659-4fe4-4222-8497-85dd7e43e25b",
 				"RADIXOPERATOR_APP_BUILDER_RESOURCES_LIMITS_CPU": "2000m",

--- a/pipeline-runner/internal/jobs/build/acr_test.go
+++ b/pipeline-runner/internal/jobs/build/acr_test.go
@@ -128,9 +128,16 @@ func assertACRJobSpec(t *testing.T, pushImage bool) {
 	assert.ElementsMatch(t, []string{"clone"}, slice.Map(job.Spec.Template.Spec.InitContainers, func(c corev1.Container) string { return c.Name }))
 	cloneContainer, _ := slice.FindFirst(job.Spec.Template.Spec.InitContainers, func(c corev1.Container) bool { return c.Name == "clone" })
 	assert.Equal(t, args.GitCloneGitImage, cloneContainer.Image)
-	expectedCommand := fmt.Sprintf("umask 002 && git config --global --add safe.directory %[3]s && git clone %[2]s -b %[4]s --verbose --progress --filter=blob:none %[3]s && (cd %[3]s && git submodule update --init --recursive || echo \"Warning: Unable to clone submodules, proceeding without them\") && cd %[3]s && echo \"Checking out commit %[1]s\" && git merge-base --is-ancestor %[1]s HEAD && git checkout -q %[1]s && cd - && cd /some-workspace && if [ -n \"$(git lfs ls-files 2>/dev/null)\" ]; then git lfs install && echo 'Pulling large files...' && git lfs pull && echo 'Done'; fi && cd - && chmod -R g+r /some-workspace/.git", gitCommitHash, cloneURL, gitWorkspace, gitRefName)
+	expectedCommand := `umask 002 && git config --global --add safe.directory "$RADIX_CLONE_DIR" && git clone -b "$RADIX_CLONE_BRANCH" --verbose --progress --filter=blob:none -- "$RADIX_CLONE_REPO" "$RADIX_CLONE_DIR" && (cd "$RADIX_CLONE_DIR" && git submodule update --init --recursive || echo "Warning: Unable to clone submodules, proceeding without them") && cd "$RADIX_CLONE_DIR" && echo "Checking out commit $RADIX_CLONE_COMMIT" && git merge-base --is-ancestor "$RADIX_CLONE_COMMIT" HEAD && git checkout -q "$RADIX_CLONE_COMMIT" && cd - && cd "$RADIX_CLONE_DIR" && if [ -n "$(git lfs ls-files 2>/dev/null)" ]; then git lfs install && echo 'Pulling large files...' && git lfs pull && echo 'Done'; fi && cd - && chmod -R g+r "$RADIX_CLONE_DIR/.git"`
 	assert.Equal(t, []string{"sh", "-c", expectedCommand}, cloneContainer.Command)
 	assert.Empty(t, cloneContainer.Args)
+	assert.ElementsMatch(t, []corev1.EnvVar{
+		{Name: "HOME", Value: git.CloneRepoHomeVolumePath},
+		{Name: "RADIX_CLONE_REPO", Value: cloneURL},
+		{Name: "RADIX_CLONE_BRANCH", Value: gitRefName},
+		{Name: "RADIX_CLONE_DIR", Value: gitWorkspace},
+		{Name: "RADIX_CLONE_COMMIT", Value: gitCommitHash},
+	}, cloneContainer.Env)
 	expectedCloneVolumeMounts := []corev1.VolumeMount{
 		{Name: git.BuildContextVolumeName, MountPath: "/some-workspace"},
 		{Name: git.GitSSHKeyVolumeName, MountPath: "/.ssh", ReadOnly: true},

--- a/pipeline-runner/internal/jobs/build/buildkit_test.go
+++ b/pipeline-runner/internal/jobs/build/buildkit_test.go
@@ -161,9 +161,16 @@ func assertBuildKitJobSpec(t *testing.T, useBuildCache, refreshBuildCache, pushI
 			assert.ElementsMatch(t, []string{"clone"}, slice.Map(job.Spec.Template.Spec.InitContainers, func(c corev1.Container) string { return c.Name }))
 			cloneContainer, _ := slice.FindFirst(job.Spec.Template.Spec.InitContainers, func(c corev1.Container) bool { return c.Name == "clone" })
 			assert.Equal(t, args.GitCloneGitImage, cloneContainer.Image)
-			expectedCommand := fmt.Sprintf("umask 002 && git config --global --add safe.directory %[3]s && git clone %[2]s -b %[4]s --verbose --progress --filter=blob:none %[3]s && (cd %[3]s && git submodule update --init --recursive || echo \"Warning: Unable to clone submodules, proceeding without them\") && cd %[3]s && echo \"Checking out commit %[1]s\" && git merge-base --is-ancestor %[1]s HEAD && git checkout -q %[1]s && cd - && cd %[3]s && if [ -n \"$(git lfs ls-files 2>/dev/null)\" ]; then git lfs install && echo 'Pulling large files...' && git lfs pull && echo 'Done'; fi && cd - && chmod -R g+r /some-workspace/.git", gitCommitHash, cloneURL, gitWorkspace, gitRefName)
+			expectedCommand := `umask 002 && git config --global --add safe.directory "$RADIX_CLONE_DIR" && git clone -b "$RADIX_CLONE_BRANCH" --verbose --progress --filter=blob:none -- "$RADIX_CLONE_REPO" "$RADIX_CLONE_DIR" && (cd "$RADIX_CLONE_DIR" && git submodule update --init --recursive || echo "Warning: Unable to clone submodules, proceeding without them") && cd "$RADIX_CLONE_DIR" && echo "Checking out commit $RADIX_CLONE_COMMIT" && git merge-base --is-ancestor "$RADIX_CLONE_COMMIT" HEAD && git checkout -q "$RADIX_CLONE_COMMIT" && cd - && cd "$RADIX_CLONE_DIR" && if [ -n "$(git lfs ls-files 2>/dev/null)" ]; then git lfs install && echo 'Pulling large files...' && git lfs pull && echo 'Done'; fi && cd - && chmod -R g+r "$RADIX_CLONE_DIR/.git"`
 			assert.Equal(t, []string{"sh", "-c", expectedCommand}, cloneContainer.Command)
 			assert.Empty(t, cloneContainer.Args)
+			assert.ElementsMatch(t, []corev1.EnvVar{
+				{Name: "HOME", Value: git.CloneRepoHomeVolumePath},
+				{Name: "RADIX_CLONE_REPO", Value: cloneURL},
+				{Name: "RADIX_CLONE_BRANCH", Value: gitRefName},
+				{Name: "RADIX_CLONE_DIR", Value: gitWorkspace},
+				{Name: "RADIX_CLONE_COMMIT", Value: gitCommitHash},
+			}, cloneContainer.Env)
 			expectedCloneVolumeMounts := []corev1.VolumeMount{
 				{Name: git.BuildContextVolumeName, MountPath: gitWorkspace},
 				{Name: git.GitSSHKeyVolumeName, MountPath: "/.ssh", ReadOnly: true},

--- a/pkg/apis/git/clone.go
+++ b/pkg/apis/git/clone.go
@@ -28,30 +28,32 @@ func CloneInitContainersWithSourceCode(sshURL, branch, commitID, directory, gitI
 
 // CloneInitContainersWithContainerName The sidecars for cloning a git repo. Lfs is to support large files in cloned source code, it is not needed for Radix config ot SubPipeline
 func CloneInitContainersWithContainerName(sshURL, branch, commitID, directory string, useLfs, skipBlobs bool, cloneContainerName, gitImage string) []corev1.Container {
+	// User-controlled values (sshURL, branch, commitID, directory) are passed as environment variables
+	// and referenced via quoted "$VAR" in shell commands to prevent shell injection.
 	commands := []string{
 		"umask 002", // make sure all users and groups have read+execute access to the files, since different users may access it (default is 022 and group+write for backwards compatibility)
-		fmt.Sprintf("git config --global --add safe.directory %s", directory),
+		`git config --global --add safe.directory "$RADIX_CLONE_DIR"`,
 	}
 
 	cloneArgs := []string{
-		fmt.Sprintf("-b %s", branch),
+		`-b "$RADIX_CLONE_BRANCH"`,
 		"--verbose",
 		"--progress",
 	}
 	if skipBlobs {
 		cloneArgs = append(cloneArgs, "--filter=blob:none")
 	}
-	commands = append(commands, fmt.Sprintf("git clone %[1]s %[2]s %[3]s && (cd %[3]s && git submodule update --init --recursive || echo \"Warning: Unable to clone submodules, proceeding without them\")", sshURL, strings.Join(cloneArgs, " "), directory))
+	commands = append(commands, fmt.Sprintf(`git clone %s -- "$RADIX_CLONE_REPO" "$RADIX_CLONE_DIR" && (cd "$RADIX_CLONE_DIR" && git submodule update --init --recursive || echo "Warning: Unable to clone submodules, proceeding without them")`, strings.Join(cloneArgs, " ")))
 
 	if len(commitID) > 0 {
-		commands = append(commands, fmt.Sprintf("cd %[1]s && echo \"Checking out commit %[2]s\" && git merge-base --is-ancestor %[2]s HEAD && git checkout -q %[2]s && cd -", directory, commitID))
+		commands = append(commands, `cd "$RADIX_CLONE_DIR" && echo "Checking out commit $RADIX_CLONE_COMMIT" && git merge-base --is-ancestor "$RADIX_CLONE_COMMIT" HEAD && git checkout -q "$RADIX_CLONE_COMMIT" && cd -`)
 	}
 
 	if useLfs {
-		commands = append(commands, fmt.Sprintf("cd %s && if [ -n \"$(git lfs ls-files 2>/dev/null)\" ]; then git lfs install && echo 'Pulling large files...' && git lfs pull && echo 'Done'; fi && cd -", directory))
+		commands = append(commands, `cd "$RADIX_CLONE_DIR" && if [ -n "$(git lfs ls-files 2>/dev/null)" ]; then git lfs install && echo 'Pulling large files...' && git lfs pull && echo 'Done'; fi && cd -`)
 	}
 
-	commands = append(commands, fmt.Sprintf("chmod -R g+r %s/.git", directory))
+	commands = append(commands, `chmod -R g+r "$RADIX_CLONE_DIR/.git"`)
 
 	gitCloneCmd := []string{"sh", "-c", strings.Join(commands, " && ")}
 
@@ -62,10 +64,11 @@ func CloneInitContainersWithContainerName(sshURL, branch, commitID, directory st
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         gitCloneCmd,
 			Env: []corev1.EnvVar{
-				{
-					Name:  "HOME",
-					Value: CloneRepoHomeVolumePath,
-				},
+				{Name: "HOME", Value: CloneRepoHomeVolumePath},
+				{Name: "RADIX_CLONE_REPO", Value: sshURL},
+				{Name: "RADIX_CLONE_BRANCH", Value: branch},
+				{Name: "RADIX_CLONE_DIR", Value: directory},
+				{Name: "RADIX_CLONE_COMMIT", Value: commitID},
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/pkg/apis/git/clone_test.go
+++ b/pkg/apis/git/clone_test.go
@@ -6,8 +6,17 @@ import (
 	"github.com/equinor/radix-common/utils/slice"
 	"github.com/equinor/radix-operator/pkg/apis/git"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
+
+func envVarMap(envVars []corev1.EnvVar) map[string]string {
+	m := make(map[string]string)
+	for _, e := range envVars {
+		m[e.Name] = e.Value
+	}
+	return m
+}
 
 func Test_CloneInitContainers_CustomImages(t *testing.T) {
 	type containerInfo struct {
@@ -34,4 +43,72 @@ func Test_CloneInitContainersWithContainerName_CustomImages(t *testing.T) {
 		{name: cloneName, image: "anygit:any"},
 	}
 	assert.Equal(t, expected, actual)
+}
+
+// Shell injection tests: user-controlled values must never be interpolated raw into the shell script.
+// Each value must be stored in an env var and referenced via quoted "$VAR" in the command.
+
+func Test_CloneInitContainers_ShellInjection_BranchName(t *testing.T) {
+	maliciousBranch := `main$(echo${IFS}RADIX_CLONE_INJECTION_PROOF>&2)`
+	containers := git.CloneInitContainersWithSourceCode("git@github.com:org/repo.git", maliciousBranch, "", "/workspace", "gitimage:latest")
+	require.Len(t, containers, 1)
+	c := containers[0]
+	require.Len(t, c.Command, 3)
+	// The raw branch value must not appear in the shell script
+	assert.NotContains(t, c.Command[2], maliciousBranch)
+	// The value must be passed via env var instead
+	envs := envVarMap(c.Env)
+	assert.Equal(t, maliciousBranch, envs["RADIX_CLONE_BRANCH"])
+}
+
+func Test_CloneInitContainers_ShellInjection_CommitID(t *testing.T) {
+	maliciousCommit := "abc123; echo INJECTED"
+	containers := git.CloneInitContainersWithSourceCode("git@github.com:org/repo.git", "main", maliciousCommit, "/workspace", "gitimage:latest")
+	require.Len(t, containers, 1)
+	c := containers[0]
+	require.Len(t, c.Command, 3)
+	assert.NotContains(t, c.Command[2], maliciousCommit)
+	envs := envVarMap(c.Env)
+	assert.Equal(t, maliciousCommit, envs["RADIX_CLONE_COMMIT"])
+}
+
+func Test_CloneInitContainers_ShellInjection_RepoURL(t *testing.T) {
+	maliciousURL := "git@github.com:org/repo.git && echo INJECTED"
+	containers := git.CloneInitContainersWithSourceCode(maliciousURL, "main", "", "/workspace", "gitimage:latest")
+	require.Len(t, containers, 1)
+	c := containers[0]
+	require.Len(t, c.Command, 3)
+	assert.NotContains(t, c.Command[2], maliciousURL)
+	envs := envVarMap(c.Env)
+	assert.Equal(t, maliciousURL, envs["RADIX_CLONE_REPO"])
+}
+
+func Test_CloneInitContainers_ShellInjection_Directory(t *testing.T) {
+	maliciousDir := "/workspace; echo INJECTED"
+	containers := git.CloneInitContainersWithSourceCode("git@github.com:org/repo.git", "main", "", maliciousDir, "gitimage:latest")
+	require.Len(t, containers, 1)
+	c := containers[0]
+	require.Len(t, c.Command, 3)
+	assert.NotContains(t, c.Command[2], maliciousDir)
+	envs := envVarMap(c.Env)
+	assert.Equal(t, maliciousDir, envs["RADIX_CLONE_DIR"])
+}
+
+func Test_CloneInitContainers_EnvVarsPresent(t *testing.T) {
+	containers := git.CloneInitContainersWithSourceCode("git@github.com:org/repo.git", "main", "abc123def456", "/workspace", "gitimage:latest")
+	require.Len(t, containers, 1)
+	envs := envVarMap(containers[0].Env)
+	assert.Equal(t, "git@github.com:org/repo.git", envs["RADIX_CLONE_REPO"])
+	assert.Equal(t, "main", envs["RADIX_CLONE_BRANCH"])
+	assert.Equal(t, "/workspace", envs["RADIX_CLONE_DIR"])
+	assert.Equal(t, "abc123def456", envs["RADIX_CLONE_COMMIT"])
+}
+
+func Test_CloneInitContainers_NoCommitID_NoCommitEnvVar(t *testing.T) {
+	containers := git.CloneInitContainersWithSourceCode("git@github.com:org/repo.git", "main", "", "/workspace", "gitimage:latest")
+	require.Len(t, containers, 1)
+	envs := envVarMap(containers[0].Env)
+	value, hasCommit := envs["RADIX_CLONE_COMMIT"]
+	assert.True(t, hasCommit)
+	assert.Equal(t, "", value)
 }

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -358,9 +358,15 @@ func (s *RadixJobTestSuite) TestObjectSynced_PipelineJobCreated() {
 		{
 			Name:            "clone-config",
 			Image:           s.config.gitImage,
-			Command:         []string{"sh", "-c", "umask 002 && git config --global --add safe.directory /workspace && git clone  -b  --verbose --progress /workspace && (cd /workspace && git submodule update --init --recursive || echo \"Warning: Unable to clone submodules, proceeding without them\") && chmod -R g+r /workspace/.git"},
+			Command:         []string{"sh", "-c", `umask 002 && git config --global --add safe.directory "$RADIX_CLONE_DIR" && git clone -b "$RADIX_CLONE_BRANCH" --verbose --progress -- "$RADIX_CLONE_REPO" "$RADIX_CLONE_DIR" && (cd "$RADIX_CLONE_DIR" && git submodule update --init --recursive || echo "Warning: Unable to clone submodules, proceeding without them") && chmod -R g+r "$RADIX_CLONE_DIR/.git"`},
 			ImagePullPolicy: corev1.PullIfNotPresent,
-			Env:             []corev1.EnvVar{{Name: "HOME", Value: "/home/clone"}},
+			Env: []corev1.EnvVar{
+				{Name: "HOME", Value: "/home/clone"},
+				{Name: "RADIX_CLONE_REPO", Value: ""},
+				{Name: "RADIX_CLONE_BRANCH", Value: ""},
+				{Name: "RADIX_CLONE_DIR", Value: "/workspace"},
+				{Name: "RADIX_CLONE_COMMIT", Value: ""},
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "build-context",


### PR DESCRIPTION
Update the git clone commands to use environment variables for user-controlled inputs, mitigating potential shell injection risks. Adjust the launch configuration to reflect the current weekly version.