### PR TITLE
feat: get annotation in get application

### DIFF
--- a/api-server/api/applications/applications_controller_test.go
+++ b/api-server/api/applications/applications_controller_test.go
@@ -509,7 +509,7 @@ func TestGetApplication_Annotations(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"radix.equinor.com/federated-credentials-migrated": "true",
-	}, application.Annotations)
+	}, application.Registration.Annotations)
 }
 
 func TestGetApplication_Annotations_NoneExposed_ReturnsNil(t *testing.T) {
@@ -527,7 +527,7 @@ func TestGetApplication_Annotations_NoneExposed_ReturnsNil(t *testing.T) {
 	application := applicationModels.Application{}
 	err = controllertest.GetResponseBody(response, &application)
 	require.NoError(t, err)
-	assert.Nil(t, application.Annotations)
+	assert.Nil(t, application.Registration.Annotations)
 }
 
 func TestGetApplication_WithJobs(t *testing.T) {

--- a/api-server/api/applications/applications_controller_test.go
+++ b/api-server/api/applications/applications_controller_test.go
@@ -492,6 +492,44 @@ func TestGetApplication_AllFieldsAreSet(t *testing.T) {
 	assert.Equal(t, "ci", application.Registration.ConfigurationItem)
 }
 
+func TestGetApplication_Annotations(t *testing.T) {
+	commonTestUtils, controllerTestUtils, _, _, _, _, _, _, _ := setupTest(t)
+	_, err := commonTestUtils.ApplyRegistration(builders.ARadixRegistration().
+		WithName("any-name").
+		WithAnnotations(map[string]string{
+			"radix.equinor.com/federated-credentials-migrated": "true",
+		}))
+	require.NoError(t, err)
+
+	responseChannel := controllerTestUtils.ExecuteRequest("GET", fmt.Sprintf("/api/v1/applications/%s", "any-name"))
+	response := <-responseChannel
+
+	application := applicationModels.Application{}
+	err = controllertest.GetResponseBody(response, &application)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"radix.equinor.com/federated-credentials-migrated": "true",
+	}, application.Annotations)
+}
+
+func TestGetApplication_Annotations_NoneExposed_ReturnsNil(t *testing.T) {
+	commonTestUtils, controllerTestUtils, _, _, _, _, _, _, _ := setupTest(t)
+	_, err := commonTestUtils.ApplyRegistration(builders.ARadixRegistration().
+		WithName("any-name").
+		WithAnnotations(map[string]string{
+			"some.other/annotation": "should-be-filtered",
+		}))
+	require.NoError(t, err)
+
+	responseChannel := controllerTestUtils.ExecuteRequest("GET", fmt.Sprintf("/api/v1/applications/%s", "any-name"))
+	response := <-responseChannel
+
+	application := applicationModels.Application{}
+	err = controllertest.GetResponseBody(response, &application)
+	require.NoError(t, err)
+	assert.Nil(t, application.Annotations)
+}
+
 func TestGetApplication_WithJobs(t *testing.T) {
 	// Setup
 	commonTestUtils, controllerTestUtils, kubeclient, _, _, _, _, _, _ := setupTest(t)

--- a/api-server/api/applications/models/application.go
+++ b/api-server/api/applications/models/application.go
@@ -53,4 +53,9 @@ type Application struct {
 	//
 	// required: true
 	UseBuildCache bool `json:"useBuildCache"`
+
+	// Annotations of the application RadixRegistration resource
+	//
+	// required: false
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/api-server/api/applications/models/application.go
+++ b/api-server/api/applications/models/application.go
@@ -53,9 +53,4 @@ type Application struct {
 	//
 	// required: true
 	UseBuildCache bool `json:"useBuildCache"`
-
-	// Annotations of the application RadixRegistration resource
-	//
-	// required: false
-	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/api-server/api/applications/models/application_registration.go
+++ b/api-server/api/applications/models/application_registration.go
@@ -72,4 +72,9 @@ type ApplicationRegistration struct {
 	//
 	// required: false
 	ConfigurationItem string `json:"configurationItem"`
+
+	// Annotations of the RadixRegistration resource
+	//
+	// required: false
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/api-server/api/models/application.go
+++ b/api-server/api/models/application.go
@@ -8,7 +8,7 @@ import (
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
-var annotationsToExpose = []string{
+var annotationToExpose = []string{
 	"radix.equinor.com/federated-credentials-migrated",
 }
 
@@ -23,7 +23,7 @@ func BuildApplication(rr *radixv1.RadixRegistration, ra *radixv1.RadixApplicatio
 		DNSAliases:         buildDNSAlias(dnsAliasList, dnsZone),
 		DNSExternalAliases: BuildDNSExternalAliases(rdList),
 		UseBuildCache:      useBuildCache(ra),
-		Annotations:        filterAnnotations(rr.Annotations, annotationsToExpose),
+		Annotations:        filterAnnotation(rr.Annotations, annotationToExpose),
 	}
 	if ra != nil {
 		application.Environments = BuildEnvironmentSummaryList(rr, ra, reList, rdList, rjList)
@@ -65,7 +65,7 @@ func buildDNSAlias(dnsAliases []radixv1.RadixDNSAlias, dnsZone string) []applica
 	})
 }
 
-func filterAnnotations(annotations map[string]string, keys []string) map[string]string {
+func filterAnnotation(annotations map[string]string, keys []string) map[string]string {
 	result := make(map[string]string)
 	for _, key := range keys {
 		if val, ok := annotations[key]; ok {

--- a/api-server/api/models/application.go
+++ b/api-server/api/models/application.go
@@ -23,7 +23,6 @@ func BuildApplication(rr *radixv1.RadixRegistration, ra *radixv1.RadixApplicatio
 		DNSAliases:         buildDNSAlias(dnsAliasList, dnsZone),
 		DNSExternalAliases: BuildDNSExternalAliases(rdList),
 		UseBuildCache:      useBuildCache(ra),
-		Annotations:        filterAnnotation(rr.Annotations, annotationToExpose),
 	}
 	if ra != nil {
 		application.Environments = BuildEnvironmentSummaryList(rr, ra, reList, rdList, rjList)

--- a/api-server/api/models/application.go
+++ b/api-server/api/models/application.go
@@ -8,6 +8,10 @@ import (
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
+var annotationsToExpose = []string{
+	"radix.equinor.com/federated-credentials-migrated",
+}
+
 // BuildApplication builds an Application model.
 func BuildApplication(rr *radixv1.RadixRegistration, ra *radixv1.RadixApplication, reList []radixv1.RadixEnvironment, rdList []radixv1.RadixDeployment, rjList []radixv1.RadixJob, userIsAdmin bool, dnsAliasList []radixv1.RadixDNSAlias, dnsZone string) *applicationModels.Application {
 	application := applicationModels.Application{
@@ -19,6 +23,7 @@ func BuildApplication(rr *radixv1.RadixRegistration, ra *radixv1.RadixApplicatio
 		DNSAliases:         buildDNSAlias(dnsAliasList, dnsZone),
 		DNSExternalAliases: BuildDNSExternalAliases(rdList),
 		UseBuildCache:      useBuildCache(ra),
+		Annotations:        filterAnnotations(rr.Annotations, annotationsToExpose),
 	}
 	if ra != nil {
 		application.Environments = BuildEnvironmentSummaryList(rr, ra, reList, rdList, rjList)
@@ -58,4 +63,17 @@ func buildDNSAlias(dnsAliases []radixv1.RadixDNSAlias, dnsZone string) []applica
 			},
 		})
 	})
+}
+
+func filterAnnotations(annotations map[string]string, keys []string) map[string]string {
+	result := make(map[string]string)
+	for _, key := range keys {
+		if val, ok := annotations[key]; ok {
+			result[key] = val
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/api-server/api/models/application_registration.go
+++ b/api-server/api/models/application_registration.go
@@ -8,5 +8,6 @@ import (
 // BuildApplicationRegistration builds an ApplicationRegistration model.
 func BuildApplicationRegistration(rr *radixv1.RadixRegistration) *applicationModels.ApplicationRegistration {
 	appReg := applicationModels.NewApplicationRegistrationBuilder().WithRadixRegistration(rr).Build()
+	appReg.Annotations = filterAnnotation(rr.Annotations, annotationToExpose)
 	return &appReg
 }

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -5908,6 +5908,14 @@
         "useBuildCache"
       ],
       "properties": {
+        "annotations": {
+          "description": "Annotations of the application RadixRegistration resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "appAlias": {
           "$ref": "#/definitions/ApplicationAlias"
         },

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -5908,14 +5908,6 @@
         "useBuildCache"
       ],
       "properties": {
-        "annotations": {
-          "description": "Annotations of the application RadixRegistration resource",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Annotations"
-        },
         "appAlias": {
           "$ref": "#/definitions/ApplicationAlias"
         },
@@ -6035,6 +6027,14 @@
             "type": "string"
           },
           "x-go-name": "AdUsers"
+        },
+        "annotations": {
+          "description": "Annotations of the RadixRegistration resource",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
         },
         "appId": {
           "description": "AppID the unique application ID, which is a ULID",


### PR DESCRIPTION
Task related: 
- https://github.com/equinor/radix-private/issues/639


As per discussion in [slack](https://equinor.slack.com/archives/G9M0R6BSB/p1784197666360309) and in office, we decided to return in getApplication only `´radix.equinor.com/federated-credentials-migrated´` annotation. 