### PR TITLE
fix: allow api-server to create events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,9 +239,19 @@ delete-temp-resources:
 	rm -rf $(CRD_TEMP_DIR)
 
 .PHONY: lint
-lint: bootstrap
+lint: lint-fmt lint-golangci lint-helm
+
+lint-fmt: bootstrap
 	go fmt ./...
+
+lint-golangci: bootstrap
 	golangci-lint run
+
+lint-helm: bootstrap
+	helm lint ./charts/radix-operator \
+		--set rbac.createApp.groups[0]=platform-users \
+		--set ingress.gateway.name=radix \
+		--set ingress.gateway.namespace=istio
 
 .PHONY: generate
 generate: bootstrap code-gen helmresources mocks swagger

--- a/charts/radix-operator/templates/deployment.yaml
+++ b/charts/radix-operator/templates/deployment.yaml
@@ -169,9 +169,9 @@ spec:
               value: {{ .Values.radixPipelineRunner.image.pullPolicy | default "Always" }}
 
             - name: RADIXOPERATOR_INGRESS_GATEWAY_NAME
-              value: {{ required "gateway name is required to operate" .Values.ingress.gateway.name }}
+              value: {{ required "ingress.gateway.name is required to operate" .Values.ingress.gateway.name }}
             - name: RADIXOPERATOR_INGRESS_GATEWAY_NAMESPACE
-              value: {{ required "gateway namespace is required to operate" .Values.ingress.gateway.namespace }}
+              value: {{ required "ingress.gateway.namespace is required to operate" .Values.ingress.gateway.namespace }}
             - name: RADIXOPERATOR_INGRESS_GATEWAY_SECTION_NAME
               value: {{ .Values.ingress.gateway.sectionName }}
             - name: RADIXOPERATOR_SAFE_TO_RESTART_BATCH_JOB_THRESHOLD

--- a/charts/radix-operator/templates/radix-api-server-rbac.yaml
+++ b/charts/radix-operator/templates/radix-api-server-rbac.yaml
@@ -98,6 +98,12 @@ rules:
   verbs:
   - get
   - update
+- apigroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/radix-operator/templates/radix-api-server-rbac.yaml
+++ b/charts/radix-operator/templates/radix-api-server-rbac.yaml
@@ -99,7 +99,7 @@ rules:
   - get
   - update
 - apigroups:
-  - ''
+  - '*'
   resources:
   - events
   verbs:

--- a/charts/radix-operator/templates/radix-api-server-rbac.yaml
+++ b/charts/radix-operator/templates/radix-api-server-rbac.yaml
@@ -98,8 +98,8 @@ rules:
   verbs:
   - get
   - update
-- apigroups:
-  - '*'
+- apiGroups:
+  - ''
   resources:
   - events
   verbs:


### PR DESCRIPTION
This pull request adds a new RBAC rule to the `radix-api-server` configuration to allow the creation of Kubernetes `events` resources. This enables the API server to create events, which can be useful for logging or tracking actions within the cluster.

RBAC permissions update:

* Added a rule in `radix-api-server-rbac.yaml` to grant the ability to create `events` resources in the core API group.

Fixing this bug:
> [pod/radix-api-server-6d8c6886b5-s5f8w/radix-api-server] E0710 07:27:44.113882       1 event.go:359] "Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:default:radix-api-server\" cannot create resource \"events\" in API group \"\" in the namespace \"rihag-app\"" event="&Event{ObjectMeta:{rihag.18c0dd04904eaa52  rihag-app    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:RadixApplication,Namespace:rihag-app,Name:rihag,UID:,APIVersion:radix.equinor.com/v1,ResourceVersion:,FieldPath:,},Reason:GithubPushReceived,Message:Pipeline job radix-pipeline-20260710072744-5j1uc created for branch main (commit 4942d4e323f61c7c78e7412f2a095f8d4f03c4af),Source:EventSource{Component:radix-api-server,Host:,},FirstTimestamp:2026-07-10 07:27:44.10939861 +0000 UTC m=+3719.745390988,LastTimestamp:2026-07-10 07:27:44.10939861 +0000 UTC m=+3719.745390988,Count:1,Type:Normal,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:radix-api-server,ReportingInstance:,}"