### PR TITLE
fix: Remove Azure ACR service principal secrets

### DIFF
--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -419,7 +419,6 @@ func createClusterPrerequisites(ctx context.Context, c client.Client, gitKnownHo
 	// registration-controller copies these into each app namespace, so they must exist in the
 	// default namespace.
 	acrSecretNames := []string{
-		defaults.AzureACRServicePrincipleSecretName,
 		defaults.AzureACRServicePrincipleBuildahSecretName,
 		defaults.AzureACRTokenPasswordAppRegistrySecretName,
 	}

--- a/pkg/apis/application/application_test.go
+++ b/pkg/apis/application/application_test.go
@@ -169,7 +169,7 @@ func TestOnSync_RegistrationCreated_AppNamespaceWithResourcesCreated(t *testing.
 
 	secrets, _ := client.CoreV1().Secrets("any-app-app").List(context.Background(), metav1.ListOptions{})
 	secretNames := slice.Map(secrets.Items, func(s corev1.Secret) string { return s.Name })
-	expectedSecrets := []string{defaults.GitPrivateKeySecretName, defaults.AzureACRServicePrincipleBuildahSecretName, defaults.AzureACRServicePrincipleSecretName, defaults.AzureACRTokenPasswordAppRegistrySecretName}
+	expectedSecrets := []string{defaults.GitPrivateKeySecretName, defaults.AzureACRServicePrincipleBuildahSecretName, defaults.AzureACRTokenPasswordAppRegistrySecretName}
 	assert.ElementsMatch(t, expectedSecrets, secretNames)
 
 	serviceAccounts, _ := client.CoreV1().ServiceAccounts("any-app-app").List(context.Background(), metav1.ListOptions{})

--- a/pkg/apis/application/secrets.go
+++ b/pkg/apis/application/secrets.go
@@ -154,7 +154,7 @@ func (app *Application) getCurrentAndDesiredGitPublicDeployKeyConfigMap(ctx cont
 func (app *Application) applyContainerRegistryCredentialSecretsToAppNamespace(ctx context.Context) error {
 	appNamespace := utils.GetAppNamespace(app.registration.Name)
 
-	for _, secretName := range []string{defaults.AzureACRServicePrincipleSecretName, defaults.AzureACRServicePrincipleBuildahSecretName, defaults.AzureACRTokenPasswordAppRegistrySecretName} {
+	for _, secretName := range []string{defaults.AzureACRServicePrincipleBuildahSecretName, defaults.AzureACRTokenPasswordAppRegistrySecretName} {
 		err := app.copySecretData(ctx, corev1.NamespaceDefault, appNamespace, secretName)
 		if err != nil {
 			return fmt.Errorf("failed to sync secret %s: %w", secretName, err)

--- a/pkg/apis/defaults/commonsecrets.go
+++ b/pkg/apis/defaults/commonsecrets.go
@@ -1,9 +1,6 @@
 package defaults
 
 const (
-	// AzureACRServicePrincipleSecretName name of the secret containing ACR authentication information, consumed by az cli
-	AzureACRServicePrincipleSecretName = "radix-sp-acr-azure"
-
 	// AzureACRServicePrincipleBuildahSecretName name of the secret containing ACR authentication information, consumed by buildah
 	AzureACRServicePrincipleBuildahSecretName = "radix-sp-buildah-azure"
 

--- a/pkg/apis/test/utils.go
+++ b/pkg/apis/test/utils.go
@@ -345,20 +345,6 @@ func (tu *Utils) CreateClusterPrerequisites(clustername, subscriptionId string) 
 		context.Background(),
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      defaults.AzureACRServicePrincipleSecretName,
-				Namespace: corev1.NamespaceDefault,
-			},
-			StringData: map[string]string{
-				"sp_credentials.json": "{}",
-			},
-		},
-		metav1.CreateOptions{})
-	errs = append(errs, err)
-
-	_, err = tu.client.CoreV1().Secrets(corev1.NamespaceDefault).Create(
-		context.Background(),
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
 				Name:      defaults.AzureACRServicePrincipleBuildahSecretName,
 				Namespace: corev1.NamespaceDefault,
 			},


### PR DESCRIPTION
Eliminate references and usage of the Azure ACR service principal secret to streamline the code and enhance security. This change simplifies the handling of container registry credentials.