### PR TITLE
ci: Disable fail-fast when creating images

### DIFF
--- a/.github/workflows/build-and-publish-artifacts.yml
+++ b/.github/workflows/build-and-publish-artifacts.yml
@@ -42,6 +42,7 @@ jobs:
     env:
       CONTAINER_REGISTRY: ghcr.io
     strategy:
+      fail-fast: false
       matrix:
         container:
           - file: operator.Dockerfile


### PR DESCRIPTION
Prevent the CI process from failing immediately when creating images, allowing for more flexibility during the build process.