### PR TITLE
feat(api-server): rerun job returns pipeline jobId 

### DIFF
--- a/api-server/api/jobs/job_controller.go
+++ b/api-server/api/jobs/job_controller.go
@@ -259,8 +259,10 @@ func (jc *jobController) RerunApplicationJob(accounts accounts.Accounts, w http.
 	//   type: string
 	//   required: false
 	// responses:
-	//   "204":
-	//     description: "Job rerun ok"
+	//   "200":
+	//     description: "New job summary"
+	//     schema:
+	//        "$ref": "#/definitions/JobSummary"
 	//   "401":
 	//     description: "Unauthorized"
 	//   "404":
@@ -268,14 +270,14 @@ func (jc *jobController) RerunApplicationJob(accounts accounts.Accounts, w http.
 	appName := mux.Vars(r)["appName"]
 	jobName := mux.Vars(r)["jobName"]
 	handler := Init(accounts, deployments.Init(accounts))
-	err := handler.RerunJob(r.Context(), appName, jobName)
+	jobSummary, err := handler.RerunJob(r.Context(), appName, jobName)
 
 	if err != nil {
 		jc.ErrorResponse(w, r, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	jc.JSONResponse(w, r, jobSummary)
 }
 
 // GetTektonPipelineRuns Get the Tekton pipeline runs overview

--- a/api-server/api/jobs/job_handler_test.go
+++ b/api-server/api/jobs/job_handler_test.go
@@ -299,8 +299,12 @@ func (s *JobHandlerTestSuite) TestJobHandler_RerunJob() {
 				s.NoError(err)
 			}
 
-			_, err := jh.RerunJob(context.Background(), appName, tt.jobNameToRerun)
+			jobSummary, err := jh.RerunJob(context.Background(), appName, tt.jobNameToRerun)
 			s.Equal(tt.expectedError, err)
+			if tt.expectedError == nil {
+				s.NotNil(jobSummary)
+				s.NotEmpty(jobSummary.Name)
+			}
 		})
 	}
 }

--- a/api-server/api/jobs/job_handler_test.go
+++ b/api-server/api/jobs/job_handler_test.go
@@ -299,7 +299,7 @@ func (s *JobHandlerTestSuite) TestJobHandler_RerunJob() {
 				s.NoError(err)
 			}
 
-			err := jh.RerunJob(context.Background(), appName, tt.jobNameToRerun)
+			_, err := jh.RerunJob(context.Background(), appName, tt.jobNameToRerun)
 			s.Equal(tt.expectedError, err)
 		})
 	}

--- a/api-server/api/jobs/manage_job_handler.go
+++ b/api-server/api/jobs/manage_job_handler.go
@@ -52,23 +52,23 @@ func (jh JobHandler) StopJob(ctx context.Context, appName, jobName string) error
 }
 
 // RerunJob Reruns the pipeline job as a copy
-func (jh JobHandler) RerunJob(ctx context.Context, appName, jobName string) error {
+func (jh JobHandler) RerunJob(ctx context.Context, appName, jobName string) (*jobModels.JobSummary, error) {
 	log.Ctx(ctx).Info().Msgf("Rerunning the job %s in the application %s", jobName, appName)
 	radixJob, err := jh.getPipelineJobByName(ctx, appName, jobName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !slice.Any(jobConditionsValidForJobRerun, func(condition radixv1.RadixJobCondition) bool { return condition == radixJob.Status.Condition }) {
-		return jobModels.JobHasInvalidConditionToRerunError(appName, jobName, radixJob.Status.Condition)
+		return nil, jobModels.JobHasInvalidConditionToRerunError(appName, jobName, radixJob.Status.Condition)
 	}
 
 	copiedRadixJob := jh.buildPipelineJobToRerunFrom(ctx, radixJob)
-	_, err = jh.createPipelineJob(ctx, appName, copiedRadixJob)
+	jobSummary, err := jh.createPipelineJob(ctx, appName, copiedRadixJob)
 	if err != nil {
-		return fmt.Errorf("failed to create a job %s to rerun: %v", radixJob.GetName(), err)
+		return nil, fmt.Errorf("failed to create a job %s to rerun: %v", radixJob.GetName(), err)
 	}
 
-	return nil
+	return jobSummary, nil
 }
 func (jh JobHandler) createPipelineJob(ctx context.Context, appName string, job *radixv1.RadixJob) (*jobModels.JobSummary, error) {
 	log.Ctx(ctx).Info().Msgf("Starting job: %s", job.GetName())

--- a/api-server/swaggerui/html/swagger.json
+++ b/api-server/swaggerui/html/swagger.json
@@ -5043,8 +5043,11 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Job rerun ok"
+          "200": {
+            "description": "New job summary",
+            "schema": {
+              "$ref": "#/definitions/JobSummary"
+            }
           },
           "401": {
             "description": "Unauthorized"


### PR DESCRIPTION
* The `RerunJob` API endpoint now returns HTTP 200 with a `JobSummary` object describing the new job, instead of HTTP 204 with no content.
* Fix the relevant affected tests 