### PR TITLE
fix(job): update status while running

### DIFF
--- a/pipeline-runner/internal/runner/app.go
+++ b/pipeline-runner/internal/runner/app.go
@@ -100,6 +100,7 @@ func (cli *PipelineRunner) Run(ctx context.Context) error {
 			cli.UpdateStatus(ctx, v1.JobStoppedNoChanges)
 			return nil
 		}
+		cli.UpdateStatus(ctx, v1.JobRunning)
 	}
 	cli.UpdateStatus(ctx, v1.JobSucceeded)
 	return nil


### PR DESCRIPTION
It was updating the status when the job was completed, now changed to update to while it is running also. 