### PR TITLE
fix: custom radix arguments to sub pipeline not populated for promote and deploy jobs

### DIFF
--- a/pipeline-runner/model/pipelineInfo.go
+++ b/pipeline-runner/model/pipelineInfo.go
@@ -201,12 +201,6 @@ func getStepImplementationForStepType(stepType pipeline.StepType, allStepImpleme
 	return nil
 }
 
-// SetGitAttributes Set git attributes to be used later by other steps
-func (p *PipelineInfo) SetGitAttributes(gitCommitHash, gitTags string) {
-	p.GitCommitHash = gitCommitHash
-	p.GitTags = gitTags
-}
-
 // IsPipelineType Check pipeline type
 func (p *PipelineInfo) IsPipelineType(pipelineType radixv1.RadixPipelineType) bool {
 	return p.GetRadixPipelineType() == pipelineType

--- a/pipeline-runner/steps/internal/deployment.go
+++ b/pipeline-runner/steps/internal/deployment.go
@@ -78,6 +78,26 @@ func GetGitRefNameFromDeployment(rd *radixv1.RadixDeployment) string {
 	return rd.Annotations[kube.RadixBranchAnnotation]
 }
 
+func GetGitRefTypeFromDeployment(rd *radixv1.RadixDeployment) string {
+	if rd == nil {
+		return ""
+	}
+
+	if refType, ok := rd.Annotations[kube.RadixGitRefTypeAnnotation]; ok && len(refType) > 0 {
+		return refType
+	}
+
+	return string(radixv1.GitRefBranch)
+}
+
+func GetGitTagsFromDeployment(rd *radixv1.RadixDeployment) string {
+	if rd == nil {
+		return ""
+	}
+
+	return rd.Annotations[kube.RadixGitTagsAnnotation]
+}
+
 func constructRadixDeployment(pipelineInfo *model.PipelineInfo, env, commitID, gitTags string, components []radixv1.RadixDeployComponent, jobs []radixv1.RadixDeployJobComponent, radixConfigHash, buildSecretHash string) *radixv1.RadixDeployment {
 	radixApplication := pipelineInfo.RadixApplication
 	appName := radixApplication.GetName()

--- a/pipeline-runner/steps/internal/deployment_test.go
+++ b/pipeline-runner/steps/internal/deployment_test.go
@@ -574,3 +574,26 @@ func Test_GetGitRefNameFromDeployment(t *testing.T) {
 	rd = utils.NewDeploymentBuilder().BuildRD()
 	assert.Equal(t, "", GetGitRefNameFromDeployment(rd))
 }
+
+func Test_GetGitRefTypeFromDeployment(t *testing.T) {
+	assert.Equal(t, "", GetGitRefTypeFromDeployment(nil))
+
+	rd := utils.NewDeploymentBuilder().WithAnnotations(map[string]string{kube.RadixGitRefTypeAnnotation: string(radixv1.GitRefTag)}).BuildRD()
+	assert.Equal(t, string(radixv1.GitRefTag), GetGitRefTypeFromDeployment(rd))
+
+	rd = utils.NewDeploymentBuilder().WithAnnotations(map[string]string{kube.RadixGitRefTypeAnnotation: ""}).BuildRD()
+	assert.Equal(t, string(radixv1.GitRefBranch), GetGitRefTypeFromDeployment(rd))
+
+	rd = utils.NewDeploymentBuilder().BuildRD()
+	assert.Equal(t, string(radixv1.GitRefBranch), GetGitRefTypeFromDeployment(rd))
+}
+
+func Test_GetGitTagsFromDeployment(t *testing.T) {
+	assert.Equal(t, "", GetGitTagsFromDeployment(nil))
+
+	rd := utils.NewDeploymentBuilder().WithAnnotations(map[string]string{kube.RadixGitTagsAnnotation: "v1.0.0,v1.1.0"}).BuildRD()
+	assert.Equal(t, "v1.0.0,v1.1.0", GetGitTagsFromDeployment(rd))
+
+	rd = utils.NewDeploymentBuilder().BuildRD()
+	assert.Equal(t, "", GetGitTagsFromDeployment(rd))
+}

--- a/pipeline-runner/steps/preparepipeline/step.go
+++ b/pipeline-runner/steps/preparepipeline/step.go
@@ -327,10 +327,9 @@ func (step *PreparePipelinesStepImplementation) getTargetGitInfoForSubPipelines(
 		if env, ok := pipelineInfo.GetRadixApplication().GetEnvironmentByName(pipelineInfo.PipelineArguments.ToEnvironment); ok {
 			if len(env.Build.From) > 0 {
 				gitRef = env.Build.From
-			}
-
-			if len(env.Build.FromType) > 0 {
-				gitRefType = env.Build.FromType
+				if len(env.Build.FromType) > 0 {
+					gitRefType = env.Build.FromType
+				}
 			}
 		}
 

--- a/pipeline-runner/steps/preparepipeline/step.go
+++ b/pipeline-runner/steps/preparepipeline/step.go
@@ -181,8 +181,9 @@ func (step *PreparePipelinesStepImplementation) getGitInfoForBuild(pipelineInfo 
 	if err != nil {
 		return "", "", err
 	}
-	tagsConcat := strings.Join(tags, " ")
-	if err = prepareInternal.GitTagsContainIllegalChars(tagsConcat); err != nil {
+
+	tagsConcat, err := concatGitTags(tags)
+	if err != nil {
 		return "", "", err
 	}
 
@@ -227,7 +228,7 @@ func (step *PreparePipelinesStepImplementation) setRadixConfig(pipelineInfo *mod
 }
 
 func (step *PreparePipelinesStepImplementation) setSubPipelinesToRun(ctx context.Context, pipelineInfo *model.PipelineInfo, repo git.Repository) error {
-	gitCommit, err := step.getTargetGitCommitForSubPipelines(ctx, pipelineInfo, repo)
+	gitCommit, gitTags, gitRef, gitRefType, err := step.getTargetGitInfoForSubPipelines(ctx, pipelineInfo, repo)
 	if err != nil {
 		return err
 	}
@@ -247,10 +248,10 @@ func (step *PreparePipelinesStepImplementation) setSubPipelinesToRun(ctx context
 			PipelineType: pipelineInfo.PipelineArguments.PipelineType,
 			Environment:  targetEnv.Environment,
 			GitSSHUrl:    step.GetRegistration().Spec.CloneURL,
-			GitRef:       pipelineInfo.GetGitRef(),
-			GitRefType:   pipelineInfo.GetGitRefTypeOrDefault(),
-			GitCommit:    pipelineInfo.GitCommitHash,
-			GitTags:      pipelineInfo.GitTags,
+			GitRef:       gitRef,
+			GitRefType:   gitRefType,
+			GitCommit:    gitCommit,
+			GitTags:      gitTags,
 		}
 	}
 
@@ -280,71 +281,98 @@ func (step *PreparePipelinesStepImplementation) setSubPipelinesToRun(ctx context
 	return errors.Join(errs...)
 }
 
-func (step *PreparePipelinesStepImplementation) getTargetGitCommitForSubPipelines(ctx context.Context, pipelineInfo *model.PipelineInfo, repo git.Repository) (string, error) {
-	pipelineArgs := pipelineInfo.PipelineArguments
+func (step *PreparePipelinesStepImplementation) getTargetGitInfoForSubPipelines(ctx context.Context, pipelineInfo *model.PipelineInfo, repo git.Repository) (gitCommit, gitTags, gitRef, gitRefType string, err error) {
 	pipelineType := pipelineInfo.GetRadixPipelineType()
 
-	if pipelineType == radixv1.ApplyConfig {
-		return "", nil
-	}
-
-	if pipelineType == radixv1.Promote {
-		sourceRdHashFromAnnotation, sourceDeploymentGitBranch, err := step.getPromoteSourceDeploymentGitInfo(ctx, pipelineInfo.PipelineArguments.FromEnvironment, pipelineInfo.PipelineArguments.DeploymentName)
+	switch pipelineType {
+	case radixv1.ApplyConfig:
+		return "", "", "", "", nil
+	case radixv1.BuildDeploy, radixv1.Build:
+		return pipelineInfo.GitCommitHash, pipelineInfo.GitTags, pipelineInfo.GetGitRef(), pipelineInfo.GetGitRefTypeOrDefault(), nil
+	case radixv1.Promote:
+		gitCommit, gitTags, gitRef, gitRefType, err := step.getPromoteSourceDeploymentGitInfo(ctx, pipelineInfo.PipelineArguments.FromEnvironment, pipelineInfo.PipelineArguments.DeploymentName)
 		if err != nil {
-			return "", err
+			return "", "", "", "", err
 		}
 
-		if sourceRdHashFromAnnotation != "" {
-			return sourceRdHashFromAnnotation, nil
+		if gitCommit != "" {
+			return gitCommit, gitTags, gitRef, gitRefType, nil
 		}
 
-		// TODO: Should we fail if sourcecommithash is empty instead of trying to resolve commit from source RD branch?
-		if sourceDeploymentGitBranch == "" {
+		if gitRef == "" {
 			log.Ctx(ctx).Info().Msg("Source deployment has no git metadata, skipping sub-pipelines")
-			return "", nil
+			return "", "", "", "", nil
 		}
-		sourceRdHashFromBranchHead, err := repo.ResolveCommitForReference(sourceDeploymentGitBranch)
+
+		gitCommit, err = repo.ResolveCommitForReference(gitRef)
 		if err != nil {
-			return "", nil
-		}
-		return sourceRdHashFromBranchHead, nil
-	}
-
-	if pipelineType == radixv1.Deploy {
-		pipelineJobBranch := step.GetRegistration().Spec.ConfigBranch
-
-		if env, ok := pipelineInfo.GetRadixApplication().GetEnvironmentByName(pipelineArgs.ToEnvironment); ok && len(env.Build.From) > 0 {
-			pipelineJobBranch = env.Build.From
+			return "", "", "", "", nil
 		}
 
-		if containsRegex(pipelineJobBranch) {
+		tags, err := repo.ResolveTagsForCommit(gitCommit)
+		if err != nil {
+			return "", "", "", "", err
+		}
+
+		tagsConcat, err := concatGitTags(tags)
+		if err != nil {
+			return "", "", "", "", err
+		}
+
+		return gitCommit, tagsConcat, gitRef, gitRefType, nil
+	case radixv1.Deploy:
+		gitRef = step.GetRegistration().Spec.ConfigBranch
+		gitRefType = string(radixv1.GitRefBranch)
+
+		if env, ok := pipelineInfo.GetRadixApplication().GetEnvironmentByName(pipelineInfo.PipelineArguments.ToEnvironment); ok {
+			if len(env.Build.From) > 0 {
+				gitRef = env.Build.From
+			}
+
+			if len(env.Build.FromType) > 0 {
+				gitRefType = env.Build.FromType
+			}
+		}
+
+		if containsRegex(gitRef) {
 			log.Ctx(ctx).Info().Msg("Deploy job with build branch having regex pattern, skipping sub-pipelines.")
-			return "", nil
+			return "", "", "", "", nil
 		}
 
-		gitHash, err := repo.ResolveCommitForReference(pipelineJobBranch)
+		gitCommit, err := repo.ResolveCommitForReference(gitRef)
 		if err != nil {
-			return "", err
+			return "", "", "", "", err
 		}
-		return gitHash, nil
+
+		tags, err := repo.ResolveTagsForCommit(gitCommit)
+		if err != nil {
+			return "", "", "", "", err
+		}
+
+		tagsConcat, err := concatGitTags(tags)
+		if err != nil {
+			return "", "", "", "", err
+		}
+
+		return gitCommit, tagsConcat, gitRef, gitRefType, nil
 	}
 
-	if pipelineType == radixv1.BuildDeploy || pipelineType == radixv1.Build {
-		return pipelineInfo.GitCommitHash, nil
-	}
-
-	return "", fmt.Errorf("unknown pipeline type %s", pipelineType)
+	return "", "", "", "", fmt.Errorf("unknown pipeline type %s", pipelineType)
 }
 
-func (step *PreparePipelinesStepImplementation) getPromoteSourceDeploymentGitInfo(ctx context.Context, sourceEnvName, sourceDeploymentName string) (string, string, error) {
+func (step *PreparePipelinesStepImplementation) getPromoteSourceDeploymentGitInfo(ctx context.Context, sourceEnvName, sourceDeploymentName string) (gitCommit, gitTags, gitRef, gitRefType string, err error) {
 	ns := utils.GetEnvironmentNamespace(step.GetAppName(), sourceEnvName)
 	rd, err := step.GetRadixClient().RadixV1().RadixDeployments(ns).Get(ctx, sourceDeploymentName, metav1.GetOptions{})
 	if err != nil {
-		return "", "", err
+		return "", "", "", "", err
 	}
-	gitHash := internal.GetGitCommitHashFromDeployment(rd)
-	gitBranch := internal.GetGitRefNameFromDeployment(rd)
-	return gitHash, gitBranch, err
+
+	gitCommit = internal.GetGitCommitHashFromDeployment(rd)
+	gitTags = internal.GetGitTagsFromDeployment(rd)
+	gitRef = internal.GetGitRefNameFromDeployment(rd)
+	gitRefType = internal.GetGitRefTypeFromDeployment(rd)
+
+	return gitCommit, gitTags, gitRef, gitRefType, err
 }
 
 func containsRegex(value string) bool {
@@ -768,4 +796,12 @@ func getComponentNames(ra *radixv1.RadixApplication) model.EnvironmentComponentN
 		result[env.Name] = componentNames
 	}
 	return result
+}
+
+func concatGitTags(tags []string) (string, error) {
+	tagsConcat := strings.Join(tags, " ")
+	if err := prepareInternal.GitTagsContainIllegalChars(tagsConcat); err != nil {
+		return "", err
+	}
+	return tagsConcat, nil
 }

--- a/pipeline-runner/steps/preparepipeline/step.go
+++ b/pipeline-runner/steps/preparepipeline/step.go
@@ -290,7 +290,7 @@ func (step *PreparePipelinesStepImplementation) getTargetGitInfoForSubPipelines(
 	case radixv1.BuildDeploy, radixv1.Build:
 		return pipelineInfo.GitCommitHash, pipelineInfo.GitTags, pipelineInfo.GetGitRef(), pipelineInfo.GetGitRefTypeOrDefault(), nil
 	case radixv1.Promote:
-		gitCommit, gitTags, gitRef, gitRefType, err := step.getPromoteSourceDeploymentGitInfo(ctx, pipelineInfo.PipelineArguments.FromEnvironment, pipelineInfo.PipelineArguments.DeploymentName)
+		gitCommit, gitTags, gitRef, gitRefType, err = step.getPromoteSourceDeploymentGitInfo(ctx, pipelineInfo.PipelineArguments.FromEnvironment, pipelineInfo.PipelineArguments.DeploymentName)
 		if err != nil {
 			return "", "", "", "", err
 		}

--- a/pipeline-runner/steps/preparepipeline/step.go
+++ b/pipeline-runner/steps/preparepipeline/step.go
@@ -306,7 +306,7 @@ func (step *PreparePipelinesStepImplementation) getTargetGitInfoForSubPipelines(
 
 		gitCommit, err = repo.ResolveCommitForReference(gitRef)
 		if err != nil {
-			return "", "", "", "", nil
+			return "", "", "", "", err
 		}
 
 		tags, err := repo.ResolveTagsForCommit(gitCommit)
@@ -338,7 +338,7 @@ func (step *PreparePipelinesStepImplementation) getTargetGitInfoForSubPipelines(
 			return "", "", "", "", nil
 		}
 
-		gitCommit, err := repo.ResolveCommitForReference(gitRef)
+		gitCommit, err = repo.ResolveCommitForReference(gitRef)
 		if err != nil {
 			return "", "", "", "", err
 		}

--- a/pipeline-runner/steps/preparepipeline/step.go
+++ b/pipeline-runner/steps/preparepipeline/step.go
@@ -369,10 +369,13 @@ func (step *PreparePipelinesStepImplementation) getPromoteSourceDeploymentGitInf
 
 	gitCommit = internal.GetGitCommitHashFromDeployment(rd)
 	gitTags = internal.GetGitTagsFromDeployment(rd)
+	if err := prepareInternal.GitTagsContainIllegalChars(gitTags); err != nil {
+		return "", "", "", "", err
+	}
 	gitRef = internal.GetGitRefNameFromDeployment(rd)
 	gitRefType = internal.GetGitRefTypeFromDeployment(rd)
 
-	return gitCommit, gitTags, gitRef, gitRefType, err
+	return gitCommit, gitTags, gitRef, gitRefType, nil
 }
 
 func containsRegex(value string) bool {

--- a/pipeline-runner/steps/preparepipeline/step.go
+++ b/pipeline-runner/steps/preparepipeline/step.go
@@ -334,7 +334,7 @@ func (step *PreparePipelinesStepImplementation) getTargetGitInfoForSubPipelines(
 		}
 
 		if containsRegex(gitRef) {
-			log.Ctx(ctx).Info().Msg("Deploy job with build branch having regex pattern, skipping sub-pipelines.")
+			log.Ctx(ctx).Info().Msgf("Git ref %q contains regex pattern, skipping sub-pipelines.", gitRef)
 			return "", "", "", "", nil
 		}
 

--- a/pipeline-runner/steps/preparepipeline/step_test.go
+++ b/pipeline-runner/steps/preparepipeline/step_test.go
@@ -1440,6 +1440,15 @@ func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams_De
 			expectedCommit:  "configbranchcommit",
 			expectedGitTags: "v1 v2",
 		},
+		"environment build from type is ignored when build from is empty": {
+			ra: utils.NewRadixApplicationBuilder().WithAppName(appName).WithEnvironmentByBuild(toEnvironment, radixv1.EnvBuild{
+				FromType: string(radixv1.GitRefTag),
+			}).BuildRA(),
+			expectedGitRef:  configBranch,
+			expectedRefType: string(radixv1.GitRefBranch),
+			expectedCommit:  "configbranchcommit",
+			expectedGitTags: "v1 v2",
+		},
 		"environment build from tag uses environment git ref and type": {
 			ra: utils.NewRadixApplicationBuilder().WithAppName(appName).WithEnvironmentByBuild(toEnvironment, radixv1.EnvBuild{
 				From:     "v3",

--- a/pipeline-runner/steps/preparepipeline/step_test.go
+++ b/pipeline-runner/steps/preparepipeline/step_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/equinor/radix-operator/pipeline-runner/steps/preparepipeline"
 	prepareInternal "github.com/equinor/radix-operator/pipeline-runner/steps/preparepipeline/internal"
 	operatorDefaults "github.com/equinor/radix-operator/pkg/apis/defaults"
+	"github.com/equinor/radix-operator/pkg/apis/kube"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	radixfake "github.com/equinor/radix-operator/pkg/client/clientset/versioned/fake"
@@ -1163,7 +1164,7 @@ func (s *stepTestSuite) Test_PipelineContext_CreatePipeline() {
 	}
 }
 
-func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams() {
+func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams_BuildDeploy() {
 	const (
 		appName    = "anyapp"
 		envName1   = internalTest.Env1
@@ -1270,6 +1271,276 @@ func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams() 
 		GitCommit:    gitCommit,
 		GitTags:      "v1 v2",
 	}, pipelineInfo.EnvironmentSubPipelineParams[envName2])
+}
+
+func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams_Promote() {
+	const (
+		appName         = "anyapp"
+		fromEnvironment = "dev"
+		toEnvironment   = "prod"
+		deploymentName  = "rd-dev"
+		gitRef          = "release-1"
+		gitRefType      = string(radixv1.GitRefTag)
+		gitCommit       = "sourcecommit"
+		gitTags         = "v1 v2"
+		cloneURL        = "git@github.com:equinor/radix-operator.git"
+		configBranch    = "configbranch"
+	)
+
+	rr := utils.NewRegistrationBuilder().WithName(appName).WithCloneURL(cloneURL).WithConfigBranch(configBranch).BuildRR()
+	_, err := s.radixClient.RadixV1().RadixRegistrations().Create(context.TODO(), rr, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.applyRadixDeployments([]radixv1.RadixDeployment{*utils.NewDeploymentBuilder().
+		WithAppName(appName).
+		WithEnvironment(fromEnvironment).
+		WithDeploymentName(deploymentName).
+		WithAnnotations(map[string]string{
+			kube.RadixGitRefAnnotation:     gitRef,
+			kube.RadixGitRefTypeAnnotation: gitRefType,
+			kube.RadixCommitAnnotation:     gitCommit,
+			kube.RadixGitTagsAnnotation:    gitTags,
+		}).BuildRD()})
+
+	pipelineInfo := &model.PipelineInfo{
+		Definition: &pipeline.Definition{},
+		PipelineArguments: model.PipelineArguments{
+			AppName:         appName,
+			PipelineType:    string(radixv1.Promote),
+			FromEnvironment: fromEnvironment,
+			ToEnvironment:   toEnvironment,
+			DeploymentName:  deploymentName,
+		},
+	}
+
+	mockRadixConfigReader := prepareInternal.NewMockRadixConfigReader(s.ctrl)
+	mockRadixConfigReader.EXPECT().Read(pipelineInfo).Return(utils.NewRadixApplicationBuilder().WithAppName(appName).WithEnvironmentNoBranch(toEnvironment).BuildRA(), nil).Times(1)
+	mockGitRepo := git.NewMockRepository(s.ctrl)
+	mockGitRepo.EXPECT().Checkout(configBranch).Times(1).Return(nil)
+	mockGitRepo.EXPECT().Checkout(gitCommit).Times(1).Return(nil)
+	mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
+	mockSubPipelineReader := prepareInternal.NewMockSubPipelineReader(s.ctrl)
+	mockSubPipelineReader.EXPECT().ReadPipelineAndTasks(pipelineInfo, toEnvironment).Return(false, "", nil, nil, nil).Times(1)
+	mockOwnerReferenceFactory := ownerreferences.NewMockOwnerReferenceFactory(s.ctrl)
+	step := preparepipeline.NewPreparePipelinesStep(
+		preparepipeline.WithRadixConfigReader(mockRadixConfigReader),
+		preparepipeline.WithSubPipelineReader(mockSubPipelineReader),
+		preparepipeline.WithBuildContextBuilder(mockContextBuilder),
+		preparepipeline.WithOwnerReferenceFactory(mockOwnerReferenceFactory),
+		preparepipeline.WithOpenGitRepoFunc(func(_ string) (git.Repository, error) { return mockGitRepo, nil }),
+	)
+
+	ctx := context.Background()
+	step.Init(ctx, s.kubeClient, s.radixClient, s.dynamicClient, s.tknClient, rr)
+	err = step.Run(ctx, pipelineInfo)
+	s.Require().NoError(err)
+
+	s.Equal(map[string]model.SubPipelineParams{
+		toEnvironment: {
+			PipelineType: string(radixv1.Promote),
+			Environment:  toEnvironment,
+			GitSSHUrl:    cloneURL,
+			GitRef:       gitRef,
+			GitRefType:   gitRefType,
+			GitCommit:    gitCommit,
+			GitTags:      gitTags,
+		},
+	}, pipelineInfo.EnvironmentSubPipelineParams)
+}
+
+func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams_Promote_ResolveGitInfoFromGitRef() {
+	const (
+		appName         = "anyapp"
+		fromEnvironment = "dev"
+		toEnvironment   = "prod"
+		deploymentName  = "rd-dev"
+		gitRef          = "main"
+		gitCommit       = "resolvedcommit"
+		cloneURL        = "git@github.com:equinor/radix-operator.git"
+		configBranch    = "configbranch"
+	)
+
+	rr := utils.NewRegistrationBuilder().WithName(appName).WithCloneURL(cloneURL).WithConfigBranch(configBranch).BuildRR()
+	_, err := s.radixClient.RadixV1().RadixRegistrations().Create(context.TODO(), rr, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.applyRadixDeployments([]radixv1.RadixDeployment{*utils.NewDeploymentBuilder().
+		WithAppName(appName).
+		WithEnvironment(fromEnvironment).
+		WithDeploymentName(deploymentName).
+		WithAnnotations(map[string]string{
+			kube.RadixGitRefAnnotation: gitRef,
+		}).BuildRD()})
+
+	pipelineInfo := &model.PipelineInfo{
+		Definition: &pipeline.Definition{},
+		PipelineArguments: model.PipelineArguments{
+			AppName:         appName,
+			PipelineType:    string(radixv1.Promote),
+			FromEnvironment: fromEnvironment,
+			ToEnvironment:   toEnvironment,
+			DeploymentName:  deploymentName,
+		},
+	}
+
+	mockRadixConfigReader := prepareInternal.NewMockRadixConfigReader(s.ctrl)
+	mockRadixConfigReader.EXPECT().Read(pipelineInfo).Return(utils.NewRadixApplicationBuilder().WithAppName(appName).WithEnvironmentNoBranch(toEnvironment).BuildRA(), nil).Times(1)
+	mockGitRepo := git.NewMockRepository(s.ctrl)
+	mockGitRepo.EXPECT().Checkout(configBranch).Times(1).Return(nil)
+	mockGitRepo.EXPECT().ResolveCommitForReference(gitRef).Times(1).Return(gitCommit, nil)
+	mockGitRepo.EXPECT().ResolveTagsForCommit(gitCommit).Times(1).Return([]string{"v1", "v2"}, nil)
+	mockGitRepo.EXPECT().Checkout(gitCommit).Times(1).Return(nil)
+	mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
+	mockSubPipelineReader := prepareInternal.NewMockSubPipelineReader(s.ctrl)
+	mockSubPipelineReader.EXPECT().ReadPipelineAndTasks(pipelineInfo, toEnvironment).Return(false, "", nil, nil, nil).Times(1)
+	mockOwnerReferenceFactory := ownerreferences.NewMockOwnerReferenceFactory(s.ctrl)
+	step := preparepipeline.NewPreparePipelinesStep(
+		preparepipeline.WithRadixConfigReader(mockRadixConfigReader),
+		preparepipeline.WithSubPipelineReader(mockSubPipelineReader),
+		preparepipeline.WithBuildContextBuilder(mockContextBuilder),
+		preparepipeline.WithOwnerReferenceFactory(mockOwnerReferenceFactory),
+		preparepipeline.WithOpenGitRepoFunc(func(_ string) (git.Repository, error) { return mockGitRepo, nil }),
+	)
+
+	ctx := context.Background()
+	step.Init(ctx, s.kubeClient, s.radixClient, s.dynamicClient, s.tknClient, rr)
+	err = step.Run(ctx, pipelineInfo)
+	s.Require().NoError(err)
+
+	s.Equal(map[string]model.SubPipelineParams{
+		toEnvironment: {
+			PipelineType: string(radixv1.Promote),
+			Environment:  toEnvironment,
+			GitSSHUrl:    cloneURL,
+			GitRef:       gitRef,
+			GitRefType:   string(radixv1.GitRefBranch),
+			GitCommit:    gitCommit,
+			GitTags:      "v1 v2",
+		},
+	}, pipelineInfo.EnvironmentSubPipelineParams)
+}
+
+func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams_Deploy() {
+	const (
+		appName       = "anyapp"
+		toEnvironment = "dev"
+		cloneURL      = "git@github.com:equinor/radix-operator.git"
+		configBranch  = "configbranch"
+	)
+
+	tests := map[string]struct {
+		ra              *radixv1.RadixApplication
+		expectedGitRef  string
+		expectedRefType string
+		expectedCommit  string
+		expectedGitTags string
+	}{
+		"environment without build from uses config branch": {
+			ra:              utils.NewRadixApplicationBuilder().WithAppName(appName).WithEnvironmentNoBranch(toEnvironment).BuildRA(),
+			expectedGitRef:  configBranch,
+			expectedRefType: string(radixv1.GitRefBranch),
+			expectedCommit:  "configbranchcommit",
+			expectedGitTags: "v1 v2",
+		},
+		"environment build from tag uses environment git ref and type": {
+			ra: utils.NewRadixApplicationBuilder().WithAppName(appName).WithEnvironmentByBuild(toEnvironment, radixv1.EnvBuild{
+				From:     "v3",
+				FromType: string(radixv1.GitRefTag),
+			}).BuildRA(),
+			expectedGitRef:  "v3",
+			expectedRefType: string(radixv1.GitRefTag),
+			expectedCommit:  "tagcommit",
+			expectedGitTags: "v3",
+		},
+	}
+
+	for testName, testSpec := range tests {
+		s.Run(testName, func() {
+			rr := utils.NewRegistrationBuilder().WithName(appName).WithCloneURL(cloneURL).WithConfigBranch(configBranch).BuildRR()
+			_, err := s.radixClient.RadixV1().RadixRegistrations().Create(context.TODO(), rr, metav1.CreateOptions{})
+			s.Require().NoError(err)
+
+			pipelineInfo := &model.PipelineInfo{
+				Definition: &pipeline.Definition{},
+				PipelineArguments: model.PipelineArguments{
+					AppName:       appName,
+					PipelineType:  string(radixv1.Deploy),
+					ToEnvironment: toEnvironment,
+				},
+			}
+
+			mockRadixConfigReader := prepareInternal.NewMockRadixConfigReader(s.ctrl)
+			mockRadixConfigReader.EXPECT().Read(pipelineInfo).Return(testSpec.ra, nil).Times(1)
+			mockGitRepo := git.NewMockRepository(s.ctrl)
+			mockGitRepo.EXPECT().Checkout(configBranch).Times(1).Return(nil)
+			mockGitRepo.EXPECT().ResolveCommitForReference(testSpec.expectedGitRef).Times(1).Return(testSpec.expectedCommit, nil)
+			mockGitRepo.EXPECT().ResolveTagsForCommit(testSpec.expectedCommit).Times(1).Return(strings.Fields(testSpec.expectedGitTags), nil)
+			mockGitRepo.EXPECT().Checkout(testSpec.expectedCommit).Times(1).Return(nil)
+			mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
+			mockSubPipelineReader := prepareInternal.NewMockSubPipelineReader(s.ctrl)
+			mockSubPipelineReader.EXPECT().ReadPipelineAndTasks(pipelineInfo, toEnvironment).Return(false, "", nil, nil, nil).Times(1)
+			mockOwnerReferenceFactory := ownerreferences.NewMockOwnerReferenceFactory(s.ctrl)
+			step := preparepipeline.NewPreparePipelinesStep(
+				preparepipeline.WithRadixConfigReader(mockRadixConfigReader),
+				preparepipeline.WithSubPipelineReader(mockSubPipelineReader),
+				preparepipeline.WithBuildContextBuilder(mockContextBuilder),
+				preparepipeline.WithOwnerReferenceFactory(mockOwnerReferenceFactory),
+				preparepipeline.WithOpenGitRepoFunc(func(_ string) (git.Repository, error) { return mockGitRepo, nil }),
+			)
+
+			ctx := context.Background()
+			step.Init(ctx, s.kubeClient, s.radixClient, s.dynamicClient, s.tknClient, rr)
+			err = step.Run(ctx, pipelineInfo)
+			s.Require().NoError(err)
+
+			s.Equal(map[string]model.SubPipelineParams{
+				toEnvironment: {
+					PipelineType: string(radixv1.Deploy),
+					Environment:  toEnvironment,
+					GitSSHUrl:    cloneURL,
+					GitRef:       testSpec.expectedGitRef,
+					GitRefType:   testSpec.expectedRefType,
+					GitCommit:    testSpec.expectedCommit,
+					GitTags:      testSpec.expectedGitTags,
+				},
+			}, pipelineInfo.EnvironmentSubPipelineParams)
+		})
+	}
+}
+
+func (s *stepTestSuite) Test_PipelineContext_SetsEnvironmentSubPipelineParams_ApplyConfig() {
+	const (
+		appName      = "anyapp"
+		configBranch = "configbranch"
+	)
+
+	rr := utils.NewRegistrationBuilder().WithName(appName).WithConfigBranch(configBranch).BuildRR()
+	pipelineInfo := &model.PipelineInfo{
+		Definition: &pipeline.Definition{},
+		PipelineArguments: model.PipelineArguments{
+			AppName:      appName,
+			PipelineType: string(radixv1.ApplyConfig),
+		},
+	}
+
+	mockRadixConfigReader := prepareInternal.NewMockRadixConfigReader(s.ctrl)
+	mockRadixConfigReader.EXPECT().Read(pipelineInfo).Return(utils.NewRadixApplicationBuilder().WithAppName(appName).BuildRA(), nil).Times(1)
+	mockGitRepo := git.NewMockRepository(s.ctrl)
+	mockGitRepo.EXPECT().Checkout(configBranch).Times(1).Return(nil)
+	mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
+	mockSubPipelineReader := prepareInternal.NewMockSubPipelineReader(s.ctrl)
+	mockOwnerReferenceFactory := ownerreferences.NewMockOwnerReferenceFactory(s.ctrl)
+	step := preparepipeline.NewPreparePipelinesStep(
+		preparepipeline.WithRadixConfigReader(mockRadixConfigReader),
+		preparepipeline.WithSubPipelineReader(mockSubPipelineReader),
+		preparepipeline.WithBuildContextBuilder(mockContextBuilder),
+		preparepipeline.WithOwnerReferenceFactory(mockOwnerReferenceFactory),
+		preparepipeline.WithOpenGitRepoFunc(func(_ string) (git.Repository, error) { return mockGitRepo, nil }),
+	)
+
+	ctx := context.Background()
+	step.Init(ctx, s.kubeClient, s.radixClient, s.dynamicClient, s.tknClient, rr)
+	err := step.Run(ctx, pipelineInfo)
+	s.Require().NoError(err)
+	s.Empty(pipelineInfo.EnvironmentSubPipelineParams)
 }
 
 func (s *stepTestSuite) Test_SubPipeline_ResolveAndCheckoutCommit_Deploy_EnvironmentMissingBuildFrom() {

--- a/pipeline-runner/steps/preparepipeline/step_test.go
+++ b/pipeline-runner/steps/preparepipeline/step_test.go
@@ -260,6 +260,7 @@ func (s *stepTestSuite) Test_TargetEnvironments_Deploy() {
 			mockGitRepo := git.NewMockRepository(s.ctrl)
 			mockGitRepo.EXPECT().Checkout(gomock.Any()).AnyTimes().Return(nil)
 			mockGitRepo.EXPECT().ResolveCommitForReference(gomock.Any()).AnyTimes().Return("", nil)
+			mockGitRepo.EXPECT().ResolveTagsForCommit(gomock.Any()).AnyTimes().Return(nil, nil)
 			mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
 			mockContextBuilder.EXPECT().GetBuildContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			mockSubPipelineReader := prepareInternal.NewMockSubPipelineReader(s.ctrl)
@@ -1291,6 +1292,7 @@ func (s *stepTestSuite) Test_SubPipeline_ResolveAndCheckoutCommit_Deploy_Environ
 	mockGitRepo := git.NewMockRepository(s.ctrl)
 	mockGitRepo.EXPECT().Checkout(configBranch).Times(1).Return(nil) // Get radixconfig
 	mockGitRepo.EXPECT().ResolveCommitForReference(configBranch).Times(1).Return(configBranchCommit, nil)
+	mockGitRepo.EXPECT().ResolveTagsForCommit(configBranchCommit).Times(1).Return(nil, nil)
 	mockGitRepo.EXPECT().Checkout(configBranchCommit).Times(1).Return(nil)
 
 	mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
@@ -1334,6 +1336,7 @@ func (s *stepTestSuite) Test_SubPipeline_ResolveAndCheckoutCommit_Deploy_Environ
 	mockGitRepo := git.NewMockRepository(s.ctrl)
 	mockGitRepo.EXPECT().Checkout(configBranch).Times(1).Return(nil) // Get radixconfig
 	mockGitRepo.EXPECT().ResolveCommitForReference(envBranch).Times(1).Return(envBranchCommit, nil)
+	mockGitRepo.EXPECT().ResolveTagsForCommit(envBranchCommit).Times(1).Return(nil, nil)
 	mockGitRepo.EXPECT().Checkout(envBranchCommit).Times(1).Return(nil)
 
 	mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
@@ -1641,6 +1644,7 @@ func (s *stepTestSuite) Test_EnvironmentSubPipelineComponentNames() {
 			mockGitRepo := git.NewMockRepository(s.ctrl)
 			mockGitRepo.EXPECT().Checkout(gomock.Any()).AnyTimes().Return(nil)
 			mockGitRepo.EXPECT().ResolveCommitForReference(gomock.Any()).AnyTimes().Return("somecommit", nil)
+			mockGitRepo.EXPECT().ResolveTagsForCommit(gomock.Any()).AnyTimes().Return([]string{"v1", "v2"}, nil)
 			mockContextBuilder := prepareInternal.NewMockContextBuilder(s.ctrl)
 			mockSubPipelineReader := prepareInternal.NewMockSubPipelineReader(s.ctrl)
 			mockSubPipelineReader.EXPECT().ReadPipelineAndTasks(gomock.Any(), gomock.Any()).Return(false, "", nil, nil, nil).AnyTimes()


### PR DESCRIPTION
## Summary

Fixes sub-pipeline argument population for promote and deploy pipelines by resolving and passing the correct git metadata into `EnvironmentSubPipelineParams`.

The prepare pipeline step now determines the target git commit, ref, ref type, tags, and clone URL for each supported pipeline type before creating sub-pipelines. This ensures custom Radix sub-pipeline arguments are populated consistently for build-deploy, promote, and deploy jobs.

## Changes

- Populate sub-pipeline params per target environment with:
  - pipeline type
  - environment
  - git SSH URL
  - git ref
  - git ref type
  - git commit
  - git tags
- Resolve promote git metadata from the source deployment when available.
- Fall back to resolving promote commit and tags from the source deployment git ref when commit metadata is missing.
- Resolve deploy git metadata from the target environment build source, or from the registration config branch when no environment source is configured.
- Skip sub-pipeline creation for deploy pipelines when the resolved git ref contains a regex pattern.
- Add helpers for reading git ref type and git tags from RadixDeployment annotations.
- Remove the unused `PipelineInfo.SetGitAttributes` helper.
- Add unit coverage for build-deploy, promote, deploy, and apply-config sub-pipeline param behavior.

## Testing

- `make test`