### PR TITLE
fix: validate subdomain length constrain

### DIFF
--- a/pkg/apis/deployment/gateway.go
+++ b/pkg/apis/deployment/gateway.go
@@ -47,7 +47,6 @@ func (deploy *Deployment) reconcileHTTPRouteComponent(ctx context.Context, compo
 	if component.IsPublic() {
 		// HTTPRoute for external dns is reconciled in externaldns.go, so filter out those
 		hosts = slice.FindAll(
-			//
 			getComponentDNSInfo(ctx, component, *deploy.radixDeployment, *deploy.kubeutil),
 			func(host dnsInfo) bool { return host.dnsType != dnsTypeExternal })
 	}

--- a/pkg/apis/deployment/gateway.go
+++ b/pkg/apis/deployment/gateway.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/equinor/radix-operator/pkg/apis/utils/domain"
 	"github.com/equinor/radix-operator/pkg/apis/utils/labels"
 	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,7 @@ func (deploy *Deployment) reconcileHTTPRouteComponent(ctx context.Context, compo
 	if component.IsPublic() {
 		// HTTPRoute for external dns is reconciled in externaldns.go, so filter out those
 		hosts = slice.FindAll(
+			//
 			getComponentDNSInfo(ctx, component, *deploy.radixDeployment, *deploy.kubeutil),
 			func(host dnsInfo) bool { return host.dnsType != dnsTypeExternal })
 	}
@@ -251,7 +253,8 @@ func getActiveClusterHostName(componentName, namespace string) string {
 	if dnsZone == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s-%s.%s", componentName, namespace, dnsZone)
+
+	return fmt.Sprintf("%s.%s", domain.GetComponentHostname(componentName, namespace), dnsZone)
 }
 
 func getHostName(componentName, namespace, clustername string) string {
@@ -259,8 +262,8 @@ func getHostName(componentName, namespace, clustername string) string {
 	if dnsZone == "" {
 		return ""
 	}
-	hostnameTemplate := "%s-%s.%s.%s"
-	return fmt.Sprintf(hostnameTemplate, componentName, namespace, clustername, dnsZone)
+	hostnameTemplate := "%s.%s.%s"
+	return fmt.Sprintf(hostnameTemplate, domain.GetComponentHostname(componentName, namespace), clustername, dnsZone)
 }
 func getAppAliasIngressName(appName string) string {
 	return fmt.Sprintf("%s-url-alias", appName)

--- a/pkg/apis/utils/domain/domain.go
+++ b/pkg/apis/utils/domain/domain.go
@@ -1,0 +1,8 @@
+package domain
+
+import "fmt"
+
+// GetComponentHostname returns the domain label for a component in a namespace.
+func GetComponentHostname(componentName, namespace string) string {
+	return fmt.Sprintf("%s-%s", componentName, namespace)
+}

--- a/pkg/apis/utils/domain/domain_test.go
+++ b/pkg/apis/utils/domain/domain_test.go
@@ -1,0 +1,9 @@
+package domain
+
+import "testing"
+
+func TestGetComponentHostname(t *testing.T) {
+	if actual, expected := GetComponentHostname("component", "namespace"), "component-namespace"; actual != expected {
+		t.Errorf("GetComponentHostname() = %q, want %q", actual, expected)
+	}
+}

--- a/pkg/apis/utils/domain/domain_test.go
+++ b/pkg/apis/utils/domain/domain_test.go
@@ -1,9 +1,11 @@
 package domain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestGetComponentHostname(t *testing.T) {
-	if actual, expected := GetComponentHostname("component", "namespace"), "component-namespace"; actual != expected {
-		t.Errorf("GetComponentHostname() = %q, want %q", actual, expected)
-	}
+	assert.Equal(t, "component-namespace", GetComponentHostname("component", "namespace"))
 }

--- a/webhook/validation/httproute/errors.go
+++ b/webhook/validation/httproute/errors.go
@@ -5,5 +5,6 @@ import (
 )
 
 var (
-	ErrDuplicateHostname = errors.New("hostname already exists")
+	ErrDuplicateHostname    = errors.New("hostname already exists")
+	ErrHostnameLabelTooLong = errors.New("hostname label exceeds 63 characters")
 )

--- a/webhook/validation/httproute/validate_hr.go
+++ b/webhook/validation/httproute/validate_hr.go
@@ -80,7 +80,13 @@ func createHttpRouteUsableValidator(kubeClient client.Client) validatorFunc {
 
 		var errs []error
 		for _, incomingHostname := range route.Spec.Hostnames {
-			if !validateHostname(normalizeHostname(incomingHostname), existingHostnames) {
+			normalizedIncomingHostname := normalizeHostname(incomingHostname)
+			if !validateHostnameLabelLength(normalizedIncomingHostname) {
+				errs = append(errs, fmt.Errorf("failed to validate hostname %s: %w", incomingHostname, ErrHostnameLabelTooLong))
+				continue
+			}
+
+			if !validateHostname(normalizedIncomingHostname, existingHostnames) {
 				errs = append(errs, fmt.Errorf("failed to validate hostname %s: %w", incomingHostname, ErrDuplicateHostname))
 			}
 		}
@@ -91,6 +97,19 @@ func createHttpRouteUsableValidator(kubeClient client.Client) validatorFunc {
 
 func normalizeHostname(hostname gatewayapiv1.Hostname) string {
 	return strings.ToLower(string(hostname))
+}
+
+func validateHostnameLabelLength(hostname string) bool {
+	// According to RFC 1035, each label in a hostname must be between 1 and 63 characters long. https://www.rfc-editor.org/info/rfc2181/
+	const maxHostnameLabelLength = 63
+
+	for label := range strings.SplitSeq(hostname, ".") {
+		if len(label) > maxHostnameLabelLength {
+			return false
+		}
+	}
+
+	return true
 }
 
 func validateHostname(incomingHostname string, existing []string) bool {

--- a/webhook/validation/httproute/validate_hr_test.go
+++ b/webhook/validation/httproute/validate_hr_test.go
@@ -2,6 +2,7 @@ package httproute_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/equinor/radix-operator/pkg/apis/kube"
@@ -222,6 +223,33 @@ func Test_Webhook_HttpRoute_ValidationSucceeds_WhenBothRoutes_HaveWildcards_AtDi
 	wrns, err := validator.Validate(context.Background(), validHttpRoute2)
 	assert.NoError(t, err)
 	assert.Empty(t, wrns)
+}
+
+func Test_Webhook_HttpRoute_ValidationSucceeds_WhenHostnameLabelLength_Is63(t *testing.T) {
+	validHttpRoute := test.Load[*gatewayapiv1.HTTPRoute]("./testdata/httproute.yaml")
+	validHttpRoute.Spec.Hostnames = []gatewayapiv1.Hostname{
+		gatewayapiv1.Hostname(strings.Repeat("a", 63) + ".hostname.com"),
+	}
+
+	client := test.CreateClient(radixNamespace(validHttpRoute.Namespace), validHttpRoute)
+
+	validator := httproute.CreateOnlineValidator(client)
+	wrns, err := validator.Validate(context.Background(), validHttpRoute)
+	assert.NoError(t, err)
+	assert.Empty(t, wrns)
+}
+
+func Test_Webhook_HttpRoute_ValidationFails_WhenHostnameLabelLength_Is64(t *testing.T) {
+	validHttpRoute := test.Load[*gatewayapiv1.HTTPRoute]("./testdata/httproute.yaml")
+	validHttpRoute.Spec.Hostnames = []gatewayapiv1.Hostname{
+		gatewayapiv1.Hostname(strings.Repeat("a", 64) + ".hostname.com"),
+	}
+
+	client := test.CreateClient(radixNamespace(validHttpRoute.Namespace), validHttpRoute)
+
+	validator := httproute.CreateOnlineValidator(client)
+	_, err := validator.Validate(context.Background(), validHttpRoute)
+	assert.ErrorIs(t, err, httproute.ErrHostnameLabelTooLong)
 }
 
 // radixNamespace creates a Namespace with the kube.RadixAppLabel set, which is

--- a/webhook/validation/radixapplication/errors.go
+++ b/webhook/validation/radixapplication/errors.go
@@ -71,7 +71,7 @@ var (
 	ErrSecretRefEnvVarNameConflictsWithEnvironmentVariable           = errors.New("secret reference environment variable name conflicts with environment variable")
 	ErrDuplicatePathForAzureKeyVault                                 = errors.New("duplicate path for Azure Key vault")
 	ErrInvalidEnvironmentNameLength                                  = errors.New("combined app-name and environment name length must be between 2 and 62 characters")
-	ErrInvalidHostnameLength										 = errors.New("hostname length must be between 2 and 63 characters")
+	ErrInvalidHostnameLength                                         = errors.New("hostname length must be between 2 and 63 characters")
 	ErrEnvironmentNameIsNotAvailable                                 = errors.New("environment name is not available. it is already in use or conflicts with reserved namespace")
 	ErrEgressRuleMustContainAtLeastOneDestination                    = errors.New("egress rule must contain at least one destination")
 	ErrEgressRulePortOutOfRange                                      = errors.New("egress rule port must be equal to or greater than 1 and lower than or equal to 65535")

--- a/webhook/validation/radixapplication/errors.go
+++ b/webhook/validation/radixapplication/errors.go
@@ -8,7 +8,7 @@ var (
 	ErrInternalError = errors.New("internal error. Please try again later or contact support if the issue persists")
 
 	ErrNoRadixApplication                                            = errors.New("no corresponding radix application found. Name of the application in radixconfig.yaml needs to be exactly the same as used when defining the app in the console")
-	ErrApplicationNameTooLong                                        = errors.New("application name cannot exceed 63 characters")
+	ErrApplicationNameTooLong                                        = errors.New("application name cannot exceed 40 characters")
 	ErrDNSAliasComponentIsNotMarkedAsPublic                          = errors.New("component for dns alias is not marked as public")
 	ErrDNSAliasAlreadyUsedByAnotherApplication                       = errors.New("dns alias is already used by another application")
 	ErrDNSAliasReservedForRadixPlatformApplication                   = errors.New("dns alias is reserved for Radix platform application")
@@ -71,6 +71,7 @@ var (
 	ErrSecretRefEnvVarNameConflictsWithEnvironmentVariable           = errors.New("secret reference environment variable name conflicts with environment variable")
 	ErrDuplicatePathForAzureKeyVault                                 = errors.New("duplicate path for Azure Key vault")
 	ErrInvalidEnvironmentNameLength                                  = errors.New("combined app-name and environment name length must be between 2 and 62 characters")
+	ErrInvalidHostnameLength										 = errors.New("hostname length must be between 2 and 63 characters")
 	ErrEnvironmentNameIsNotAvailable                                 = errors.New("environment name is not available. it is already in use or conflicts with reserved namespace")
 	ErrEgressRuleMustContainAtLeastOneDestination                    = errors.New("egress rule must contain at least one destination")
 	ErrEgressRulePortOutOfRange                                      = errors.New("egress rule port must be equal to or greater than 1 and lower than or equal to 65535")

--- a/webhook/validation/radixapplication/errors.go
+++ b/webhook/validation/radixapplication/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrInternalError = errors.New("internal error. Please try again later or contact support if the issue persists")
 
 	ErrNoRadixApplication                                            = errors.New("no corresponding radix application found. Name of the application in radixconfig.yaml needs to be exactly the same as used when defining the app in the console")
+	ErrApplicationNameTooLong                                        = errors.New("application name cannot exceed 63 characters")
 	ErrDNSAliasComponentIsNotMarkedAsPublic                          = errors.New("component for dns alias is not marked as public")
 	ErrDNSAliasAlreadyUsedByAnotherApplication                       = errors.New("dns alias is already used by another application")
 	ErrDNSAliasReservedForRadixPlatformApplication                   = errors.New("dns alias is reserved for Radix platform application")

--- a/webhook/validation/radixapplication/validate.go
+++ b/webhook/validation/radixapplication/validate.go
@@ -358,7 +358,8 @@ func envNameValidator(ctx context.Context, ra *radixv1.RadixApplication) ([]stri
 			return nil, []error{fmt.Errorf("environment %s: %w", env.Name, ErrInvalidEnvironmentNameLength)}
 		}
 		for _, component := range ra.Spec.Components {
-			if len(component.PublicPort) == 0 && component.Public == false {
+			//nolint:staticcheck // Public is supported for backwards compatibility.
+			if len(component.PublicPort) == 0 && !component.Public {
 				continue
 			}
 			namespace := utils.GetEnvironmentNamespace(ra.Name, env.Name)

--- a/webhook/validation/radixapplication/validate.go
+++ b/webhook/validation/radixapplication/validate.go
@@ -38,6 +38,7 @@ var (
 
 var (
 	offlineValidators = []validatorFunc{
+		applicationNameValidator,
 		deprecatedPublicUsageValidator,
 		componentJobNameValidator,
 		componentValidator,
@@ -158,6 +159,15 @@ func branchNameValidator(ctx context.Context, ra *radixv1.RadixApplication) ([]s
 			return nil, []error{fmt.Errorf("environment %s branch from '%s': %w", env.Name, env.Build.From, ErrInvalidBranchName)}
 		}
 	}
+	return nil, nil
+}
+
+func applicationNameValidator(_ context.Context, ra *radixv1.RadixApplication) ([]string, []error) {
+	const maxApplicationNameLength = 63
+	if len(ra.Name) > maxApplicationNameLength {
+		return nil, []error{ErrApplicationNameTooLong}
+	}
+
 	return nil, nil
 }
 
@@ -725,3 +735,5 @@ func validateResourceRequirements(resources radixv1.ResourceRequirements) ([]str
 
 	return wrns, errors.Join(errs...)
 }
+
+// validation for total lenth (when u apply config)

--- a/webhook/validation/radixapplication/validate.go
+++ b/webhook/validation/radixapplication/validate.go
@@ -15,6 +15,7 @@ import (
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/equinor/radix-operator/pkg/apis/utils/branch"
+	"github.com/equinor/radix-operator/pkg/apis/utils/domain"
 	"github.com/equinor/radix-operator/webhook/validation/genericvalidator"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
@@ -163,7 +164,7 @@ func branchNameValidator(ctx context.Context, ra *radixv1.RadixApplication) ([]s
 }
 
 func applicationNameValidator(_ context.Context, ra *radixv1.RadixApplication) ([]string, []error) {
-	const maxApplicationNameLength = 63
+	const maxApplicationNameLength = 40
 	if len(ra.Name) > maxApplicationNameLength {
 		return nil, []error{ErrApplicationNameTooLong}
 	}
@@ -356,6 +357,16 @@ func envNameValidator(ctx context.Context, ra *radixv1.RadixApplication) ([]stri
 		if len(ra.Name)+len(env.Name) > 62 {
 			return nil, []error{fmt.Errorf("environment %s: %w", env.Name, ErrInvalidEnvironmentNameLength)}
 		}
+		for _, component := range ra.Spec.Components {
+			if len(component.PublicPort) == 0 && component.Public == false {
+				continue
+			}
+			namespace := utils.GetEnvironmentNamespace(ra.Name, env.Name)
+			if len(domain.GetComponentHostname(component.Name, namespace)) > 63 {
+				return nil, []error{fmt.Errorf("component %s in environment %s: %w", component.Name, env.Name, ErrInvalidHostnameLength)}
+			}
+		}
+
 	}
 	return nil, nil
 }

--- a/webhook/validation/radixapplication/validate.go
+++ b/webhook/validation/radixapplication/validate.go
@@ -735,5 +735,3 @@ func validateResourceRequirements(resources radixv1.ResourceRequirements) ([]str
 
 	return wrns, errors.Join(errs...)
 }
-
-// validation for total lenth (when u apply config)

--- a/webhook/validation/radixapplication/validate_ra_test.go
+++ b/webhook/validation/radixapplication/validate_ra_test.go
@@ -165,9 +165,9 @@ func Test_missing_rr(t *testing.T) {
 }
 
 func Test_RadixApplicationNameValidation(t *testing.T) {
-	t.Run("name length 63 is valid", func(t *testing.T) {
+	t.Run("name length 40 is valid", func(t *testing.T) {
 		validRA := &radixv1.RadixApplication{}
-		validRA.Name = strings.Repeat("a", 63)
+		validRA.Name = strings.Repeat("a", 40)
 
 		validator := radixapplication.CreateOfflineValidator()
 		wnrs, err := validator.Validate(context.Background(), validRA)
@@ -176,9 +176,9 @@ func Test_RadixApplicationNameValidation(t *testing.T) {
 		assert.Empty(t, wnrs)
 	})
 
-	t.Run("name length 64 is invalid", func(t *testing.T) {
+	t.Run("name length 41 is invalid", func(t *testing.T) {
 		validRA := &radixv1.RadixApplication{}
-		validRA.Name = strings.Repeat("a", 64)
+		validRA.Name = strings.Repeat("a", 41)
 
 		validator := radixapplication.CreateOfflineValidator()
 		_, err := validator.Validate(context.Background(), validRA)

--- a/webhook/validation/radixapplication/validate_ra_test.go
+++ b/webhook/validation/radixapplication/validate_ra_test.go
@@ -164,6 +164,29 @@ func Test_missing_rr(t *testing.T) {
 	assert.Empty(t, wnrs)
 }
 
+func Test_RadixApplicationNameValidation(t *testing.T) {
+	t.Run("name length 63 is valid", func(t *testing.T) {
+		validRA := &radixv1.RadixApplication{}
+		validRA.Name = strings.Repeat("a", 63)
+
+		validator := radixapplication.CreateOfflineValidator()
+		wnrs, err := validator.Validate(context.Background(), validRA)
+
+		assert.NoError(t, err)
+		assert.Empty(t, wnrs)
+	})
+
+	t.Run("name length 64 is invalid", func(t *testing.T) {
+		validRA := &radixv1.RadixApplication{}
+		validRA.Name = strings.Repeat("a", 64)
+
+		validator := radixapplication.CreateOfflineValidator()
+		_, err := validator.Validate(context.Background(), validRA)
+
+		assert.ErrorIs(t, err, radixapplication.ErrApplicationNameTooLong)
+	})
+}
+
 func Test_invalid_ra(t *testing.T) {
 	wayTooLongName := "waytoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongname"
 	invalidBranchName := "/master"

--- a/webhook/validation/radixapplication/validate_ra_test.go
+++ b/webhook/validation/radixapplication/validate_ra_test.go
@@ -187,6 +187,37 @@ func Test_RadixApplicationNameValidation(t *testing.T) {
 	})
 }
 
+func Test_ComponentHostnameValidation(t *testing.T) {
+	newRadixApplication := func(componentName string) *radixv1.RadixApplication {
+		return &radixv1.RadixApplication{
+			ObjectMeta: metav1.ObjectMeta{Name: "app"},
+			Spec: radixv1.RadixApplicationSpec{
+				Environments: []radixv1.Environment{{Name: "dev"}},
+				Components:   []radixv1.RadixComponent{{Name: componentName, Public: true}},
+			},
+		}
+	}
+
+	t.Run("hostname length 63 is valid", func(t *testing.T) {
+		ra := newRadixApplication(strings.Repeat("c", 55))
+
+		validator := radixapplication.CreateOfflineValidator()
+		warnings, err := validator.Validate(context.Background(), ra)
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, warnings)
+	})
+
+	t.Run("hostname length 64 is invalid", func(t *testing.T) {
+		ra := newRadixApplication(strings.Repeat("c", 56))
+
+		validator := radixapplication.CreateOfflineValidator()
+		_, err := validator.Validate(context.Background(), ra)
+
+		assert.ErrorIs(t, err, radixapplication.ErrInvalidHostnameLength)
+	})
+}
+
 func Test_invalid_ra(t *testing.T) {
 	wayTooLongName := "waytoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongname"
 	invalidBranchName := "/master"

--- a/webhook/validation/radixregistration/errors.go
+++ b/webhook/validation/radixregistration/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrAdGroupIsRequired                    = errors.New("ad group is required")
 	ErrConfigurationItemIsRequired          = errors.New("configuration item is required")
 	ErrAppIdMustBeUnique                    = errors.New("app id must be unique")
+	ErrAppNameTooLong                       = errors.New("application name cannot exceed 40 characters")
 	WarningAdGroupsShouldHaveAtleastOneItem = "warning: adGroups should have at least one item"
 	ErrEnvironmentNameIsNotAvailable        = errors.New("app name is not available. it is already in use or conflicts with reserved namespace")
 )

--- a/webhook/validation/radixregistration/validate_rr.go
+++ b/webhook/validation/radixregistration/validate_rr.go
@@ -125,6 +125,7 @@ func createRequireUniqueAppIdValidator(client client.Client) validatorFunc {
 func createNamespaceUsableValidator(kubeClient client.Client) validatorFunc {
 	return func(ctx context.Context, rr *radixv1.RadixRegistration) (string, error) {
 		envNs := utils.GetEnvironmentNamespace(rr.Name, "app")
+		
 		existingNamespace := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: envNs}}
 		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(existingNamespace), existingNamespace); err != nil {
 			if k8sErrors.IsNotFound(err) {

--- a/webhook/validation/radixregistration/validate_rr.go
+++ b/webhook/validation/radixregistration/validate_rr.go
@@ -125,7 +125,6 @@ func createRequireUniqueAppIdValidator(client client.Client) validatorFunc {
 func createNamespaceUsableValidator(kubeClient client.Client) validatorFunc {
 	return func(ctx context.Context, rr *radixv1.RadixRegistration) (string, error) {
 		envNs := utils.GetEnvironmentNamespace(rr.Name, "app")
-		//
 		existingNamespace := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: envNs}}
 		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(existingNamespace), existingNamespace); err != nil {
 			if k8sErrors.IsNotFound(err) {

--- a/webhook/validation/radixregistration/validate_rr.go
+++ b/webhook/validation/radixregistration/validate_rr.go
@@ -28,6 +28,7 @@ var _ genericvalidator.Validator[*radixv1.RadixRegistration] = &Validator{}
 func CreateOnlineValidator(client client.Client, requireAdGroups, requireConfigurationItem bool) *Validator {
 	return &Validator{
 		validators: []validatorFunc{
+			createAppNameLengthValidator(),
 			createRequireUniqueAppIdValidator(client),
 			createRequireAdGroupsValidator(requireAdGroups),
 			CreateRequireConfigurationItemValidator(requireConfigurationItem),
@@ -39,6 +40,7 @@ func CreateOnlineValidator(client client.Client, requireAdGroups, requireConfigu
 func CreateOfflineValidator(requireAdGroups, requireConfigurationItem bool) Validator {
 	return Validator{
 		validators: []validatorFunc{
+			createAppNameLengthValidator(),
 			createRequireAdGroupsValidator(requireAdGroups),
 			CreateRequireConfigurationItemValidator(requireConfigurationItem),
 		},
@@ -59,6 +61,17 @@ func (validator *Validator) Validate(ctx context.Context, rr *radixv1.RadixRegis
 	}
 
 	return wrns, errors.Join(errs...)
+}
+
+func createAppNameLengthValidator() validatorFunc {
+	return func(ctx context.Context, rr *radixv1.RadixRegistration) (string, error) {
+		const maxApplicationNameLength = 40
+		if len(rr.Name) > maxApplicationNameLength {
+			return "", ErrAppNameTooLong
+		}
+
+		return "", nil
+	}
 }
 
 // RequireAdGroups validates that AdGroups contains minimum one item
@@ -112,7 +125,7 @@ func createRequireUniqueAppIdValidator(client client.Client) validatorFunc {
 func createNamespaceUsableValidator(kubeClient client.Client) validatorFunc {
 	return func(ctx context.Context, rr *radixv1.RadixRegistration) (string, error) {
 		envNs := utils.GetEnvironmentNamespace(rr.Name, "app")
-
+		//
 		existingNamespace := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: envNs}}
 		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(existingNamespace), existingNamespace); err != nil {
 			if k8sErrors.IsNotFound(err) {

--- a/webhook/validation/radixregistration/validate_rr.go
+++ b/webhook/validation/radixregistration/validate_rr.go
@@ -125,7 +125,6 @@ func createRequireUniqueAppIdValidator(client client.Client) validatorFunc {
 func createNamespaceUsableValidator(kubeClient client.Client) validatorFunc {
 	return func(ctx context.Context, rr *radixv1.RadixRegistration) (string, error) {
 		envNs := utils.GetEnvironmentNamespace(rr.Name, "app")
-		
 		existingNamespace := &corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: envNs}}
 		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(existingNamespace), existingNamespace); err != nil {
 			if k8sErrors.IsNotFound(err) {

--- a/webhook/validation/radixregistration/validate_rr_test.go
+++ b/webhook/validation/radixregistration/validate_rr_test.go
@@ -1,6 +1,7 @@
 package radixregistration_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/equinor/radix-operator/pkg/apis/kube"
@@ -46,6 +47,16 @@ func TestCanRadixApplicationBeUpdated(t *testing.T) {
 			expectedError:            nil,
 		},
 		{
+			name: "registration name longer than 40 chars fails",
+			updateRR: func(rr *radixv1.RadixRegistration) {
+				rr.Name = strings.Repeat("a", 41)
+			},
+			requireAdGroups:          false,
+			requireConfigurationItem: false,
+			expectedWarnings:         nil,
+			expectedError:            radixregistration.ErrAppNameTooLong,
+		},
+		{
 			name:                     "required ConfigurationItem is empty fails",
 			updateRR:                 func(rr *radixv1.RadixRegistration) { rr.Spec.ConfigurationItem = "" },
 			requireAdGroups:          false,
@@ -86,6 +97,29 @@ func TestCanRadixApplicationBeUpdated(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_RegistrationNameLengthLimit(t *testing.T) {
+	t.Run("name length 40 is valid", func(t *testing.T) {
+		validRR := test.Load[*radixv1.RadixRegistration]("testdata/radixregistration.yaml")
+		validRR.Name = strings.Repeat("a", 40)
+
+		validator := radixregistration.CreateOfflineValidator(false, false)
+		warnings, err := validator.Validate(t.Context(), validRR)
+
+		assert.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("name length 41 is invalid", func(t *testing.T) {
+		validRR := test.Load[*radixv1.RadixRegistration]("testdata/radixregistration.yaml")
+		validRR.Name = strings.Repeat("a", 41)
+
+		validator := radixregistration.CreateOfflineValidator(false, false)
+		_, err := validator.Validate(t.Context(), validRR)
+
+		assert.ErrorIs(t, err, radixregistration.ErrAppNameTooLong)
+	})
 }
 
 func TestDuplicateAppIDMustFail(t *testing.T) {


### PR DESCRIPTION
**Hostname label length validation:**

* Added a new error `ErrHostnameLabelTooLong` to `errors.go` to represent when a hostname label exceeds 63 characters.
* Implemented the `validateHostnameLabelLength` function to check that each label in a hostname is at most 63 characters, and integrated this check into the HTTPRoute validation logic in `validate_hr.go`. [[1]](diffhunk://#diff-0e9ed8a3b102341b594cd0ebe6139cb6f6e90d13dadaec8f52133716ae95349fR102-R114) [[2]](diffhunk://#diff-0e9ed8a3b102341b594cd0ebe6139cb6f6e90d13dadaec8f52133716ae95349fL83-R89)

**Testing:**

* Added unit tests to verify that hostnames with labels of exactly 63 characters are accepted, and those with labels of 64 characters are rejected, in `validate_hr_test.go`.

**Changes:** 
<img width="1060" height="1085" alt="Screenshot 2026-08-13 at 14 15 36" src="https://github.com/user-attachments/assets/794f123a-1b8d-417e-a7a7-8a3a849bfe60" />

