### PR TITLE
fix: remove deprecated field ´deployment´

### DIFF
--- a/api-server/api/deployments/models/component_deployment.go
+++ b/api-server/api/deployments/models/component_deployment.go
@@ -223,12 +223,6 @@ type AuxiliaryResource struct {
 }
 
 type OAuth2AuxiliaryResource struct {
-	// Deprecated. Use Deployments instead
-	// Deployment describes the underlying Kubernetes deployment for the resource
-	//
-	// required: true
-	Deployment AuxiliaryResourceDeployment `json:"deployment,omitempty"`
-
 	// Deployments describes the underlying Kubernetes deployments for the resource
 	//
 	// required: false

--- a/api-server/api/environments/component_spec.go
+++ b/api-server/api/environments/component_spec.go
@@ -154,7 +154,6 @@ func getOAuth2AuxiliaryResource(podList []corev1.Pod, deploymentList []appsv1.De
 	}
 	oauthProxyDeployment := getAuxiliaryResourceDeployment(podList, deploymentList, deployment, component, v1.OAuthProxyAuxiliaryComponentType)
 	auxiliaryResource := deploymentModels.OAuth2AuxiliaryResource{
-		Deployment:  oauthProxyDeployment, // for backward compatibility
 		Deployments: []deploymentModels.AuxiliaryResourceDeployment{oauthProxyDeployment},
 	}
 	if oauth2.IsSessionStoreTypeSystemManaged() {

--- a/api-server/api/models/auxiliary_resource.go
+++ b/api-server/api/models/auxiliary_resource.go
@@ -20,7 +20,6 @@ func getAuxiliaryResources(rd *radixv1.RadixDeployment, component radixv1.RadixC
 func getOAuth2AuxiliaryResource(rd *radixv1.RadixDeployment, component radixv1.RadixCommonDeployComponent, deploymentList []appsv1.Deployment, podList []corev1.Pod, eventWarnings map[string]string) *deploymentModels.OAuth2AuxiliaryResource {
 	auxiliaryResource := deploymentModels.OAuth2AuxiliaryResource{}
 	oauthProxyDeployment := getAuxiliaryResourceDeployment(rd, component, radixv1.OAuthProxyAuxiliaryComponentType, deploymentList, podList, eventWarnings)
-	auxiliaryResource.Deployment = oauthProxyDeployment // for backward compatibility
 	auxiliaryResource.Deployments = append(auxiliaryResource.Deployments, oauthProxyDeployment)
 	if component.GetAuthentication().GetOAuth2().IsSessionStoreTypeSystemManaged() {
 		oauthRedisDeployment := getAuxiliaryResourceDeployment(rd, component, radixv1.OAuthRedisAuxiliaryComponentType, deploymentList, podList, eventWarnings)

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -7914,13 +7914,7 @@
     },
     "OAuth2AuxiliaryResource": {
       "type": "object",
-      "required": [
-        "deployment"
-      ],
       "properties": {
-        "deployment": {
-          "$ref": "#/definitions/AuxiliaryResourceDeployment"
-        },
         "deployments": {
           "description": "Deployments describes the underlying Kubernetes deployments for the resource",
           "type": "array",


### PR DESCRIPTION
This pull request removes the deprecated `Deployment` field from the `OAuth2AuxiliaryResource` struct and updates related code and API documentation to use the `Deployments` field exclusively. This change simplifies the model and eliminates backward compatibility code for the old single-deployment field.

**Model and API changes:**

* Removed the deprecated `Deployment` field from the `OAuth2AuxiliaryResource` struct in `component_deployment.go`, so only the `Deployments` array is used going forward.
* Updated the OpenAPI/Swagger schema in `swagger.json` to remove the `deployment` property and its `required` status for `OAuth2AuxiliaryResource`.

**Code cleanup:**

* Removed references and assignments to the deprecated `Deployment` field in `component_spec.go` and `auxiliary_resource.go`, ensuring only the `Deployments` field is populated and used. [[1]](diffhunk://#diff-51986f1cd0cd1525b3ac3bcdbc572aeb2e5e53185bef6991b26e8faa2d98eeeaL157) [[2]](diffhunk://#diff-e6a561b8347efb864b489c81a4ace91591e5be748461de146c27e04513f0d2e4L23)