### PR TITLE
Expose cron schedule for cron jobs

### DIFF
--- a/api-server/api/deployments/models/scheduled_batch.go
+++ b/api-server/api/deployments/models/scheduled_batch.go
@@ -58,6 +58,12 @@ type ScheduledJobSummary struct {
 	// example: "batch-abc"
 	BatchName string `json:"batchName,omitempty"`
 
+	// CronSchedule is the cron schedule expression, if this job was created by a cron schedule.
+	//
+	// required: false
+	// example: "0 1 * * *"
+	CronSchedule string `json:"cronSchedule,omitempty"`
+
 	// TimeLimitSeconds How long the job supposed to run at maximum
 	//
 	// required: false

--- a/api-server/api/environments/environment_controller_radixbatches_test.go
+++ b/api-server/api/environments/environment_controller_radixbatches_test.go
@@ -546,8 +546,9 @@ func Test_GetJob_AllProps(t *testing.T) {
 	testData := []v1.RadixBatch{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "job-batch1",
-				Labels: labels.Merge(labels.ForApplicationName(anyAppName), labels.ForComponentName(anyJobName), labels.ForBatchType(kube.RadixBatchTypeJob)),
+				Name:        "job-batch1",
+				Labels:      labels.Merge(labels.ForApplicationName(anyAppName), labels.ForComponentName(anyJobName), labels.ForBatchType(kube.RadixBatchTypeJob)),
+				Annotations: map[string]string{kube.RadixBatchCronScheduleAnnotation: "0 1 * * *"},
 			},
 			Spec: v1.RadixBatchSpec{
 				Jobs: []v1.RadixBatchJob{
@@ -660,6 +661,7 @@ func Test_GetJob_AllProps(t *testing.T) {
 		Message:          "anymessage",
 		BackoffLimit:     *defaultBackoffLimit,
 		TimeLimitSeconds: numbers.Int64Ptr(123),
+		CronSchedule:     "0 1 * * *",
 		Resources: models.ResourceRequirements{
 			Limits:   models.Resources{CPU: "100Mi", Memory: "500M"},
 			Requests: models.Resources{CPU: "50Mi", Memory: "250M"},
@@ -688,6 +690,7 @@ func Test_GetJob_AllProps(t *testing.T) {
 		Status:           models.ScheduledBatchJobStatusWaiting,
 		BackoffLimit:     5,
 		TimeLimitSeconds: numbers.Int64Ptr(999),
+		CronSchedule:     "0 1 * * *",
 		Resources: models.ResourceRequirements{
 			Limits:   models.Resources{CPU: "101Mi", Memory: "501M"},
 			Requests: models.Resources{CPU: "51Mi", Memory: "251M"},

--- a/api-server/api/models/batch.go
+++ b/api-server/api/models/batch.go
@@ -106,6 +106,7 @@ func GetScheduledJobSummary(radixBatch *radixv1.RadixBatch, radixBatchJob *radix
 		Name:           fmt.Sprintf("%s-%s", radixBatch.GetName(), radixBatchJob.Name),
 		DeploymentName: radixBatch.Spec.RadixDeploymentJobRef.Name,
 		BatchName:      batchName,
+		CronSchedule:   radixBatch.GetAnnotations()[kube.RadixBatchCronScheduleAnnotation],
 		JobId:          radixBatchJob.JobId,
 		ReplicaList:    getReplicaSummaryListForJob(radixBatch, *radixBatchJob),
 		Status:         radixv1.RadixBatchJobApiStatusWaiting,

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -8829,6 +8829,12 @@
           "format": "date-time",
           "x-go-name": "Created"
         },
+        "cronSchedule": {
+          "description": "CronSchedule is the cron schedule expression, if this job was created by a cron schedule.",
+          "type": "string",
+          "x-go-name": "CronSchedule",
+          "example": "\"0 1 * * *\""
+        },
         "deploymentName": {
           "description": "DeploymentName name of RadixDeployment for the job",
           "type": "string",

--- a/job-scheduler/api/v1/controllers/jobs/controller.go
+++ b/job-scheduler/api/v1/controllers/jobs/controller.go
@@ -114,7 +114,7 @@ func (controller *jobController) CreateJob(c *gin.Context) {
 		}
 	}
 
-	jobState, err := controller.handler.CreateJob(c.Request.Context(), &jobScheduleDescription, false)
+	jobState, err := controller.handler.CreateJob(c.Request.Context(), &jobScheduleDescription, "")
 	if err != nil {
 		controller.HandleError(c, err)
 		return

--- a/job-scheduler/api/v1/controllers/jobs/controller_test.go
+++ b/job-scheduler/api/v1/controllers/jobs/controller_test.go
@@ -200,7 +200,7 @@ func TestCreateJob(t *testing.T) {
 		ctx := context.Background()
 		jobHandler.
 			EXPECT().
-			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, false).
+			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, "").
 			Return(&createdJob, nil).
 			Times(1)
 		controllerTestUtils := setupTest(jobHandler)
@@ -253,7 +253,7 @@ func TestCreateJob(t *testing.T) {
 		ctx := context.Background()
 		jobHandler.
 			EXPECT().
-			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, false).
+			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, "").
 			Return(&createdJob, nil).
 			Times(1)
 		controllerTestUtils := setupTest(jobHandler)
@@ -282,7 +282,7 @@ func TestCreateJob(t *testing.T) {
 		ctx := context.Background()
 		jobHandler.
 			EXPECT().
-			CreateJob(test.RequestContextMatcher{}, gomock.Any(), false).
+			CreateJob(test.RequestContextMatcher{}, gomock.Any(), "").
 			Times(0)
 		controllerTestUtils := setupTest(jobHandler)
 		responseChannel := controllerTestUtils.ExecuteRequestWithBody(ctx, http.MethodPost, "/api/v1/jobs", struct{ Payload interface{} }{Payload: struct{}{}})
@@ -310,7 +310,7 @@ func TestCreateJob(t *testing.T) {
 		ctx := context.Background()
 		jobHandler.
 			EXPECT().
-			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, false).
+			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, "").
 			Return(nil, apiErrors.NewNotFound(anyKind, anyName)).
 			Times(1)
 		controllerTestUtils := setupTest(jobHandler)
@@ -338,7 +338,7 @@ func TestCreateJob(t *testing.T) {
 		ctx := context.Background()
 		jobHandler.
 			EXPECT().
-			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, false).
+			CreateJob(test.RequestContextMatcher{}, &jobScheduleDescription, "").
 			Return(nil, errors.New("any error")).
 			Times(1)
 		controllerTestUtils := setupTest(jobHandler)

--- a/job-scheduler/api/v1/handlers/internal/handler.go
+++ b/job-scheduler/api/v1/handlers/internal/handler.go
@@ -19,6 +19,7 @@ import (
 	apiErrors "github.com/equinor/radix-operator/job-scheduler/pkg/errors"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	radixAnnotations "github.com/equinor/radix-operator/pkg/apis/utils/annotations"
 	radixLabels "github.com/equinor/radix-operator/pkg/apis/utils/labels"
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
@@ -108,7 +109,7 @@ func (h *Handler) CreateBatch(ctx context.Context, batchScheduleDescription *com
 		return nil, apiErrors.NewInvalidWithReason("BatchScheduleDescription", "empty job description list ")
 	}
 
-	radixBatch, err := h.createRadixBatchOrJob(ctx, *batchScheduleDescription, kube.RadixBatchTypeBatch, false)
+	radixBatch, err := h.createRadixBatchOrJob(ctx, *batchScheduleDescription, kube.RadixBatchTypeBatch, "")
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (h *Handler) CopyBatch(ctx context.Context, sourceBatchName, deploymentName
 	return batch.CopyRadixBatchOrJob(ctx, h.kubeUtil.RadixClient(), sourceRadixBatch, "", h.radixDeployJobComponent, deploymentName)
 }
 
-func (h *Handler) createRadixBatchOrJob(ctx context.Context, batchScheduleDescription common.BatchScheduleDescription, radixBatchType kube.RadixBatchType, isCronJob bool) (*modelsv1.BatchStatus, error) {
+func (h *Handler) createRadixBatchOrJob(ctx context.Context, batchScheduleDescription common.BatchScheduleDescription, radixBatchType kube.RadixBatchType, cronSchedule string) (*modelsv1.BatchStatus, error) {
 	logger := log.Ctx(ctx)
 	namespace := h.env.RadixDeploymentNamespace
 	radixComponentName := h.env.RadixComponentName
@@ -149,7 +150,7 @@ func (h *Handler) createRadixBatchOrJob(ctx context.Context, batchScheduleDescri
 
 	appName := radixDeployment.Spec.AppName //nolint:staticcheck
 
-	createdRadixBatch, err := h.createRadixBatch(ctx, namespace, appName, radixDeployment.GetName(), *radixJobComponent, batchScheduleDescription, radixBatchType, isCronJob)
+	createdRadixBatch, err := h.createRadixBatch(ctx, namespace, appName, radixDeployment.GetName(), *radixJobComponent, batchScheduleDescription, radixBatchType, cronSchedule)
 	if err != nil {
 		return nil, apiErrors.NewFromError(err)
 	}
@@ -160,7 +161,7 @@ func (h *Handler) createRadixBatchOrJob(ctx context.Context, batchScheduleDescri
 }
 
 // CreateRadixBatchSingleJob Create a batch single job with parameters
-func (h *Handler) CreateRadixBatchSingleJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, isCronJob bool) (*modelsv1.BatchStatus, error) {
+func (h *Handler) CreateRadixBatchSingleJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, cronSchedule string) (*modelsv1.BatchStatus, error) {
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("Create Radix Batch single job")
 	if jobScheduleDescription == nil {
@@ -169,7 +170,7 @@ func (h *Handler) CreateRadixBatchSingleJob(ctx context.Context, jobScheduleDesc
 	radixBatchJob, err := h.createRadixBatchOrJob(ctx, common.BatchScheduleDescription{
 		JobScheduleDescriptions:        []common.JobScheduleDescription{*jobScheduleDescription},
 		DefaultRadixJobComponentConfig: nil,
-	}, kube.RadixBatchTypeJob, isCronJob)
+	}, kube.RadixBatchTypeJob, cronSchedule)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +216,7 @@ func (h *Handler) StopAllSingleRadixJobs(ctx context.Context) error {
 	return batch.StopAllRadixBatches(ctx, h.kubeUtil.RadixClient(), h.env.RadixAppName, h.env.RadixEnvironmentName, h.env.RadixComponentName, kube.RadixBatchTypeJob)
 }
 
-func (h *Handler) createRadixBatch(ctx context.Context, namespace, appName, radixDeploymentName string, radixJobComponent radixv1.RadixDeployJobComponent, batchScheduleDescription common.BatchScheduleDescription, radixBatchType kube.RadixBatchType, isCronJob bool) (*radixv1.RadixBatch, error) {
+func (h *Handler) createRadixBatch(ctx context.Context, namespace, appName, radixDeploymentName string, radixJobComponent radixv1.RadixDeployJobComponent, batchScheduleDescription common.BatchScheduleDescription, radixBatchType kube.RadixBatchType, cronSchedule string) (*radixv1.RadixBatch, error) {
 	logger := log.Ctx(ctx)
 	batchName := internal.GenerateBatchName(radixJobComponent.GetName())
 	logger.Debug().Msgf("Create Radix Batch %s", batchName)
@@ -232,8 +233,9 @@ func (h *Handler) createRadixBatch(ctx context.Context, namespace, appName, radi
 				radixLabels.ForApplicationName(appName),
 				radixLabels.ForComponentName(radixJobComponentName),
 				radixLabels.ForBatchType(radixBatchType),
-				radixLabels.ForBatchCron(isCronJob),
+				radixLabels.ForBatchCron(cronSchedule != ""),
 			),
+			Annotations: radixAnnotations.ForBatchCronSchedule(cronSchedule),
 		},
 		Spec: radixv1.RadixBatchSpec{
 			BatchId: batchScheduleDescription.BatchId,

--- a/job-scheduler/api/v1/handlers/internal/handler_test.go
+++ b/job-scheduler/api/v1/handlers/internal/handler_test.go
@@ -252,7 +252,7 @@ func Test_CreateBatch(t *testing.T) {
 				if len(ts.batchDescription.JobScheduleDescriptions) > 0 {
 					jobScheduleDescription = &ts.batchDescription.JobScheduleDescriptions[0]
 				}
-				createdRadixBatch, err = h.CreateRadixBatchSingleJob(context.TODO(), jobScheduleDescription, false)
+				createdRadixBatch, err = h.CreateRadixBatchSingleJob(context.TODO(), jobScheduleDescription, "")
 			}
 			if ts.expectedError {
 				assert.NotNil(t, err)

--- a/job-scheduler/api/v1/handlers/jobs/job_handler.go
+++ b/job-scheduler/api/v1/handlers/jobs/job_handler.go
@@ -27,7 +27,7 @@ type JobHandler interface {
 	// GetJob Get status of a job
 	GetJob(ctx context.Context, jobName string) (*modelsv1.JobStatus, error)
 	// CreateJob Create a job with parameters
-	CreateJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, isCronJob bool) (*modelsv1.JobStatus, error)
+	CreateJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, cronSchedule string) (*modelsv1.JobStatus, error)
 	// CopyJob creates a copy of an existing job with deploymentName as value for radixDeploymentJobRef.name
 	CopyJob(ctx context.Context, jobName string, deploymentName string) (*modelsv1.JobStatus, error)
 	// DeleteJob Delete a job
@@ -117,10 +117,10 @@ func (handler *jobHandler) GetJob(ctx context.Context, jobName string) (*modelsv
 }
 
 // CreateJob Create a job with parameters
-func (handler *jobHandler) CreateJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, isCronJob bool) (*modelsv1.JobStatus, error) {
+func (handler *jobHandler) CreateJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, cronSchedule string) (*modelsv1.JobStatus, error) {
 	logger := log.Ctx(ctx)
 	logger.Debug().Msgf("Create job for namespace: %s", handler.GetEnv().RadixDeploymentNamespace)
-	radixBatch, err := handler.CreateRadixBatchSingleJob(ctx, jobScheduleDescription, isCronJob)
+	radixBatch, err := handler.CreateRadixBatchSingleJob(ctx, jobScheduleDescription, cronSchedule)
 	if err != nil {
 		return nil, err
 	}

--- a/job-scheduler/api/v1/handlers/jobs/job_handler_test.go
+++ b/job-scheduler/api/v1/handlers/jobs/job_handler_test.go
@@ -123,7 +123,7 @@ func TestCreateJob(t *testing.T) {
 		_, err := radixClient.RadixV1().RadixDeployments(envNamespace).Create(context.TODO(), rd, metav1.CreateOptions{})
 		require.NoError(t, err)
 		handler := New(kubeUtil, modelsEnv.NewEnv(), &radixDeployJobComponent)
-		jobStatus, err := handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, false)
+		jobStatus, err := handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, "")
 		require.Nil(t, err)
 		assert.NotNil(t, jobStatus)
 		batchName, batchJobName, ok := internal.ParseBatchAndJobNameFromScheduledJobName(jobStatus.Name)
@@ -135,9 +135,39 @@ func TestCreateJob(t *testing.T) {
 		assert.Equal(t, appJobComponent, radixBatch.Labels[kube.RadixComponentLabel])
 		assert.Equal(t, string(kube.RadixBatchTypeJob), radixBatch.Labels[kube.RadixBatchTypeLabel])
 		assert.Equal(t, "false", radixBatch.Labels[kube.RadixBatchCronLabel])
+		assert.Empty(t, radixBatch.Annotations[kube.RadixBatchCronScheduleAnnotation])
 		require.Len(t, radixBatch.Spec.Jobs, 1)
 		expectedJob := radixv1.RadixBatchJob{Name: batchJobName}
 		assert.Equal(t, expectedJob, radixBatch.Spec.Jobs[0])
+	})
+
+	t.Run("cron job sets cron label and schedule annotation", func(t *testing.T) {
+		appName, appEnvironment, appJobComponent, appDeployment := "app", "qa", appJobComponent, "app-deploy-1"
+		envNamespace := utils.GetEnvironmentNamespace(appName, appEnvironment)
+		rd := utils.ARadixDeployment().
+			WithDeploymentName(appDeployment).
+			WithAppName(appName).
+			WithEnvironment(appEnvironment).
+			WithComponents().
+			WithJobComponents(utils.NewDeployJobComponentBuilder().WithName(appJobComponent)).
+			BuildRD()
+
+		defer test.Cleanup(t)
+		radixClient, _, kubeUtil := test.SetupTest(t, appName, appEnvironment, appJobComponent, appDeployment, 1)
+		_, err := radixClient.RadixV1().RadixDeployments(envNamespace).Create(context.TODO(), rd, metav1.CreateOptions{})
+		require.NoError(t, err)
+		handler := New(kubeUtil, modelsEnv.NewEnv(), &radixDeployJobComponent)
+
+		const cronSchedule = "0 1 * * *"
+		jobStatus, err := handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, cronSchedule)
+		require.Nil(t, err)
+		require.NotNil(t, jobStatus)
+		batchName, _, ok := internal.ParseBatchAndJobNameFromScheduledJobName(jobStatus.Name)
+		require.True(t, ok)
+		radixBatch, err := radixClient.RadixV1().RadixBatches(envNamespace).Get(context.TODO(), batchName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "true", radixBatch.Labels[kube.RadixBatchCronLabel])
+		assert.Equal(t, cronSchedule, radixBatch.Annotations[kube.RadixBatchCronScheduleAnnotation])
 	})
 
 	t.Run("job with payload path", func(t *testing.T) {
@@ -157,7 +187,7 @@ func TestCreateJob(t *testing.T) {
 		require.NoError(t, err)
 		env := modelsEnv.NewEnv()
 		handler := New(kubeUtil, env, &radixDeployJobComponent)
-		jobStatus, err := handler.CreateJob(context.TODO(), &models.JobScheduleDescription{Payload: payloadString}, false)
+		jobStatus, err := handler.CreateJob(context.TODO(), &models.JobScheduleDescription{Payload: payloadString}, "")
 		require.Nil(t, err)
 		assert.NotNil(t, jobStatus)
 		// Test secret spec
@@ -206,7 +236,7 @@ func TestCreateJob(t *testing.T) {
 		require.NoError(t, err)
 		env := modelsEnv.NewEnv()
 		handler := New(kubeUtil, env, &radixDeployJobComponent)
-		_, err = handler.CreateJob(context.TODO(), &models.JobScheduleDescription{Payload: payloadString}, false)
+		_, err = handler.CreateJob(context.TODO(), &models.JobScheduleDescription{Payload: payloadString}, "")
 		assert.Error(t, err)
 		assert.Equal(t, models.StatusReasonUnknown, apiErrors.ReasonForError(err))
 		assert.Contains(t, err.Error(), "missing an expected payload path, but there is a payload in the job")
@@ -244,7 +274,7 @@ func TestCreateJob(t *testing.T) {
 				},
 			},
 		}
-		jobStatus, err := handler.CreateJob(context.TODO(), &jobRequestConfig, false)
+		jobStatus, err := handler.CreateJob(context.TODO(), &jobRequestConfig, "")
 		require.NoError(t, err)
 		assert.NotNil(t, jobStatus)
 
@@ -287,7 +317,7 @@ func TestCreateJob(t *testing.T) {
 		_, err := radixClient.RadixV1().RadixDeployments(envNamespace).Create(context.TODO(), rd, metav1.CreateOptions{})
 		require.NoError(t, err)
 		handler := New(kubeUtil, modelsEnv.NewEnv(), &radixDeployJobComponent)
-		_, err = handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, false)
+		_, err = handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, "")
 		require.Error(t, err)
 		assert.Equal(t, models.StatusReasonNotFound, apiErrors.ReasonForError(err))
 		assert.Equal(t, apiErrors.NotFoundMessage("job component", appJobComponent), err.Error())
@@ -308,7 +338,7 @@ func TestCreateJob(t *testing.T) {
 		_, err := radixClient.RadixV1().RadixDeployments(envNamespace).Create(context.TODO(), rd, metav1.CreateOptions{})
 		require.NoError(t, err)
 		handler := New(kubeUtil, modelsEnv.NewEnv(), &radixDeployJobComponent)
-		_, err = handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, false)
+		_, err = handler.CreateJob(context.TODO(), &models.JobScheduleDescription{}, "")
 		require.Error(t, err)
 		assert.Equal(t, models.StatusReasonNotFound, apiErrors.ReasonForError(err))
 		assert.Equal(t, apiErrors.NotFoundMessage("radix deployment", appDeployment), err.Error())
@@ -337,7 +367,7 @@ func TestCreateJob(t *testing.T) {
 					GpuCount: "2",
 				},
 			},
-		}, false)
+		}, "")
 		require.NoError(t, err)
 
 		batchName, jobName, ok := internal.ParseBatchAndJobNameFromScheduledJobName(jobStatus.Name)
@@ -386,7 +416,7 @@ func TestCreateJob(t *testing.T) {
 					},
 				},
 			},
-		}, false)
+		}, "")
 		require.NoError(t, err)
 
 		batchName, jobName, ok := internal.ParseBatchAndJobNameFromScheduledJobName(jobStatus.Name)

--- a/job-scheduler/api/v1/handlers/jobs/mock/job_mock.go
+++ b/job-scheduler/api/v1/handlers/jobs/mock/job_mock.go
@@ -58,18 +58,18 @@ func (mr *MockJobHandlerMockRecorder) CopyJob(ctx, jobName, deploymentName any) 
 }
 
 // CreateJob mocks base method.
-func (m *MockJobHandler) CreateJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, isCronJob bool) (*v1.JobStatus, error) {
+func (m *MockJobHandler) CreateJob(ctx context.Context, jobScheduleDescription *common.JobScheduleDescription, cronSchedule string) (*v1.JobStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateJob", ctx, jobScheduleDescription, isCronJob)
+	ret := m.ctrl.Call(m, "CreateJob", ctx, jobScheduleDescription, cronSchedule)
 	ret0, _ := ret[0].(*v1.JobStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateJob indicates an expected call of CreateJob.
-func (mr *MockJobHandlerMockRecorder) CreateJob(ctx, jobScheduleDescription, isCronJob any) *gomock.Call {
+func (mr *MockJobHandlerMockRecorder) CreateJob(ctx, jobScheduleDescription, cronSchedule any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJob", reflect.TypeOf((*MockJobHandler)(nil).CreateJob), ctx, jobScheduleDescription, isCronJob)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJob", reflect.TypeOf((*MockJobHandler)(nil).CreateJob), ctx, jobScheduleDescription, cronSchedule)
 }
 
 // DeleteJob mocks base method.

--- a/job-scheduler/internal/cronserver/cronserver.go
+++ b/job-scheduler/internal/cronserver/cronserver.go
@@ -83,7 +83,7 @@ func (s *Server) Start(ctx context.Context) error {
 				return
 			}
 
-			if _, err := s.jobHandler.CreateJob(runCtx, &common.JobScheduleDescription{}, true); err != nil {
+			if _, err := s.jobHandler.CreateJob(runCtx, &common.JobScheduleDescription{}, schedule); err != nil {
 				log.Error().Err(err).Msg("failed to create scheduled job")
 			}
 		}); err != nil {

--- a/pkg/apis/kube/kube.go
+++ b/pkg/apis/kube/kube.go
@@ -35,6 +35,8 @@ const (
 	RadixDeploymentObservedGeneration = "radix.equinor.com/radix-deployment-observed-generation"
 	// RadixFederatedCredentialsMigratedAnnotation marks that an user has confirmed that application's credentials have been checked and migrated to federated credentials if needed
 	RadixFederatedCredentialsMigratedAnnotation = "radix.equinor.com/federated-credentials-migrated"
+	// RadixBatchCronScheduleAnnotation holds the cron schedule expression a RadixBatch was created from, for presentation only
+	RadixBatchCronScheduleAnnotation = "radix.equinor.com/batch-cron-schedule"
 )
 
 // Radix Labels

--- a/pkg/apis/utils/annotations/annotations.go
+++ b/pkg/apis/utils/annotations/annotations.go
@@ -29,6 +29,15 @@ func ForRadixDeploymentName(deploymentName string) map[string]string {
 	return map[string]string{kube.RadixDeploymentNameAnnotation: deploymentName}
 }
 
+// ForBatchCronSchedule returns an annotation holding the cron schedule expression a RadixBatch
+// was created from. Returns nil when the schedule is empty, so non-cron batches carry no annotation.
+func ForBatchCronSchedule(schedule string) map[string]string {
+	if len(schedule) == 0 {
+		return nil
+	}
+	return map[string]string{kube.RadixBatchCronScheduleAnnotation: schedule}
+}
+
 // ForKubernetesDeploymentObservedGeneration returns annotations describing which RadixDeployment version was used while syncing
 func ForKubernetesDeploymentObservedGeneration(rd *radixv1.RadixDeployment) map[string]string {
 	if rd == nil {

--- a/pkg/apis/utils/annotations/annotations_test.go
+++ b/pkg/apis/utils/annotations/annotations_test.go
@@ -46,3 +46,12 @@ func Test_ForClusterAutoscalerSafeToEvict(t *testing.T) {
 	expected = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
 	assert.Equal(t, expected, actual)
 }
+
+func Test_ForBatchCronSchedule(t *testing.T) {
+	actual := ForBatchCronSchedule("")
+	assert.Equal(t, map[string]string(nil), actual)
+
+	actual = ForBatchCronSchedule("0 1 * * *")
+	expected := map[string]string{kube.RadixBatchCronScheduleAnnotation: "0 1 * * *"}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Store the schedule of a cron job on the RadixBatch CR. Then expose it through the Radix API so that we can flag jobs as started by cron in the web console, along with the schedule.