### PR TITLE
fix(api): make HasFederatedCredentialAnnotation bool

### DIFF
--- a/api-server/api/applications/applications_controller_test.go
+++ b/api-server/api/applications/applications_controller_test.go
@@ -54,7 +54,7 @@ const (
 	clusterName                            = "AnyClusterName"
 	dnsZone                                = "some-dns-zone.com"
 	subscriptionId                         = "12347718-c8f8-4995-bfbb-02655ff1f89c"
-	federatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
+	federatedCredentialsMigratedAnnotation = kube.RadixFederatedCredentialsMigratedAnnotation
 )
 
 func setupTest(t *testing.T, options ...ApplicationHandlerOption) (*commontest.Utils, *controllertest.Utils, *kubefake.Clientset, *radixfake.Clientset, *kedafake.Clientset, dynamicclient.Client, *secretproviderfake.Clientset, *certfake.Clientset, *tektonclientfake.Clientset) {
@@ -493,12 +493,12 @@ func TestGetApplication_AllFieldsAreSet(t *testing.T) {
 	assert.Equal(t, "ci", application.Registration.ConfigurationItem)
 }
 
-func TestGetApplication_Annotations(t *testing.T) {
+func TestGetApplication_HasFederatedCredentialAnnotation_True(t *testing.T) {
 	commonTestUtils, controllerTestUtils, _, _, _, _, _, _, _ := setupTest(t)
 	_, err := commonTestUtils.ApplyRegistration(builders.ARadixRegistration().
 		WithName("any-name").
 		WithAnnotations(map[string]string{
-			"radix.equinor.com/federated-credentials-migrated": "true",
+			federatedCredentialsMigratedAnnotation: "true",
 		}))
 	require.NoError(t, err)
 
@@ -508,17 +508,15 @@ func TestGetApplication_Annotations(t *testing.T) {
 	application := applicationModels.Application{}
 	err = controllertest.GetResponseBody(response, &application)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"radix.equinor.com/federated-credentials-migrated": "true",
-	}, application.Registration.Annotations)
+	assert.True(t, application.Registration.HasFederatedCredentialAnnotation)
 }
 
-func TestGetApplication_Annotations_NoneExposed_ReturnsNil(t *testing.T) {
+func TestGetApplication_HasFederatedCredentialAnnotation_FalseWhenNotPresent(t *testing.T) {
 	commonTestUtils, controllerTestUtils, _, _, _, _, _, _, _ := setupTest(t)
 	_, err := commonTestUtils.ApplyRegistration(builders.ARadixRegistration().
 		WithName("any-name").
 		WithAnnotations(map[string]string{
-			"some.other/annotation": "should-be-filtered",
+			"some.other/annotation": "should-be-ignored",
 		}))
 	require.NoError(t, err)
 
@@ -528,7 +526,7 @@ func TestGetApplication_Annotations_NoneExposed_ReturnsNil(t *testing.T) {
 	application := applicationModels.Application{}
 	err = controllertest.GetResponseBody(response, &application)
 	require.NoError(t, err)
-	assert.Nil(t, application.Registration.Annotations)
+	assert.False(t, application.Registration.HasFederatedCredentialAnnotation)
 }
 
 func TestGetApplication_WithJobs(t *testing.T) {

--- a/api-server/api/applications/applications_controller_test.go
+++ b/api-server/api/applications/applications_controller_test.go
@@ -508,7 +508,7 @@ func TestGetApplication_HasFederatedCredentialAnnotation_True(t *testing.T) {
 	application := applicationModels.Application{}
 	err = controllertest.GetResponseBody(response, &application)
 	require.NoError(t, err)
-	assert.True(t, application.Registration.HasFederatedCredentialAnnotation)
+	assert.True(t, application.Registration.HasMigratedFederatedCredential)
 }
 
 func TestGetApplication_HasFederatedCredentialAnnotation_FalseWhenNotPresent(t *testing.T) {
@@ -526,7 +526,7 @@ func TestGetApplication_HasFederatedCredentialAnnotation_FalseWhenNotPresent(t *
 	application := applicationModels.Application{}
 	err = controllertest.GetResponseBody(response, &application)
 	require.NoError(t, err)
-	assert.False(t, application.Registration.HasFederatedCredentialAnnotation)
+	assert.False(t, application.Registration.HasMigratedFederatedCredential)
 }
 
 func TestGetApplication_WithJobs(t *testing.T) {

--- a/api-server/api/applications/applications_handler.go
+++ b/api-server/api/applications/applications_handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/equinor/radix-operator/api-server/models"
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/defaults/k8s"
+	"github.com/equinor/radix-operator/pkg/apis/kube"
 	jobPipeline "github.com/equinor/radix-operator/pkg/apis/pipeline"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	operatorUtils "github.com/equinor/radix-operator/pkg/apis/utils"
@@ -556,7 +557,7 @@ func (ah *ApplicationHandler) validateUserIsMemberOfAdGroups(ctx context.Context
 
 // SetFederatedCredentialsMigratedAnnotation sets the radix.equinor.com/federeated-credentials-migrated annotation on the applications RadixRegistration CR
 func (ah *ApplicationHandler) SetFederatedCredentialsMigratedAnnotation(ctx context.Context, appName string) error {
-	const federatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
+	const federatedCredentialsMigratedAnnotation = kube.RadixFederatedCredentialsMigratedAnnotation
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		currentRegistration, err := ah.getUserAccount().RadixClient.RadixV1().RadixRegistrations().Get(ctx, appName, metav1.GetOptions{})

--- a/api-server/api/applications/models/application_registration.go
+++ b/api-server/api/applications/models/application_registration.go
@@ -73,8 +73,8 @@ type ApplicationRegistration struct {
 	// required: false
 	ConfigurationItem string `json:"configurationItem"`
 
-	// HasFederatedCredentialAnnotation indicates whether federated credential annotation exists
+	// HasMigratedFederatedCredential indicates whether federated credential annotation exists
 	//
 	// required: true
-	HasFederatedCredentialAnnotation bool `json:"hasFederatedCredentialAnnotation"`
+	HasMigratedFederatedCredential bool `json:"hasMigratedFederatedCredential"`
 }

--- a/api-server/api/applications/models/application_registration.go
+++ b/api-server/api/applications/models/application_registration.go
@@ -73,8 +73,8 @@ type ApplicationRegistration struct {
 	// required: false
 	ConfigurationItem string `json:"configurationItem"`
 
-	// Annotations of the RadixRegistration resource
+	// HasFederatedCredentialAnnotation indicates whether federated credential annotation exists
 	//
-	// required: false
-	Annotations map[string]string `json:"annotations,omitempty"`
+	// required: true
+	HasFederatedCredentialAnnotation bool `json:"hasFederatedCredentialAnnotation"`
 }

--- a/api-server/api/models/application.go
+++ b/api-server/api/models/application.go
@@ -8,10 +8,6 @@ import (
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
-var annotationToExpose = []string{
-	"radix.equinor.com/federated-credentials-migrated",
-}
-
 // BuildApplication builds an Application model.
 func BuildApplication(rr *radixv1.RadixRegistration, ra *radixv1.RadixApplication, reList []radixv1.RadixEnvironment, rdList []radixv1.RadixDeployment, rjList []radixv1.RadixJob, userIsAdmin bool, dnsAliasList []radixv1.RadixDNSAlias, dnsZone string) *applicationModels.Application {
 	application := applicationModels.Application{
@@ -62,17 +58,4 @@ func buildDNSAlias(dnsAliases []radixv1.RadixDNSAlias, dnsZone string) []applica
 			},
 		})
 	})
-}
-
-func filterAnnotation(annotations map[string]string, keys []string) map[string]string {
-	result := make(map[string]string)
-	for _, key := range keys {
-		if val, ok := annotations[key]; ok {
-			result[key] = val
-		}
-	}
-	if len(result) == 0 {
-		return nil
-	}
-	return result
 }

--- a/api-server/api/models/application_registration.go
+++ b/api-server/api/models/application_registration.go
@@ -2,12 +2,18 @@ package models
 
 import (
 	applicationModels "github.com/equinor/radix-operator/api-server/api/applications/models"
+	"github.com/equinor/radix-operator/pkg/apis/kube"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
 
 // BuildApplicationRegistration builds an ApplicationRegistration model.
 func BuildApplicationRegistration(rr *radixv1.RadixRegistration) *applicationModels.ApplicationRegistration {
 	appReg := applicationModels.NewApplicationRegistrationBuilder().WithRadixRegistration(rr).Build()
-	appReg.Annotations = filterAnnotation(rr.Annotations, annotationToExpose)
+	appReg.HasFederatedCredentialAnnotation = hasFederatedCredentialAnnotation(rr.Annotations)
 	return &appReg
+}
+
+func hasFederatedCredentialAnnotation(annotations map[string]string) bool {
+	_, ok := annotations[kube.RadixFederatedCredentialsMigratedAnnotation]
+	return ok
 }

--- a/api-server/api/models/application_registration.go
+++ b/api-server/api/models/application_registration.go
@@ -9,7 +9,7 @@ import (
 // BuildApplicationRegistration builds an ApplicationRegistration model.
 func BuildApplicationRegistration(rr *radixv1.RadixRegistration) *applicationModels.ApplicationRegistration {
 	appReg := applicationModels.NewApplicationRegistrationBuilder().WithRadixRegistration(rr).Build()
-	appReg.HasFederatedCredentialAnnotation = hasFederatedCredentialAnnotation(rr.Annotations)
+	appReg.HasMigratedFederatedCredential = hasFederatedCredentialAnnotation(rr.Annotations)
 	return &appReg
 }
 

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -6051,7 +6051,7 @@
         "owner",
         "creator",
         "configBranch",
-        "hasFederatedCredentialAnnotation"
+        "hasMigratedFederatedCredential"
       ],
       "properties": {
         "adGroups": {
@@ -6091,10 +6091,10 @@
           "type": "string",
           "x-go-name": "Creator"
         },
-        "hasFederatedCredentialAnnotation": {
-          "description": "HasFederatedCredentialAnnotation indicates whether federated credential annotation exists",
+        "hasMigratedFederatedCredential": {
+          "description": "HasMigratedFederatedCredential indicates whether federated credential annotation exists",
           "type": "boolean",
-          "x-go-name": "HasFederatedCredentialAnnotation"
+          "x-go-name": "HasMigratedFederatedCredential"
         },
         "name": {
           "description": "Name the unique name of the Radix application",

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -6050,7 +6050,8 @@
         "readerAdUsers",
         "owner",
         "creator",
-        "configBranch"
+        "configBranch",
+        "hasFederatedCredentialAnnotation"
       ],
       "properties": {
         "adGroups": {
@@ -6068,14 +6069,6 @@
             "type": "string"
           },
           "x-go-name": "AdUsers"
-        },
-        "annotations": {
-          "description": "Annotations of the RadixRegistration resource",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Annotations"
         },
         "appId": {
           "description": "AppID the unique application ID, which is a ULID",
@@ -6097,6 +6090,11 @@
           "description": "Owner of the application (email). Can be a single person or a shared group email",
           "type": "string",
           "x-go-name": "Creator"
+        },
+        "hasFederatedCredentialAnnotation": {
+          "description": "HasFederatedCredentialAnnotation indicates whether federated credential annotation exists",
+          "type": "boolean",
+          "x-go-name": "HasFederatedCredentialAnnotation"
         },
         "name": {
           "description": "Name the unique name of the Radix application",

--- a/pkg/apis/kube/kube.go
+++ b/pkg/apis/kube/kube.go
@@ -33,6 +33,8 @@ const (
 	RadixDeploymentPromotedFromEnvironmentAnnotation = "radix.equinor.com/radix-deployment-promoted-from-environment"
 	// RadixDeploymentObservedGeneration Used to verify kubernetes deployments are synced with active radix deployment, must contain the active RadixDeployments synced Generation
 	RadixDeploymentObservedGeneration = "radix.equinor.com/radix-deployment-observed-generation"
+	// RadixFederatedCredentialsMigratedAnnotation marks that an application's credentials have been migrated to federated credentials
+	RadixFederatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
 )
 
 // Radix Labels

--- a/pkg/apis/kube/kube.go
+++ b/pkg/apis/kube/kube.go
@@ -33,7 +33,7 @@ const (
 	RadixDeploymentPromotedFromEnvironmentAnnotation = "radix.equinor.com/radix-deployment-promoted-from-environment"
 	// RadixDeploymentObservedGeneration Used to verify kubernetes deployments are synced with active radix deployment, must contain the active RadixDeployments synced Generation
 	RadixDeploymentObservedGeneration = "radix.equinor.com/radix-deployment-observed-generation"
-	// RadixFederatedCredentialsMigratedAnnotation marks that an application's credentials have been migrated to federated credentials
+	// RadixFederatedCredentialsMigratedAnnotation marks that an user has confirmed that application's credentials have been checked and migrated to federated credentials if needed
 	RadixFederatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
 )
 


### PR DESCRIPTION
- removed`Annotations map[string]string` and just added bool `HasFederatedCredentialAnnotation`
- made it required field, default false 
- saved value in `kube.go`