### PR TITLE
Support in API to set and fetch annotations regarding federated credential migraton

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -247,10 +247,10 @@
 				"LOG_PRETTY": "true",
 				"OIDC_AZURE_ISSUER": "https://sts.windows.net/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/",
 				"OIDC_AZURE_AUDIENCE": "6dae42f8-4368-4678-94ff-3960e28e3630",
-				"OIDC_KUBERNETES_ISSUER": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/d759e0b0-6919-470c-82d9-848a3c0cacfd/",
-				"OIDC_KUBERNETES_AUDIENCE": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/d759e0b0-6919-470c-82d9-848a3c0cacfd/",
-				"RADIX_CLUSTERNAME": "weekly-26",
-				"CLUSTER_OIDC_ISSUERS": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/d759e0b0-6919-470c-82d9-848a3c0cacfd/,https://test-issuer.internal.radix.equinor.com",
+				"OIDC_KUBERNETES_ISSUER": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/d9638477-2a54-40df-bb15-32f73505f631/",
+				"OIDC_KUBERNETES_AUDIENCE": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/d9638477-2a54-40df-bb15-32f73505f631/",
+				"RADIX_CLUSTERNAME": "weekly-29",
+				"CLUSTER_OIDC_ISSUERS": "https://northeurope.oic.prod-aks.azure.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/d9638477-2a54-40df-bb15-32f73505f631/,https://test-issuer.internal.radix.equinor.com",
 				"CLUSTER_EGRESS_IPS": "0.0.0.0"
 			}
 		}

--- a/api-server/api/applications/applications_controller.go
+++ b/api-server/api/applications/applications_controller.go
@@ -148,6 +148,11 @@ func (ac *applicationController) GetRoutes() models.Routes {
 			Method:      "GET",
 			HandlerFunc: ac.GetApplicationEvents,
 		},
+		models.Route{
+			Path:        appPath + "/federated-credentials-migrated",
+			Method:      "POST",
+			HandlerFunc: ac.SetFederatedCredentialsMigratedAnnotation,
+		},
 	}
 
 	return routes

--- a/api-server/api/applications/applications_controller.go
+++ b/api-server/api/applications/applications_controller.go
@@ -1157,7 +1157,7 @@ func (ac *applicationController) GetApplicationEvents(accounts models.Accounts, 
 
 // SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
 func (ac *applicationController) SetFederatedCredentialsMigratedAnnotation(accounts models.Accounts, w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /applications/{appName}/federated-credentials-migration application federatedCredentialsMigratedAnnotation
+	// swagger:operation POST /applications/{appName}/federated-credentials-migrated application federatedCredentialsMigratedAnnotation
 	// ---
 	// summary: Sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
 	// parameters:

--- a/api-server/api/applications/applications_controller.go
+++ b/api-server/api/applications/applications_controller.go
@@ -150,7 +150,7 @@ func (ac *applicationController) GetRoutes() models.Routes {
 		},
 		models.Route{
 			Path:        appPath + "/federated-credentials-migrated",
-			Method:      "POST",
+			Method:      "PATCH",
 			HandlerFunc: ac.SetFederatedCredentialsMigratedAnnotation,
 		},
 	}
@@ -1157,7 +1157,7 @@ func (ac *applicationController) GetApplicationEvents(accounts models.Accounts, 
 
 // SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
 func (ac *applicationController) SetFederatedCredentialsMigratedAnnotation(accounts models.Accounts, w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /applications/{appName}/federated-credentials-migrated application federatedCredentialsMigratedAnnotation
+	// swagger:operation PATCH /applications/{appName}/federated-credentials-migrated application federatedCredentialsMigratedAnnotation
 	// ---
 	// summary: Sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
 	// parameters:
@@ -1184,10 +1184,7 @@ func (ac *applicationController) SetFederatedCredentialsMigratedAnnotation(accou
 	//   "404":
 	//     description: "Not found"
 
-	// TODO: Update Swagger annotations to actually reflect what this endpoint returns
-
 	appName := mux.Vars(r)["appName"]
-
 	handler := ac.applicationHandlerFactory.Create(accounts)
 
 	if err := handler.SetFederatedCredentialsMigratedAnnotation(r.Context(), appName, r); err != nil {

--- a/api-server/api/applications/applications_controller.go
+++ b/api-server/api/applications/applications_controller.go
@@ -1154,3 +1154,46 @@ func (ac *applicationController) GetApplicationEvents(accounts models.Accounts, 
 
 	ac.JSONResponse(w, r, appEvents)
 }
+
+// SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
+func (ac *applicationController) SetFederatedCredentialsMigratedAnnotation(accounts models.Accounts, w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /applications/{appName}/federated-credentials-migration application federatedCredentialsMigratedAnnotation
+	// ---
+	// summary: Sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
+	// parameters:
+	// - name: appName
+	//   in: path
+	//   description: name of application
+	//   type: string
+	//   required: true
+	// - name: Impersonate-User
+	//   in: header
+	//   description: Works only with custom setup of cluster. Allow impersonation of test users (Required if Impersonate-Group is set)
+	//   type: string
+	//   required: false
+	// - name: Impersonate-Group
+	//   in: header
+	//   description: Works only with custom setup of cluster. Allow impersonation of a comma-separated list of test groups (Required if Impersonate-User is set)
+	//   type: string
+	//   required: false
+	// responses:
+	//   "204":
+	//     description: Successfully set the annotation
+	//   "401":
+	//     description: "Unauthorized"
+	//   "404":
+	//     description: "Not found"
+
+	// TODO: Update Swagger annotations to actually reflect what this endpoint returns
+
+	appName := mux.Vars(r)["appName"]
+
+	handler := ac.applicationHandlerFactory.Create(accounts)
+
+	if err := handler.SetFederatedCredentialsMigratedAnnotation(r.Context(), appName, r); err != nil {
+		ac.ErrorResponse(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api-server/api/applications/applications_controller.go
+++ b/api-server/api/applications/applications_controller.go
@@ -1187,7 +1187,7 @@ func (ac *applicationController) SetFederatedCredentialsMigratedAnnotation(accou
 	appName := mux.Vars(r)["appName"]
 	handler := ac.applicationHandlerFactory.Create(accounts)
 
-	if err := handler.SetFederatedCredentialsMigratedAnnotation(r.Context(), appName, r); err != nil {
+	if err := handler.SetFederatedCredentialsMigratedAnnotation(r.Context(), appName); err != nil {
 		ac.ErrorResponse(w, r, err)
 		return
 	}

--- a/api-server/api/applications/applications_controller_test.go
+++ b/api-server/api/applications/applications_controller_test.go
@@ -51,9 +51,10 @@ import (
 )
 
 const (
-	clusterName    = "AnyClusterName"
-	dnsZone        = "some-dns-zone.com"
-	subscriptionId = "12347718-c8f8-4995-bfbb-02655ff1f89c"
+	clusterName                            = "AnyClusterName"
+	dnsZone                                = "some-dns-zone.com"
+	subscriptionId                         = "12347718-c8f8-4995-bfbb-02655ff1f89c"
+	federatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
 )
 
 func setupTest(t *testing.T, options ...ApplicationHandlerOption) (*commontest.Utils, *controllertest.Utils, *kubefake.Clientset, *radixfake.Clientset, *kedafake.Clientset, dynamicclient.Client, *secretproviderfake.Clientset, *certfake.Clientset, *tektonclientfake.Clientset) {
@@ -1408,6 +1409,48 @@ func TestRegenerateDeployKey_InvalidKeyInParam_ErrorIsReturned(t *testing.T) {
 	responseChannel := controllerTestUtils.ExecuteRequestWithParameters("POST", fmt.Sprintf("/api/v1/applications/%s/regenerate-deploy-key", appName), regenerateParameters)
 	response := <-responseChannel
 	assert.Equal(t, http.StatusBadRequest, response.Code)
+}
+
+func TestSetFederatedCredentialsMigratedAnnotation_RouteSetsAnnotation(t *testing.T) {
+	commonTestUtils, controllerTestUtils, _, radixClient, _, _, _, _, _ := setupTest(t)
+	appName := "any-name"
+
+	_, err := commonTestUtils.ApplyRegistration(builders.ARadixRegistration().WithName(appName).WithCloneURL("git@github.com:Equinor/my-app.git"))
+	require.NoError(t, err)
+
+	responseChannel := controllerTestUtils.ExecuteRequest("PATCH", fmt.Sprintf("/api/v1/applications/%s/federated-credentials-migrated", appName))
+	response := <-responseChannel
+	assert.Equal(t, http.StatusNoContent, response.Code)
+
+	radixRegistration, err := radixClient.RadixV1().RadixRegistrations().Get(context.Background(), appName, metav1.GetOptions{})
+	require.NoError(t, err)
+	annotationValue, exists := radixRegistration.Annotations[federatedCredentialsMigratedAnnotation]
+	require.True(t, exists)
+	assert.Regexp(t, `^test-principal, \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC$`, annotationValue)
+}
+
+func TestApplicationHandler_SetFederatedCredentialsMigratedAnnotation_IsIdempotent(t *testing.T) {
+	commonTestUtils, controllerTestUtils, _, radixClient, _, _, _, _, _ := setupTest(t)
+	appName := "any-name"
+
+	_, err := commonTestUtils.ApplyRegistration(builders.ARadixRegistration().WithName(appName).WithCloneURL("git@github.com:Equinor/my-app.git"))
+	require.NoError(t, err)
+
+	responseChannel := controllerTestUtils.ExecuteRequest("PATCH", fmt.Sprintf("/api/v1/applications/%s/federated-credentials-migrated", appName))
+	response := <-responseChannel
+	assert.Equal(t, http.StatusNoContent, response.Code)
+
+	firstRegistration, err := radixClient.RadixV1().RadixRegistrations().Get(context.Background(), appName, metav1.GetOptions{})
+	require.NoError(t, err)
+	firstAnnotationValue := firstRegistration.Annotations[federatedCredentialsMigratedAnnotation]
+
+	responseChannel = controllerTestUtils.ExecuteRequest("PATCH", fmt.Sprintf("/api/v1/applications/%s/federated-credentials-migrated", appName))
+	response = <-responseChannel
+	assert.Equal(t, http.StatusNoContent, response.Code)
+
+	secondRegistration, err := radixClient.RadixV1().RadixRegistrations().Get(context.Background(), appName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, firstAnnotationValue, secondRegistration.Annotations[federatedCredentialsMigratedAnnotation])
 }
 
 func Test_GetUsedResources(t *testing.T) {

--- a/api-server/api/applications/applications_handler.go
+++ b/api-server/api/applications/applications_handler.go
@@ -554,6 +554,11 @@ func (ah *ApplicationHandler) validateUserIsMemberOfAdGroups(ctx context.Context
 	return nil
 }
 
+// SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
+func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx context.Context, appName string, r *http.Request) error {
+	// TODO: Find RadixRegistration belonging to app and set annotation
+}
+
 func createRoleToGetConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace, roleName string, labels map[string]string, configMapName string) (*rbacv1.Role, error) {
 	return kubeClient.RbacV1().Roles(namespace).Create(ctx, &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{GenerateName: roleName, Labels: labels},

--- a/api-server/api/applications/applications_handler.go
+++ b/api-server/api/applications/applications_handler.go
@@ -555,7 +555,7 @@ func (ah *ApplicationHandler) validateUserIsMemberOfAdGroups(ctx context.Context
 }
 
 // SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
-func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx context.Context, appName string, _ *http.Request) error {
+func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx context.Context, appName string) error {
 	const federatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/api-server/api/applications/applications_handler.go
+++ b/api-server/api/applications/applications_handler.go
@@ -564,11 +564,18 @@ func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx cont
 			return err
 		}
 
+		if _, exists := currentRegistration.Annotations[federatedCredentialsMigratedAnnotation]; exists {
+			return nil
+		}
+
 		updatedRegistration := currentRegistration.DeepCopy()
 		if updatedRegistration.Annotations == nil {
 			updatedRegistration.Annotations = map[string]string{}
 		}
-		updatedRegistration.Annotations[federatedCredentialsMigratedAnnotation] = "true"
+
+		now := time.Now().UTC().Format("2006-01-02 15:04:05 MST")
+		user := auth.GetOriginator(ctx)
+		updatedRegistration.Annotations[federatedCredentialsMigratedAnnotation] = fmt.Sprintf("%s, %s", user, now)
 
 		_, err = ah.getUserAccount().RadixClient.RadixV1().RadixRegistrations().Update(ctx, updatedRegistration, metav1.UpdateOptions{})
 		return err

--- a/api-server/api/applications/applications_handler.go
+++ b/api-server/api/applications/applications_handler.go
@@ -555,8 +555,24 @@ func (ah *ApplicationHandler) validateUserIsMemberOfAdGroups(ctx context.Context
 }
 
 // SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
-func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx context.Context, appName string, r *http.Request) error {
-	// TODO: Find RadixRegistration belonging to app and set annotation
+func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx context.Context, appName string, _ *http.Request) error {
+	const federatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentRegistration, err := ah.getUserAccount().RadixClient.RadixV1().RadixRegistrations().Get(ctx, appName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		updatedRegistration := currentRegistration.DeepCopy()
+		if updatedRegistration.Annotations == nil {
+			updatedRegistration.Annotations = map[string]string{}
+		}
+		updatedRegistration.Annotations[federatedCredentialsMigratedAnnotation] = "true"
+
+		_, err = ah.getUserAccount().RadixClient.RadixV1().RadixRegistrations().Update(ctx, updatedRegistration, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func createRoleToGetConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace, roleName string, labels map[string]string, configMapName string) (*rbacv1.Role, error) {

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -4298,7 +4298,7 @@
       }
     },
     "/applications/{appName}/federated-credentials-migrated": {
-      "post": {
+      "patch": {
         "tags": [
           "application"
         ],

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -4297,6 +4297,47 @@
         }
       }
     },
+    "/applications/{appName}/federated-credentials-migrated": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "Sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR",
+        "operationId": "federatedCredentialsMigratedAnnotation",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "name of application",
+            "name": "appName",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Works only with custom setup of cluster. Allow impersonation of test users (Required if Impersonate-Group is set)",
+            "name": "Impersonate-User",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "Works only with custom setup of cluster. Allow impersonation of a comma-separated list of test groups (Required if Impersonate-User is set)",
+            "name": "Impersonate-Group",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully set the annotation"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/applications/{appName}/jobs": {
       "get": {
         "tags": [


### PR DESCRIPTION
Once users have updated federated credentials for the new cluster issuer we want them to confirm that they have done so.
This will be set as an annotation on the RadixRegistration CR.