### PR TITLE
fix: ensure job aux deployment is recreated if selector labels are modified

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -151,6 +151,7 @@
 				"RADIX_OAUTH_PROXY_DEFAULT_OIDC_ISSUER_URL": "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/v2.0",
 				"RADIX_OAUTH_PROXY_IMAGE": "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2",
 				"RADIX_OAUTH_REDIS_IMAGE": "docker.io/redis:8.6.0-alpine3.23",
+				"RADIXOPERATOR_JOB_AUX_IMAGE": "docker.io/bash:latest",
 				"RADIXOPERATOR_TENANT_ID": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
 				"KUBERNETES_SERVICE_PORT": "443",
 				"REGISTRATION_CONTROLLER_THREADS": "10",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -127,7 +127,7 @@
 				"USE_PROFILER": "true",
 				"APP_ALIAS_BASE_URL": "app.dev.radix.equinor.com",
 				"DNS_ZONE": "dev.radix.equinor.com",
-				"RADIX_CLUSTERNAME": "weekly-27",
+				"RADIX_CLUSTERNAME": "weekly-32",
 				"RADIXOPERATOR_CLUSTER_TYPE": "development",
 				"RADIXOPERATOR_DEFAULT_APP_ADMIN_GROUPS": "64b28659-4fe4-4222-8497-85dd7e43e25b",
 				"RADIXOPERATOR_APP_BUILDER_RESOURCES_LIMITS_CPU": "2000m",

--- a/charts/radix-operator/templates/deployment.yaml
+++ b/charts/radix-operator/templates/deployment.yaml
@@ -101,6 +101,8 @@ spec:
               value: {{ .Values.oauth2proxy.image.repository }}:{{ .Values.oauth2proxy.image.tag }}
             - name: RADIX_OAUTH_REDIS_IMAGE
               value: {{ .Values.oauth2redis.image.repository }}:{{ .Values.oauth2redis.image.tag }}
+            - name: RADIXOPERATOR_JOB_AUX_IMAGE
+              value: {{ .Values.jobAux.image.repository }}:{{ .Values.jobAux.image.tag }}
             - name: REGISTRATION_CONTROLLER_THREADS
               value: {{ .Values.registrationControllerThreads | quote }}
             - name: APPLICATION_CONTROLLER_THREADS

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -184,6 +184,11 @@ oauth2redis:
     repository: docker.io/redis
     tag: "8.0"
 
+jobAux:
+  image:
+    repository: docker.io/bash
+    tag: "latest"
+
 radixPipelineRunner:
   image:
     repository: ghcr.io/equinor/radix/pipeline

--- a/pkg/apis/config/config_test.go
+++ b/pkg/apis/config/config_test.go
@@ -46,6 +46,7 @@ func TestMustParse(t *testing.T) {
 		// DeploymentSyncer
 		defaults.OperatorTenantIdEnvironmentVariable:  "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
 		defaults.KubernetesApiPortEnvironmentVariable: "443",
+		defaults.RadixJobAuxImageEnvironmentVariable:  "docker.io/bash:alpine3.22",
 
 		// ContainerRegistryConfig
 		defaults.RadixExternalRegistryDefaultAuthEnvironmentVariable: "radix-external-registry-auth",
@@ -96,6 +97,7 @@ func TestMustParse(t *testing.T) {
 	assert.Equal(t, "3aa4a235-b6e2-48d5-9195-7fcf05b459b0", cfg.DeploymentSyncer.TenantID)
 	assert.Equal(t, int32(443), cfg.DeploymentSyncer.KubernetesAPIPort)
 	assert.Equal(t, 10, cfg.DeploymentSyncer.DeploymentHistoryLimit)
+	assert.Equal(t, "docker.io/bash:alpine3.22", cfg.DeploymentSyncer.JobAuxImage)
 
 	// ContainerRegistryConfig
 	assert.Equal(t, "radix-external-registry-auth", cfg.ContainerRegistryConfig.ExternalRegistryAuthSecret)

--- a/pkg/apis/config/deployment_config.go
+++ b/pkg/apis/config/deployment_config.go
@@ -4,4 +4,5 @@ type DeploymentSyncerConfig struct {
 	TenantID               string `envconfig:"RADIXOPERATOR_TENANT_ID" required:"true"`
 	KubernetesAPIPort      int32  `envconfig:"KUBERNETES_SERVICE_PORT" required:"true"`
 	DeploymentHistoryLimit int    `envconfig:"RADIX_DEPLOYMENTS_PER_ENVIRONMENT_HISTORY_LIMIT" required:"true"`
+	JobAuxImage            string `envconfig:"RADIXOPERATOR_JOB_AUX_IMAGE" required:"true"`
 }

--- a/pkg/apis/defaults/environment_variables.go
+++ b/pkg/apis/defaults/environment_variables.go
@@ -112,6 +112,9 @@ const (
 	// RadixOAuthRedisImageEnvironmentVariable specifies the name and tag of the OAuth Redis image
 	RadixOAuthRedisImageEnvironmentVariable = "RADIX_OAUTH_REDIS_IMAGE"
 
+	// RadixJobAuxImageEnvironmentVariable specifies the name and tag of the job aux image
+	RadixJobAuxImageEnvironmentVariable = "RADIXOPERATOR_JOB_AUX_IMAGE"
+
 	// RadixConfigFileEnvironmentVariable Path to a radixconfig.yaml
 	// to be loaded from Radix application config branch
 	RadixConfigFileEnvironmentVariable = "RADIX_FILE_NAME"

--- a/pkg/apis/deployment/deployment.go
+++ b/pkg/apis/deployment/deployment.go
@@ -11,18 +11,13 @@ import (
 	certclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/equinor/radix-common/utils/slice"
 	"github.com/equinor/radix-operator/pkg/apis/config"
-	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	internal "github.com/equinor/radix-operator/pkg/apis/internal/deployment"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	"github.com/equinor/radix-operator/pkg/apis/metrics"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
-	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/apis/volumemount"
 	radixclient "github.com/equinor/radix-operator/pkg/client/clientset/versioned"
 	"github.com/rs/zerolog/log"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -462,37 +457,6 @@ func (deploy *Deployment) syncDeploymentForRadixComponent(ctx context.Context, c
 	return nil
 }
 
-func (deploy *Deployment) createOrUpdateJobAuxDeployment(ctx context.Context, deployComponent v1.RadixCommonDeployComponent, namespace, jobKubeDeploymentName string, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) (*appsv1.Deployment, *appsv1.Deployment, error) {
-	currentJobAuxDeployment, desiredJobAuxDeployment, err := deploy.getCurrentAndDesiredJobAuxDeployment(ctx, namespace, jobKubeDeploymentName)
-	if err != nil {
-		return nil, nil, err
-	}
-	desiredJobAuxDeployment.ObjectMeta.Labels = deploy.getJobAuxDeploymentLabels(deployComponent)
-	desiredJobAuxDeployment.Spec.Selector.MatchLabels = deploy.getJobAuxDeploymentPodLabels(deployComponent)
-	desiredJobAuxDeployment.Spec.Template.Labels = deploy.getJobAuxDeploymentPodLabels(deployComponent)
-	desiredJobAuxDeployment.Spec.Template.Spec.ServiceAccountName = (&radixComponentServiceAccountSpec{component: deployComponent}).ServiceAccountName()
-	desiredJobAuxDeployment.Spec.Template.Spec.Affinity = utils.GetAffinityForJobAPIAuxComponent()
-	// Move volumes and volume mounts from desired deployment to job aux deployment
-	desiredJobAuxDeployment.Spec.Template.Spec.Volumes = volumes
-	desiredJobAuxDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
-
-	syncRadixRestartEnvironmentVariable(deployComponent, desiredJobAuxDeployment)
-	return currentJobAuxDeployment, desiredJobAuxDeployment, nil
-}
-
-func (deploy *Deployment) getCurrentAndDesiredJobAuxDeployment(ctx context.Context, namespace, jobKubeDeploymentName string) (*appsv1.Deployment, *appsv1.Deployment, error) {
-	jobAuxKubeDeploymentName := defaults.GetJobAuxKubeDeployName(jobKubeDeploymentName)
-	desiredJobAuxDeployment := deploy.createJobAuxDeployment(jobKubeDeploymentName, jobAuxKubeDeploymentName)
-	currentJobAuxDeployment, err := deploy.kubeutil.KubeClient().AppsV1().Deployments(namespace).Get(ctx, jobAuxKubeDeploymentName, metav1.GetOptions{})
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return nil, desiredJobAuxDeployment, nil
-		}
-		return nil, nil, err
-	}
-	return currentJobAuxDeployment, desiredJobAuxDeployment, nil
-}
-
 func getLabelSelectorForComponent(component v1.RadixCommonDeployComponent) string {
 	return fmt.Sprintf("%s=%s", kube.RadixComponentLabel, component.GetName())
 }
@@ -545,17 +509,4 @@ func getActiveFrom(rd *v1.RadixDeployment) metav1.Time {
 		return rd.CreationTimestamp
 	}
 	return rd.Status.ActiveFrom
-}
-
-func syncRadixRestartEnvironmentVariable(deployComponent v1.RadixCommonDeployComponent, desiredJobAuxDeployment *appsv1.Deployment) {
-	auxDeploymentEnvVars := desiredJobAuxDeployment.Spec.Template.Spec.Containers[0].Env
-	if restartComponentValue, ok := deployComponent.GetEnvironmentVariables()[defaults.RadixRestartEnvironmentVariable]; ok {
-		if index := slice.FindIndex(auxDeploymentEnvVars, func(envVar corev1.EnvVar) bool {
-			return strings.EqualFold(envVar.Name, defaults.RadixRestartEnvironmentVariable)
-		}); index >= 0 {
-			desiredJobAuxDeployment.Spec.Template.Spec.Containers[0].Env[index].Value = restartComponentValue
-			return
-		}
-		desiredJobAuxDeployment.Spec.Template.Spec.Containers[0].Env = append(auxDeploymentEnvVars, corev1.EnvVar{Name: defaults.RadixRestartEnvironmentVariable, Value: restartComponentValue})
-	}
 }

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -778,6 +778,69 @@ func TestObjectSynced_Job_GarbageCollectDeployments(t *testing.T) {
 	assert.ElementsMatch(t, []string{"job1", "job1-aux"}, actualDeploymentNames)
 }
 
+func TestObjectSynced_JobAux_DeploymentSpecIsSet(t *testing.T) {
+	const (
+		appName = "any-app"
+		envName = "test"
+		jobName = "job1"
+	)
+
+	tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, _, certClient := SetupTest(t)
+	defer TeardownTest()
+
+	_, err := ApplyDeploymentWithSync(tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, certClient,
+		utils.ARadixDeployment().
+			WithAppName(appName).
+			WithEnvironment(envName).
+			WithComponents().
+			WithJobComponents(utils.NewDeployJobComponentBuilder().WithName(jobName).WithRuntime(&radixv1.Runtime{Architecture: "customarch"})))
+	require.NoError(t, err)
+
+	namespace := utils.GetEnvironmentNamespace(appName, envName)
+	allDeployments, err := kubeclient.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	jobAuxDeploymentName := defaults.GetJobAuxKubeDeployName(jobName)
+	jobAuxDeployment := getDeploymentByName(jobAuxDeploymentName, allDeployments.Items)
+	require.NotNil(t, jobAuxDeployment)
+
+	require.NotNil(t, jobAuxDeployment.Spec.Replicas)
+	assert.Equal(t, int32(1), *jobAuxDeployment.Spec.Replicas)
+
+	assert.Equal(t, appName, jobAuxDeployment.Spec.Template.Labels[kube.RadixAppLabel])
+	assert.Equal(t, jobName, jobAuxDeployment.Spec.Template.Labels[kube.RadixAuxiliaryComponentLabel])
+	assert.Equal(t, kube.RadixJobTypeManagerAux, jobAuxDeployment.Spec.Template.Labels[kube.RadixAuxiliaryComponentTypeLabel])
+	assert.Equal(t, "true", jobAuxDeployment.Spec.Template.Labels[kube.RadixPodIsJobAuxObjectLabel])
+	require.NotEmpty(t, jobAuxDeployment.Spec.Template.Labels[kube.RadixAppIDLabel])
+
+	expectedSelectorMatchLabels := radixlabels.Merge(
+		radixlabels.ForApplicationName(appName),
+		map[string]string{kube.RadixAppIDLabel: jobAuxDeployment.Spec.Template.Labels[kube.RadixAppIDLabel]},
+		radixlabels.ForJobAuxObject(jobName, kube.RadixJobTypeManagerAux),
+	)
+	assert.EqualValues(t, expectedSelectorMatchLabels, jobAuxDeployment.Spec.Selector.MatchLabels)
+
+	assert.Equal(t, pointers.Ptr(false), jobAuxDeployment.Spec.Template.Spec.AutomountServiceAccountToken)
+	assert.Equal(t, defaultServiceAccountName, jobAuxDeployment.Spec.Template.Spec.ServiceAccountName)
+	assert.Equal(t, utils.GetAffinityForJobAPIAuxComponent(), jobAuxDeployment.Spec.Template.Spec.Affinity)
+
+	require.Len(t, jobAuxDeployment.Spec.Template.Spec.Containers, 1)
+	container := jobAuxDeployment.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, jobAuxDeploymentName, container.Name)
+	assert.Equal(t, "bash:alpine3.22", container.Image)
+	assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
+	assert.Equal(t, []string{"sh"}, container.Command)
+	assert.Equal(t, []string{"-c", "echo 'start'; while true; do echo $(date);sleep 3600; done; echo 'exit'"}, container.Args)
+	requestCPU := container.Resources.Requests[corev1.ResourceCPU]
+	requestMemory := container.Resources.Requests[corev1.ResourceMemory]
+	limitCPU := container.Resources.Limits[corev1.ResourceCPU]
+	limitMemory := container.Resources.Limits[corev1.ResourceMemory]
+	assert.True(t, requestCPU.Equal(parseQuantity("1m")))
+	assert.True(t, requestMemory.Equal(parseQuantity("20M")))
+	assert.True(t, limitCPU.Equal(parseQuantity("0")))
+	assert.True(t, limitMemory.Equal(parseQuantity("20M")))
+}
+
 func getServicesForRadixComponents(services *[]corev1.Service) []corev1.Service {
 	var result []corev1.Service
 	for _, svc := range *services {
@@ -1160,11 +1223,11 @@ func TestObjectSynced_ServiceAccountSettingsAndRbac(t *testing.T) {
 		allDeployments, _ = client.AppsV1().Deployments(utils.GetEnvironmentNamespace("any-other-app", "test")).List(context.Background(),
 			metav1.ListOptions{})
 		expectedJobDeployments := getDeploymentsForRadixComponents(allDeployments.Items)
-		assert.Equal(t, 1, len(expectedJobDeployments))
+		require.Equal(t, 1, len(expectedJobDeployments))
 		assert.Equal(t, pointers.Ptr(true), expectedJobDeployments[0].Spec.Template.Spec.AutomountServiceAccountToken)
 		assert.Equal(t, defaults.RadixJobSchedulerServiceName, expectedJobDeployments[0].Spec.Template.Spec.ServiceAccountName)
 		expectedJobAuxDeployments := getDeploymentsForRadixJobAux(allDeployments.Items)
-		assert.Equal(t, 1, len(expectedJobAuxDeployments))
+		require.Equal(t, 1, len(expectedJobAuxDeployments))
 		assert.Equal(t, pointers.Ptr(false), expectedJobAuxDeployments[0].Spec.Template.Spec.AutomountServiceAccountToken)
 		assert.Equal(t, defaultServiceAccountName, expectedJobAuxDeployments[0].Spec.Template.Spec.ServiceAccountName)
 
@@ -3600,6 +3663,90 @@ func Test_RestartJobManager_RestartsAuxDeployment(t *testing.T) {
 	require.True(t, slice.Any(jobAuxDeployments[0].Spec.Template.Spec.Containers[0].Env, func(envVar corev1.EnvVar) bool {
 		return envVar.Name == defaults.RadixRestartEnvironmentVariable && envVar.Value == restartTimestamp
 	}), "Not found restart env var in the job aux deployment")
+}
+
+func Test_JobAuxDeployment_IsDeletedOnlyWhenSelectorMatchLabelsChange(t *testing.T) {
+	const (
+		appName        = "app"
+		environment    = "dev"
+		jobName        = "job"
+		deploymentName = "deployment1"
+	)
+
+	applicationBuilder := utils.NewRadixApplicationBuilder().
+		WithAppName(appName).
+		WithRadixRegistration(utils.NewRegistrationBuilder().WithName(appName))
+	jobComponentBuilder := utils.NewDeployJobComponentBuilder().WithName(jobName)
+	newDeploymentBuilder := func() utils.DeploymentBuilder {
+		return utils.NewDeploymentBuilder().
+			WithDeploymentName(deploymentName).
+			WithRadixApplication(applicationBuilder).
+			WithAppName(appName).
+			WithEnvironment(environment).
+			WithJobComponent(jobComponentBuilder)
+	}
+	jobAuxDeploymentName := defaults.GetJobAuxKubeDeployName(jobName)
+
+	t.Run("kept when selector matchlabels are equal", func(t *testing.T) {
+		tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, _, certClient := SetupTest(t)
+		defer TeardownTest()
+
+		jobAuxDeleteCount := 0
+		kubeclient.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			deleteAction, ok := action.(k8stesting.DeleteAction)
+			if ok && deleteAction.GetName() == jobAuxDeploymentName {
+				jobAuxDeleteCount++
+			}
+			return false, nil, nil
+		})
+
+		_, err := ApplyDeploymentWithSync(tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, certClient, newDeploymentBuilder())
+		require.NoError(t, err)
+
+		err = applyDeploymentUpdateWithSync(tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, certClient, newDeploymentBuilder())
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, jobAuxDeleteCount)
+	})
+
+	t.Run("deleted when selector matchlabels do not match", func(t *testing.T) {
+		tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, _, certClient := SetupTest(t)
+		defer TeardownTest()
+
+		jobAuxDeleteCount := 0
+		kubeclient.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			deleteAction, ok := action.(k8stesting.DeleteAction)
+			if ok && deleteAction.GetName() == jobAuxDeploymentName {
+				jobAuxDeleteCount++
+			}
+			return false, nil, nil
+		})
+
+		_, err := ApplyDeploymentWithSync(tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, certClient, newDeploymentBuilder())
+		require.NoError(t, err)
+
+		envNamespace := utils.GetEnvironmentNamespace(appName, environment)
+		jobAuxDeployment, err := kubeclient.AppsV1().Deployments(envNamespace).Get(context.Background(), jobAuxDeploymentName, metav1.GetOptions{})
+		require.NoError(t, err)
+		jobAuxDeployment.Spec.Selector.MatchLabels[kube.RadixAuxiliaryComponentLabel] = "other-job"
+		_, err = kubeclient.AppsV1().Deployments(envNamespace).Update(context.Background(), jobAuxDeployment, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		err = applyDeploymentUpdateWithSync(tu, kubeclient, kubeUtil, radixclient, kedaClient, prometheusclient, certClient, newDeploymentBuilder())
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, jobAuxDeleteCount)
+
+		jobAuxDeployment, err = kubeclient.AppsV1().Deployments(envNamespace).Get(context.Background(), jobAuxDeploymentName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, jobAuxDeployment.Spec.Template.Labels[kube.RadixAppIDLabel])
+		expectedSelectorMatchLabels := radixlabels.Merge(
+			radixlabels.ForApplicationName(appName),
+			map[string]string{kube.RadixAppIDLabel: jobAuxDeployment.Spec.Template.Labels[kube.RadixAppIDLabel]},
+			radixlabels.ForJobAuxObject(jobName, kube.RadixJobTypeManagerAux),
+		)
+		assert.EqualValues(t, expectedSelectorMatchLabels, jobAuxDeployment.Spec.Selector.MatchLabels)
+	})
 }
 
 func TestRadixBatch_IsGarbageCollected(t *testing.T) {

--- a/pkg/apis/deployment/deployment_test.go
+++ b/pkg/apis/deployment/deployment_test.go
@@ -67,6 +67,7 @@ var testConfig = config.Config{
 		TenantID:               "123456789",
 		KubernetesAPIPort:      543,
 		DeploymentHistoryLimit: 10,
+		JobAuxImage:            "docker.io/bash:alpine3.22",
 	},
 	CertificateAutomation: config.CertificateAutomationConfig{
 		GatewayClusterIssuer: "test-gateway-cert-issuer",
@@ -827,7 +828,7 @@ func TestObjectSynced_JobAux_DeploymentSpecIsSet(t *testing.T) {
 	require.Len(t, jobAuxDeployment.Spec.Template.Spec.Containers, 1)
 	container := jobAuxDeployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, jobAuxDeploymentName, container.Name)
-	assert.Equal(t, "bash:alpine3.22", container.Image)
+	assert.Equal(t, testConfig.DeploymentSyncer.JobAuxImage, container.Image)
 	assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
 	assert.Equal(t, []string{"sh"}, container.Command)
 	assert.Equal(t, []string{"-c", "echo 'start'; while true; do echo $(date);sleep 3600; done; echo 'exit'"}, container.Args)

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -124,7 +124,7 @@ func (deploy *Deployment) getCurrentAndDesiredJobAuxDeployment(ctx context.Conte
 					Containers: []corev1.Container{
 						{
 							Name:            jobAuxKubeDeploymentName,
-							Image:           "bash:alpine3.22",
+							Image:           deploy.config.DeploymentSyncer.JobAuxImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: securitycontext.Container(
 								securitycontext.WithReadOnlyRootFileSystem(pointers.Ptr(true)),

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"maps"
 
 	"github.com/equinor/radix-common/utils/pointers"
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
@@ -18,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -44,31 +44,29 @@ func (deploy *Deployment) reconcileDeployComponent(ctx context.Context, deployCo
 	}
 	desiredDeployment.Spec.Template.Spec.Volumes = actualVolumes
 	desiredVolumeMounts := desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	if err = deploy.handleJobAuxDeployment(ctx, namespace, deployComponent, desiredDeployment, actualVolumes, desiredVolumeMounts); err != nil {
+	if err = deploy.handleJobAuxDeployment(ctx, deployComponent, desiredDeployment, actualVolumes, desiredVolumeMounts); err != nil {
 		return err
 	}
 	return deploy.kubeutil.ApplyDeployment(ctx, namespace, currentDeployment, desiredDeployment)
 }
 
-func (deploy *Deployment) handleJobAuxDeployment(ctx context.Context, namespace string, deployComponent v1.RadixCommonDeployComponent, desiredDeployment *appsv1.Deployment, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) error {
+func (deploy *Deployment) handleJobAuxDeployment(ctx context.Context, deployComponent v1.RadixCommonDeployComponent, desiredDeployment *appsv1.Deployment, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) error {
 	if !internal.IsDeployComponentJobSchedulerDeployment(deployComponent) {
 		return nil
 	}
-	jobKubeDeploymentName := desiredDeployment.GetName()
-	currentJobAuxDeployment, desiredJobAuxDeployment, err := deploy.createOrUpdateJobAuxDeployment(ctx, deployComponent, namespace, jobKubeDeploymentName, volumes, volumeMounts)
+
+	currentJobAuxDeployment, desiredJobAuxDeployment, err := deploy.getCurrentAndDesiredJobAuxDeployment(ctx, deployComponent, volumes, volumeMounts)
 	if err != nil {
 		return err
 	}
 
-	// If selector doesnt match pod labels, recreate deployment
-	selector := labels.Set(desiredJobAuxDeployment.Spec.Selector.MatchLabels).AsSelector()
-	if currentJobAuxDeployment != nil && !selector.Matches(labels.Set(currentJobAuxDeployment.Spec.Template.Labels)) {
+	if currentJobAuxDeployment != nil && !maps.Equal(currentJobAuxDeployment.Spec.Selector.MatchLabels, desiredJobAuxDeployment.Spec.Selector.MatchLabels) {
 		log.Ctx(ctx).Info().Msgf("Deleting outdated deployment (label selector does not match) %s", currentJobAuxDeployment.GetName())
 		if err = deploy.kubeutil.DeleteDeployment(ctx, deploy.radixDeployment.Namespace, currentJobAuxDeployment.Name); err != nil {
 			return err
 		}
 
-		currentJobAuxDeployment, desiredJobAuxDeployment, err = deploy.createOrUpdateJobAuxDeployment(ctx, deployComponent, namespace, jobKubeDeploymentName, volumes, volumeMounts)
+		currentJobAuxDeployment, desiredJobAuxDeployment, err = deploy.getCurrentAndDesiredJobAuxDeployment(ctx, deployComponent, volumes, volumeMounts)
 		if err != nil {
 			return err
 		}
@@ -78,6 +76,79 @@ func (deploy *Deployment) handleJobAuxDeployment(ctx context.Context, namespace 
 	desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = nil
 
 	return deploy.kubeutil.ApplyDeployment(ctx, deploy.radixDeployment.Namespace, currentJobAuxDeployment, desiredJobAuxDeployment)
+}
+
+func (deploy *Deployment) getCurrentAndDesiredJobAuxDeployment(ctx context.Context, deployComponent v1.RadixCommonDeployComponent, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) (*appsv1.Deployment, *appsv1.Deployment, error) {
+	jobAuxKubeDeploymentName := defaults.GetJobAuxKubeDeployName(deployComponent.GetName())
+
+	var env []corev1.EnvVar
+	if restartComponentValue, ok := deployComponent.GetEnvironmentVariables()[defaults.RadixRestartEnvironmentVariable]; ok {
+		env = append(env, corev1.EnvVar{Name: defaults.RadixRestartEnvironmentVariable, Value: restartComponentValue})
+	}
+
+	desiredJobAuxDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            jobAuxKubeDeploymentName,
+			OwnerReferences: []metav1.OwnerReference{getOwnerReferenceOfDeployment(deploy.radixDeployment)},
+			Labels: radixlabels.Merge(
+				radixlabels.ForApplicationName(deploy.registration.Name),
+				radixlabels.ForJobAuxObject(deployComponent.GetName(), kube.RadixJobTypeManagerAux),
+			),
+			Annotations: radixannotations.ForKubernetesDeploymentObservedGeneration(deploy.radixDeployment),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointers.Ptr[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: radixlabels.Merge(
+					radixlabels.ForApplicationName(deploy.registration.Name),
+					radixlabels.ForApplicationID(deploy.registration.Spec.AppID),
+					radixlabels.ForJobAuxObject(deployComponent.GetName(), kube.RadixJobTypeManagerAux),
+				),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: radixlabels.Merge(
+						radixlabels.ForApplicationName(deploy.registration.Name),
+						radixlabels.ForApplicationID(deploy.registration.Spec.AppID),
+						radixlabels.ForPodWithRadixIdentity(deployComponent.GetIdentity()),
+						radixlabels.ForJobAuxObject(deployComponent.GetName(), kube.RadixJobTypeManagerAux),
+					),
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: new(false),
+					SecurityContext:              securitycontext.Pod(),
+					ImagePullSecrets:             deploy.config.ContainerRegistryConfig.ImagePullSecretsFromExternalRegistryAuth(),
+					ServiceAccountName:           (&radixComponentServiceAccountSpec{component: deployComponent}).ServiceAccountName(),
+					Affinity:                     utils.GetAffinityForJobAPIAuxComponent(),
+					Volumes:                      volumes,
+					Containers: []corev1.Container{
+						{
+							Name:            jobAuxKubeDeploymentName,
+							Image:           "bash:alpine3.22",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							SecurityContext: securitycontext.Container(
+								securitycontext.WithReadOnlyRootFileSystem(pointers.Ptr(true)),
+								securitycontext.WithContainerRunAsUser(1000),
+							),
+							Command:      []string{"sh"},
+							Args:         []string{"-c", "echo 'start'; while true; do echo $(date);sleep 3600; done; echo 'exit'"},
+							Resources:    getJobAuxResources(),
+							VolumeMounts: volumeMounts,
+							Env:          env,
+						}},
+				},
+			},
+		},
+	}
+
+	currentJobAuxDeployment, err := deploy.kubeutil.KubeClient().AppsV1().Deployments(deploy.radixDeployment.Namespace).Get(ctx, jobAuxKubeDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return nil, desiredJobAuxDeployment, nil
+		}
+		return nil, nil, err
+	}
+	return currentJobAuxDeployment, desiredJobAuxDeployment, nil
 }
 
 func (deploy *Deployment) getCurrentAndDesiredDeployment(ctx context.Context, namespace string, deployComponent v1.RadixCommonDeployComponent) (*appsv1.Deployment, *appsv1.Deployment, error) {
@@ -131,43 +202,6 @@ func (deploy *Deployment) getDesiredCreatedDeploymentConfig(ctx context.Context,
 	return desiredDeployment, err
 }
 
-func (deploy *Deployment) createJobAuxDeployment(jobName, jobAuxDeploymentName string) *appsv1.Deployment {
-	desiredDeployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            jobAuxDeploymentName,
-			OwnerReferences: []metav1.OwnerReference{getOwnerReferenceOfDeployment(deploy.radixDeployment)},
-			Labels:          make(map[string]string),
-			Annotations:     radixannotations.ForKubernetesDeploymentObservedGeneration(deploy.radixDeployment),
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: pointers.Ptr[int32](1),
-			Selector: &metav1.LabelSelector{MatchLabels: radixlabels.ForJobAuxObject(jobName, kube.RadixJobTypeManagerAux)},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string), Annotations: make(map[string]string)},
-				Spec: corev1.PodSpec{Containers: []corev1.Container{
-					{
-						Name:      jobAuxDeploymentName,
-						Resources: getJobAuxResources(),
-					}},
-				},
-			},
-		},
-	}
-	desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken = new(false)
-	desiredDeployment.Spec.Template.Spec.SecurityContext = securitycontext.Pod()
-	desiredDeployment.Spec.Template.Spec.ImagePullSecrets = deploy.config.ContainerRegistryConfig.ImagePullSecretsFromExternalRegistryAuth()
-
-	desiredDeployment.Spec.Template.Spec.Containers[0].Image = "bash:alpine3.22"
-	desiredDeployment.Spec.Template.Spec.Containers[0].Command = []string{"sh"}
-	desiredDeployment.Spec.Template.Spec.Containers[0].Args = []string{"-c", "echo 'start'; while true; do echo $(date);sleep 3600; done; echo 'exit'"}
-	desiredDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
-	desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext = securitycontext.Container(
-		securitycontext.WithReadOnlyRootFileSystem(pointers.Ptr(true)),
-		securitycontext.WithContainerRunAsUser(1000))
-
-	return desiredDeployment
-}
-
 func (deploy *Deployment) getDesiredUpdatedDeploymentConfig(ctx context.Context, deployComponent v1.RadixCommonDeployComponent, currentDeployment *appsv1.Deployment) (*appsv1.Deployment, error) {
 	log.Ctx(ctx).Debug().Msgf("Get desired updated deployment config for application: %s.", deploy.radixDeployment.Spec.AppName) //nolint:staticcheck
 
@@ -206,15 +240,6 @@ func (deploy *Deployment) getDeploymentPodLabels(deployComponent v1.RadixCommonD
 	return lbs
 }
 
-func (deploy *Deployment) getJobAuxDeploymentPodLabels(deployComponent v1.RadixCommonDeployComponent) map[string]string {
-	return radixlabels.Merge(
-		radixlabels.ForApplicationName(deploy.radixDeployment.Spec.AppName), //nolint:staticcheck
-		radixlabels.ForApplicationID(deploy.registration.Spec.AppID),
-		radixlabels.ForPodWithRadixIdentity(deployComponent.GetIdentity()),
-		radixlabels.ForJobAuxObject(deployComponent.GetName(), kube.RadixJobTypeManagerAux),
-	)
-}
-
 func (deploy *Deployment) getDeploymentPodAnnotations(deployComponent v1.RadixCommonDeployComponent) map[string]string {
 	branch, _ := deploy.getRadixBranchAndCommitId()
 	annotations := radixannotations.ForRadixBranch(branch)
@@ -246,13 +271,6 @@ func (deploy *Deployment) getDeploymentLabels(deployComponent v1.RadixCommonDepl
 
 func getDeployComponentCommitId(deployComponent v1.RadixCommonDeployComponent) string {
 	return deployComponent.GetEnvironmentVariables()[defaults.RadixCommitHashEnvironmentVariable]
-}
-
-func (deploy *Deployment) getJobAuxDeploymentLabels(deployComponent v1.RadixCommonDeployComponent) map[string]string {
-	return radixlabels.Merge(
-		radixlabels.ForApplicationName(deploy.radixDeployment.Spec.AppName), //nolint:staticcheck
-		radixlabels.ForJobAuxObject(deployComponent.GetName(), kube.RadixJobTypeManagerAux),
-	)
 }
 
 func (deploy *Deployment) getDeploymentAnnotations() map[string]string {

--- a/pkg/apis/deployment/kubedeployment.go
+++ b/pkg/apis/deployment/kubedeployment.go
@@ -66,11 +66,9 @@ func (deploy *Deployment) handleJobAuxDeployment(ctx context.Context, deployComp
 			return err
 		}
 
-		currentJobAuxDeployment, desiredJobAuxDeployment, err = deploy.getCurrentAndDesiredJobAuxDeployment(ctx, deployComponent, volumes, volumeMounts)
-		if err != nil {
-			return err
-		}
+		currentJobAuxDeployment = nil
 	}
+
 	// Remove volumes and volume mounts from job scheduler deployment, they are set to aux deployment
 	desiredDeployment.Spec.Template.Spec.Volumes = nil
 	desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = nil

--- a/pkg/apis/deployment/kubedeployment_test.go
+++ b/pkg/apis/deployment/kubedeployment_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/equinor/radix-common/utils/pointers"
 	"github.com/equinor/radix-common/utils/slice"
-	"github.com/equinor/radix-operator/pkg/apis/config"
 	"github.com/equinor/radix-operator/pkg/apis/defaults"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/test"
@@ -446,20 +445,4 @@ func applyDeploymentWithSyncWithComponentResources(t *testing.T, origRequests, o
 			WithAppName("any-app").
 			WithEnvironment("test"))
 	return Deployment{radixclient: radixclient, kubeutil: kubeUtil, radixDeployment: rd, registration: rr.BuildRR(), config: &testConfig}
-}
-
-func TestDeployment_createJobAuxDeployment(t *testing.T) {
-	deploy := &Deployment{radixDeployment: &v1.RadixDeployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment1", UID: "uid1"}}, config: &config.Config{ContainerRegistryConfig: config.ContainerRegistryConfig{ExternalRegistryAuthSecret: "an-external-registry-secret"}}}
-	jobAuxDeployment := deploy.createJobAuxDeployment("job1", "job1-aux")
-	assert.Equal(t, "job1-aux", jobAuxDeployment.GetName())
-	resources := jobAuxDeployment.Spec.Template.Spec.Containers[0].Resources
-	s := resources.Requests.Cpu().String()
-	assert.Equal(t, "1m", s)
-	assert.Equal(t, "20M", resources.Requests.Memory().String())
-	assert.Equal(t, "0", resources.Limits.Cpu().String())
-	assert.Equal(t, "20M", resources.Limits.Memory().String())
-	assert.Equal(t, "bash:alpine3.22", jobAuxDeployment.Spec.Template.Spec.Containers[0].Image)
-	assert.Equal(t, "an-external-registry-secret", jobAuxDeployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-	assert.Equal(t, `sh`, jobAuxDeployment.Spec.Template.Spec.Containers[0].Command[0])
-	assert.Equal(t, []string{"-c", "echo 'start'; while true; do echo $(date);sleep 3600; done; echo 'exit'"}, jobAuxDeployment.Spec.Template.Spec.Containers[0].Args)
 }


### PR DESCRIPTION
## Pull request overview

Updates job auxiliary Deployment reconciliation to recreate resources when immutable selector labels change.

**Changes:**
- Compares current and desired selectors and recreates mismatched Deployments.
- Consolidates job auxiliary Deployment construction and expands tests.
- Makes the auxiliary image configurable through Helm and environment settings.