### PR TITLE
WIP: Migrate BuildKit image builder configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
 				"--IMAGE_TAG=abcdl",
 				"--PIPELINE_TYPE=build-deploy",
 				"--DEBUG=true",
-				"--buildkit-image-builder=ghcr.io/equinor/radix/buildkit-builder:latest",
+				"--builder-image=ghcr.io/equinor/radix/buildkit-builder:latest",
 				"--SECCOMP_PROFILE_FILENAME=allow-buildah.json",
 				"--RADIX_PIPELINE_GIT_CLONE_GIT_IMAGE=docker.io/alpine/git:2.45.2",
 				"--RADIX_CLUSTER_TYPE=development",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
 				"--IMAGE_TAG=abcdl",
 				"--PIPELINE_TYPE=build-deploy",
 				"--DEBUG=true",
-				"--RADIX_BUILDKIT_IMAGE_BUILDER_IMAGE=ghcr.io/equinor/radix/buildkit-builder:latest",
+				"--buildkit-image-builder=ghcr.io/equinor/radix/buildkit-builder:latest",
 				"--SECCOMP_PROFILE_FILENAME=allow-buildah.json",
 				"--RADIX_PIPELINE_GIT_CLONE_GIT_IMAGE=docker.io/alpine/git:2.45.2",
 				"--RADIX_CLUSTER_TYPE=development",
@@ -123,7 +123,6 @@
 			"env": {
 				"USE_PROFILER": "true",
 				"RADIXOPERATOR_CLUSTER_TYPE": "development",
-				"RADIX_BUILDKIT_IMAGE_BUILDER_IMAGE": "ghcr.io/equinor/radix/buildkit-builder:latest",
 				"RADIX_CONTAINER_REGISTRY": "radixdev.azurecr.io",
 				"RADIX_APP_CONTAINER_REGISTRY": "radixdevapp.azurecr.io",
 				"RADIX_OAUTH_PROXY_IMAGE": "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2",

--- a/charts/radix-operator/templates/deployment.yaml
+++ b/charts/radix-operator/templates/deployment.yaml
@@ -56,8 +56,6 @@ spec:
               value: {{ .Values.jobAux.image.repository }}:{{ .Values.jobAux.image.tag }}
             - name: SECCOMP_PROFILE_FILENAME
               value: {{ .Values.seccompProfile.fileNameOnNode }}
-            - name: RADIX_BUILDKIT_IMAGE_BUILDER_IMAGE
-              value: {{ .Values.radixBuildKitImageBuilder.image.repository }}:{{ .Values.radixBuildKitImageBuilder.image.tag | default "main-latest" }}
             - name: RADIX_PIPELINE_GIT_CLONE_GIT_IMAGE
               value: {{ .Values.gitClone.image.repository }}:{{ .Values.gitClone.image.tag | default "latest" }}
             - name: RADIXOPERATOR_CERTIFICATE_AUTOMATION_GATEWAY_CLUSTER_ISSUER

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -98,7 +98,7 @@ config:
       repository: ghcr.io/equinor/radix/job-scheduler
       tag: "" # Fallback to .Chart.Version
 
-    buildKitImageBuilder:
+    builderImage:
       repository: ghcr.io/equinor/radix/buildkit-builder
       tag: "latest"
 

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -96,7 +96,11 @@ config:
 
     jobSchedulerImage:
       repository: ghcr.io/equinor/radix/job-scheduler
-      tag: ""
+      tag: "" # Fallback to .Chart.Version
+
+    buildKitImageBuilder:
+      repository: ghcr.io/equinor/radix/buildkit-builder
+      tag: "latest"
 
 dnsZone: dev.radix.equinor.com
 radixZone: xx
@@ -218,11 +222,6 @@ radixPipelineRunner:
     tag: ""
     # Pull policy for the pipeline job image. Defaults to Always.
     pullPolicy: Always
-
-radixBuildKitImageBuilder:
-  image:
-    repository: ghcr.io/equinor/radix/buildkit-builder
-    tag: latest
 
 radixApiServer:
   useProfiler: false

--- a/charts/radix-operator/values.yaml
+++ b/charts/radix-operator/values.yaml
@@ -85,22 +85,21 @@ config:
       defaultRequestMemory: 500M
       defaultRequestCPU: 100m
 
-    # Should probably be in a builderSpecDefaults section, but for now we keep it here since it is used by the operator to set env vars for the pipeline runner job
-    builderResources:
-      limits:
-        memory: 500M
-        cpu: 2000m
-      requests:
-        memory: 500M
-        cpu: 200m
+    builder:
+      image:
+        repository: ghcr.io/equinor/radix/buildkit-builder
+        tag: "latest"
+      resources:
+        limits:
+          memory: 500M
+          cpu: 2000m
+        requests:
+          memory: 500M
+          cpu: 200m
 
     jobSchedulerImage:
       repository: ghcr.io/equinor/radix/job-scheduler
       tag: "" # Fallback to .Chart.Version
-
-    builderImage:
-      repository: ghcr.io/equinor/radix/buildkit-builder
-      tag: "latest"
 
 dnsZone: dev.radix.equinor.com
 radixZone: xx

--- a/pipeline-runner/flags/flags.go
+++ b/pipeline-runner/flags/flags.go
@@ -10,5 +10,5 @@ const (
 	BuilderResourcesRequestsCPU    = "builder-resources-requests-cpu"
 	BuilderResourcesRequestsMemory = "builder-resources-requests-memory"
 
-	BuildKitImageBuilder = "buildkit-image-builder"
+	BuilderImage = "builder-image"
 )

--- a/pipeline-runner/flags/flags.go
+++ b/pipeline-runner/flags/flags.go
@@ -9,4 +9,6 @@ const (
 	BuilderResourcesLimitsMemory   = "builder-resources-limits-memory"
 	BuilderResourcesRequestsCPU    = "builder-resources-requests-cpu"
 	BuilderResourcesRequestsMemory = "builder-resources-requests-memory"
+
+	BuildKitImageBuilder = "buildkit-image-builder"
 )

--- a/pipeline-runner/internal/jobs/build/buildkit.go
+++ b/pipeline-runner/internal/jobs/build/buildkit.go
@@ -208,7 +208,7 @@ func (c *buildKitKubeJobProps) PodInitContainers() []corev1.Container {
 func (c *buildKitKubeJobProps) PodContainers() []corev1.Container {
 	container := corev1.Container{
 		Name:            c.componentImage.ContainerName,
-		Image:           c.pipelineArgs.BuilderImage,
+		Image:           c.pipelineArgs.Builder.Image,
 		ImagePullPolicy: corev1.PullAlways,
 		Args:            c.getPodContainerArgs(),
 		Env:             c.getPodContainerEnvVars(),

--- a/pipeline-runner/internal/jobs/build/buildkit.go
+++ b/pipeline-runner/internal/jobs/build/buildkit.go
@@ -208,7 +208,7 @@ func (c *buildKitKubeJobProps) PodInitContainers() []corev1.Container {
 func (c *buildKitKubeJobProps) PodContainers() []corev1.Container {
 	container := corev1.Container{
 		Name:            c.componentImage.ContainerName,
-		Image:           c.pipelineArgs.BuildKitImageBuilder,
+		Image:           c.pipelineArgs.BuilderImage,
 		ImagePullPolicy: corev1.PullAlways,
 		Args:            c.getPodContainerArgs(),
 		Env:             c.getPodContainerEnvVars(),

--- a/pipeline-runner/internal/jobs/build/buildkit_test.go
+++ b/pipeline-runner/internal/jobs/build/buildkit_test.go
@@ -55,7 +55,7 @@ func assertBuildKitJobSpec(t *testing.T, useBuildCache, refreshBuildCache, pushI
 		CommitID:               "anycommitid",
 		ImageTag:               "anyimagetag",
 		PushImage:              pushImage,
-		BuildKitImageBuilder:   "docker.io/anyimagebuilder",
+		BuilderImage:   "docker.io/anyimagebuilder",
 		GitCloneGitImage:       "anygitcloneimage",
 		Clustertype:            "anyclustertype",
 		Clustername:            "anyclustername",
@@ -182,7 +182,7 @@ func assertBuildKitJobSpec(t *testing.T, useBuildCache, refreshBuildCache, pushI
 			require.Len(t, job.Spec.Template.Spec.Containers, 1)
 			c := job.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, ci.ContainerName, c.Name)
-			assert.Equal(t, args.BuildKitImageBuilder, c.Image)
+			assert.Equal(t, args.BuilderImage, c.Image)
 			assert.Equal(t, corev1.PullAlways, c.ImagePullPolicy)
 			expectedResources := corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]resource.Quantity{

--- a/pipeline-runner/internal/jobs/build/buildkit_test.go
+++ b/pipeline-runner/internal/jobs/build/buildkit_test.go
@@ -47,15 +47,15 @@ func assertBuildKitJobSpec(t *testing.T, useBuildCache, refreshBuildCache, pushI
 	)
 
 	args := model.PipelineArguments{
-		AppName:                "anyappname",
-		PipelineType:           "anypipelinetype",
-		JobName:                "anyjobname",
-		GitRef:                 gitRefName,
-		GitRefType:             "tag",
-		CommitID:               "anycommitid",
-		ImageTag:               "anyimagetag",
-		PushImage:              pushImage,
-		BuilderImage:   "docker.io/anyimagebuilder",
+		AppName:      "anyappname",
+		PipelineType: "anypipelinetype",
+		JobName:      "anyjobname",
+		GitRef:       gitRefName,
+		GitRefType:   "tag",
+		CommitID:     "anycommitid",
+		ImageTag:     "anyimagetag",
+		PushImage:    pushImage,
+
 		GitCloneGitImage:       "anygitcloneimage",
 		Clustertype:            "anyclustertype",
 		Clustername:            "anyclustername",
@@ -63,7 +63,13 @@ func assertBuildKitJobSpec(t *testing.T, useBuildCache, refreshBuildCache, pushI
 		AppContainerRegistry:   "anyappcontainerregistry",
 		SeccompProfileFileName: "anyseccompprofilefile",
 		ExternalContainerRegistryDefaultAuthSecret: externalRegistrySecret,
-		Builder:      model.Builder{ResourcesLimitsMemory: "100M", ResourcesRequestsCPU: "50m", ResourcesRequestsMemory: "50M", ResourcesLimitsCPU: "50m"},
+		Builder: model.Builder{
+			Image:                   "docker.io/anyimagebuilder",
+			ResourcesLimitsMemory:   "100M",
+			ResourcesRequestsCPU:    "50m",
+			ResourcesRequestsMemory: "50M",
+			ResourcesLimitsCPU:      "50m",
+		},
 		GitWorkspace: gitWorkspace,
 	}
 	require.Equal(t, pushImage, args.PushImage)
@@ -182,7 +188,7 @@ func assertBuildKitJobSpec(t *testing.T, useBuildCache, refreshBuildCache, pushI
 			require.Len(t, job.Spec.Template.Spec.Containers, 1)
 			c := job.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, ci.ContainerName, c.Name)
-			assert.Equal(t, args.BuilderImage, c.Image)
+			assert.Equal(t, args.Builder.Image, c.Image)
 			assert.Equal(t, corev1.PullAlways, c.ImagePullPolicy)
 			expectedResources := corev1.ResourceRequirements{
 				Requests: map[corev1.ResourceName]resource.Quantity{

--- a/pipeline-runner/main.go
+++ b/pipeline-runner/main.go
@@ -104,7 +104,7 @@ func setPipelineArgsFromArguments(cmd *cobra.Command, pipelineArgs *model.Pipeli
 	cmd.Flags().StringVar(&pipelineArgs.DeploymentName, defaults.RadixPromoteDeploymentEnvironmentVariable, "", "Radix deployment name to promote")
 	cmd.Flags().StringVar(&pipelineArgs.FromEnvironment, defaults.RadixPromoteFromEnvironmentEnvironmentVariable, "", "Radix application environment name to promote from")
 	cmd.Flags().StringVar(&pipelineArgs.ToEnvironment, defaults.RadixPipelineJobToEnvironmentEnvironmentVariable, "", "Radix application environment name to build-deploy or promote to")
-	cmd.Flags().StringVar(&pipelineArgs.BuildKitImageBuilder, flags.BuildKitImageBuilder, "", "Radix Build Kit Image Builder container image")
+	cmd.Flags().StringVar(&pipelineArgs.BuilderImage, flags.BuilderImage, "", "Radix Build Kit Image Builder container image")
 	cmd.Flags().StringVar(&pipelineArgs.SeccompProfileFileName, defaults.SeccompProfileFileNameEnvironmentVariable, "", "Filename of the seccomp profile injected by daemonset, relative to the /var/lib/kubelet/seccomp directory on node")
 	cmd.Flags().StringVar(&pipelineArgs.Clustertype, defaults.RadixClusterTypeEnvironmentVariable, "", "Cluster type")
 	cmd.Flags().StringVar(&pipelineArgs.Clustername, flags.ClusterName, "", "Cluster name")

--- a/pipeline-runner/main.go
+++ b/pipeline-runner/main.go
@@ -104,7 +104,7 @@ func setPipelineArgsFromArguments(cmd *cobra.Command, pipelineArgs *model.Pipeli
 	cmd.Flags().StringVar(&pipelineArgs.DeploymentName, defaults.RadixPromoteDeploymentEnvironmentVariable, "", "Radix deployment name to promote")
 	cmd.Flags().StringVar(&pipelineArgs.FromEnvironment, defaults.RadixPromoteFromEnvironmentEnvironmentVariable, "", "Radix application environment name to promote from")
 	cmd.Flags().StringVar(&pipelineArgs.ToEnvironment, defaults.RadixPipelineJobToEnvironmentEnvironmentVariable, "", "Radix application environment name to build-deploy or promote to")
-	cmd.Flags().StringVar(&pipelineArgs.BuilderImage, flags.BuilderImage, "", "Radix Build Kit Image Builder container image")
+	cmd.Flags().StringVar(&pipelineArgs.Builder.Image, flags.BuilderImage, "", "Radix Build Kit Image Builder container image")
 	cmd.Flags().StringVar(&pipelineArgs.SeccompProfileFileName, defaults.SeccompProfileFileNameEnvironmentVariable, "", "Filename of the seccomp profile injected by daemonset, relative to the /var/lib/kubelet/seccomp directory on node")
 	cmd.Flags().StringVar(&pipelineArgs.Clustertype, flags.ClusterType, "", "Cluster type")
 	cmd.Flags().StringVar(&pipelineArgs.Clustername, flags.ClusterName, "", "Cluster name")

--- a/pipeline-runner/main.go
+++ b/pipeline-runner/main.go
@@ -104,7 +104,7 @@ func setPipelineArgsFromArguments(cmd *cobra.Command, pipelineArgs *model.Pipeli
 	cmd.Flags().StringVar(&pipelineArgs.DeploymentName, defaults.RadixPromoteDeploymentEnvironmentVariable, "", "Radix deployment name to promote")
 	cmd.Flags().StringVar(&pipelineArgs.FromEnvironment, defaults.RadixPromoteFromEnvironmentEnvironmentVariable, "", "Radix application environment name to promote from")
 	cmd.Flags().StringVar(&pipelineArgs.ToEnvironment, defaults.RadixPipelineJobToEnvironmentEnvironmentVariable, "", "Radix application environment name to build-deploy or promote to")
-	cmd.Flags().StringVar(&pipelineArgs.BuildKitImageBuilder, defaults.RadixBuildKitImageBuilderEnvironmentVariable, "", "Radix Build Kit Image Builder container image")
+	cmd.Flags().StringVar(&pipelineArgs.BuildKitImageBuilder, flags.BuildKitImageBuilder, "", "Radix Build Kit Image Builder container image")
 	cmd.Flags().StringVar(&pipelineArgs.SeccompProfileFileName, defaults.SeccompProfileFileNameEnvironmentVariable, "", "Filename of the seccomp profile injected by daemonset, relative to the /var/lib/kubelet/seccomp directory on node")
 	cmd.Flags().StringVar(&pipelineArgs.Clustertype, defaults.RadixClusterTypeEnvironmentVariable, "", "Cluster type")
 	cmd.Flags().StringVar(&pipelineArgs.Clustername, flags.ClusterName, "", "Cluster name")

--- a/pipeline-runner/model/pipelineInfo.go
+++ b/pipeline-runner/model/pipelineInfo.go
@@ -78,6 +78,9 @@ type EnvironmentSubPipelineToRun struct {
 
 // Builder Holds info about the builder arguments
 type Builder struct {
+	// Image Points to the BuildKit compliant image builder
+	Image string
+
 	ResourcesLimitsMemory   string
 	ResourcesLimitsCPU      string
 	ResourcesRequestsCPU    string
@@ -123,8 +126,6 @@ type PipelineArguments struct {
 	TriggeredFromWebhook bool
 	RadixConfigFile      string
 
-	// BuilderImage Points to the BuildKit compliant image builder (repository and tag only)
-	BuilderImage string
 	// GitCloneGitImage defines image containing git cli.
 	// Must support running as user 65534.
 	// Used as option to the CloneInitContainers function.

--- a/pipeline-runner/model/pipelineInfo.go
+++ b/pipeline-runner/model/pipelineInfo.go
@@ -123,8 +123,8 @@ type PipelineArguments struct {
 	TriggeredFromWebhook bool
 	RadixConfigFile      string
 
-	// BuildKitImageBuilder Points to the BuildKit compliant image builder (repository and tag only)
-	BuildKitImageBuilder string
+	// BuilderImage Points to the BuildKit compliant image builder (repository and tag only)
+	BuilderImage string
 	// GitCloneGitImage defines image containing git cli.
 	// Must support running as user 65534.
 	// Used as option to the CloneInitContainers function.

--- a/pkg/apis/config2/config.go
+++ b/pkg/apis/config2/config.go
@@ -59,8 +59,9 @@ type OperatorConfig struct {
 
 	BuilderResources Resources `json:"builderResources" required:"true"`
 
-	JobSchedulerImage   ContainerImage            `json:"jobSchedulerImage" required:"true"`
-	PodSecurityStandard PodSecurityStandardConfig `json:"podSecurityStandard"`
+	JobSchedulerImage    ContainerImage            `json:"jobSchedulerImage" required:"true"`
+	BuildKitImageBuilder ContainerImage            `json:"buildKitImageBuilder" required:"true"`
+	PodSecurityStandard  PodSecurityStandardConfig `json:"podSecurityStandard"`
 }
 
 type OAuth2ProxyConfig struct {

--- a/pkg/apis/config2/config.go
+++ b/pkg/apis/config2/config.go
@@ -59,9 +59,9 @@ type OperatorConfig struct {
 
 	BuilderResources Resources `json:"builderResources" required:"true"`
 
-	JobSchedulerImage    ContainerImage            `json:"jobSchedulerImage" required:"true"`
-	BuildKitImageBuilder ContainerImage            `json:"buildKitImageBuilder" required:"true"`
-	PodSecurityStandard  PodSecurityStandardConfig `json:"podSecurityStandard"`
+	JobSchedulerImage   ContainerImage            `json:"jobSchedulerImage" required:"true"`
+	BuilderImage        ContainerImage            `json:"builderImage" required:"true"`
+	PodSecurityStandard PodSecurityStandardConfig `json:"podSecurityStandard"`
 }
 
 type OAuth2ProxyConfig struct {

--- a/pkg/apis/config2/config.go
+++ b/pkg/apis/config2/config.go
@@ -67,7 +67,7 @@ type OperatorConfig struct {
 
 type BuilderConfig struct {
 	Image     ContainerImage `json:"image" required:"true"`
-	Resources Resources      `json:"resources" required:"true"`
+	Resources Resources      `json:"resources" required:"true" validate:"compareQuantity(self.limits.memory, self.requests.memory) >= 0 && compareQuantity(self.limits.cpu, self.requests.cpu) >= 0"`
 }
 
 type OAuth2ProxyConfig struct {
@@ -88,8 +88,8 @@ type Resources struct {
 	Limits   ResourceRequirements `json:"limits" required:"true"`
 }
 type ResourceRequirements struct {
-	Memory *resource.Quantity `json:"memory" required:"true" validate:"compareQuantity(self, config.operator.builder.resources.requests.memory) >= 0"`
-	CPU    *resource.Quantity `json:"cpu" required:"true" validate:"compareQuantity(self, config.operator.builder.resources.requests.cpu) >= 0"`
+	Memory *resource.Quantity `json:"memory" required:"true"`
+	CPU    *resource.Quantity `json:"cpu" required:"true"`
 }
 
 type PodSecurityStandardConfig struct {

--- a/pkg/apis/config2/config.go
+++ b/pkg/apis/config2/config.go
@@ -59,11 +59,15 @@ type OperatorConfig struct {
 	AppNsLimitRange LimitRangeConfig `json:"appNsLimitRange" required:"true"`
 	EnvNsLimitRange LimitRangeConfig `json:"envNsLimitRange" required:"true"`
 
-	BuilderResources Resources `json:"builderResources" required:"true"`
+	Builder BuilderConfig `json:"builder" required:"true"`
 
 	JobSchedulerImage   ContainerImage            `json:"jobSchedulerImage" required:"true"`
-	BuilderImage        ContainerImage            `json:"builderImage" required:"true"`
 	PodSecurityStandard PodSecurityStandardConfig `json:"podSecurityStandard"`
+}
+
+type BuilderConfig struct {
+	Image     ContainerImage `json:"image" required:"true"`
+	Resources Resources      `json:"resources" required:"true"`
 }
 
 type OAuth2ProxyConfig struct {
@@ -84,8 +88,8 @@ type Resources struct {
 	Limits   ResourceRequirements `json:"limits" required:"true"`
 }
 type ResourceRequirements struct {
-	Memory *resource.Quantity `json:"memory" required:"true" validate:"compareQuantity(self, config.operator.builderResources.requests.memory) >= 0"`
-	CPU    *resource.Quantity `json:"cpu" required:"true" validate:"compareQuantity(self, config.operator.builderResources.requests.cpu) >= 0"`
+	Memory *resource.Quantity `json:"memory" required:"true" validate:"compareQuantity(self, config.operator.builder.resources.requests.memory) >= 0"`
+	CPU    *resource.Quantity `json:"cpu" required:"true" validate:"compareQuantity(self, config.operator.builder.resources.requests.cpu) >= 0"`
 }
 
 type PodSecurityStandardConfig struct {

--- a/pkg/apis/config2/config_test.go
+++ b/pkg/apis/config2/config_test.go
@@ -110,23 +110,25 @@ func TestParse_HappyPath(t *testing.T) {
 				DefaultRequestMemory: new(resource.MustParse("444M")),
 				DefaultRequestCPU:    new(resource.MustParse("111m")),
 			},
-			BuilderResources: config2.Resources{
-				Limits: config2.ResourceRequirements{
-					Memory: new(resource.MustParse("500M")),
-					CPU:    new(resource.MustParse("2000m")),
+			Builder: config2.BuilderConfig{
+				Resources: config2.Resources{
+					Limits: config2.ResourceRequirements{
+						Memory: new(resource.MustParse("500M")),
+						CPU:    new(resource.MustParse("2000m")),
+					},
+					Requests: config2.ResourceRequirements{
+						Memory: new(resource.MustParse("500M")),
+						CPU:    new(resource.MustParse("200m")),
+					},
 				},
-				Requests: config2.ResourceRequirements{
-					Memory: new(resource.MustParse("500M")),
-					CPU:    new(resource.MustParse("200m")),
+				Image: config2.ContainerImage{
+					Repository: "ghcr.io/equinor/radix/buildkit-builder",
+					Tag:        "v3.4.5",
 				},
 			},
 			JobSchedulerImage: config2.ContainerImage{
 				Repository: "ghcr.io/equinor/radix-job-scheduler",
 				Tag:        "v1.2.3",
-			},
-			BuilderImage: config2.ContainerImage{
-				Repository: "ghcr.io/equinor/radix/buildkit-builder",
-				Tag:        "v3.4.5",
 			},
 			PodSecurityStandard: config2.PodSecurityStandardConfig{
 				AppNamespace: config2.PodSecurityStandardPolicyConfig{
@@ -276,21 +278,21 @@ func TestParse_BuilderResourceLimits(t *testing.T) {
 	}{
 		"equivalent CPU quantities are valid": {
 			modifyConfig: func(cfg *config2.Config) {
-				cfg.Operator.BuilderResources.Limits.CPU = new(resource.MustParse("1"))
-				cfg.Operator.BuilderResources.Requests.CPU = new(resource.MustParse("1000m"))
+				cfg.Operator.Builder.Resources.Limits.CPU = new(resource.MustParse("1"))
+				cfg.Operator.Builder.Resources.Requests.CPU = new(resource.MustParse("1000m"))
 			},
 		},
 		"CPU limit below request is invalid": {
 			modifyConfig: func(cfg *config2.Config) {
-				cfg.Operator.BuilderResources.Limits.CPU = new(resource.MustParse("100m"))
+				cfg.Operator.Builder.Resources.Limits.CPU = new(resource.MustParse("100m"))
 			},
-			errorPath: "Operator.BuilderResources.Limits.CPU",
+			errorPath: "Operator.Builder.Resources.Limits.CPU",
 		},
 		"memory limit below request is invalid": {
 			modifyConfig: func(cfg *config2.Config) {
-				cfg.Operator.BuilderResources.Limits.Memory = new(resource.MustParse("499M"))
+				cfg.Operator.Builder.Resources.Limits.Memory = new(resource.MustParse("499M"))
 			},
-			errorPath: "Operator.BuilderResources.Limits.Memory",
+			errorPath: "Operator.Builder.Resources.Limits.Memory",
 		},
 	}
 

--- a/pkg/apis/config2/config_test.go
+++ b/pkg/apis/config2/config_test.go
@@ -286,13 +286,13 @@ func TestParse_BuilderResourceLimits(t *testing.T) {
 			modifyConfig: func(cfg *config2.Config) {
 				cfg.Operator.Builder.Resources.Limits.CPU = new(resource.MustParse("100m"))
 			},
-			errorPath: "Operator.Builder.Resources.Limits.CPU",
+			errorPath: "Operator.Builder.Resources",
 		},
 		"memory limit below request is invalid": {
 			modifyConfig: func(cfg *config2.Config) {
 				cfg.Operator.Builder.Resources.Limits.Memory = new(resource.MustParse("499M"))
 			},
-			errorPath: "Operator.Builder.Resources.Limits.Memory",
+			errorPath: "Operator.Builder.Resources",
 		},
 	}
 

--- a/pkg/apis/config2/config_test.go
+++ b/pkg/apis/config2/config_test.go
@@ -122,7 +122,7 @@ func TestParse_HappyPath(t *testing.T) {
 				Repository: "ghcr.io/equinor/radix-job-scheduler",
 				Tag:        "v1.2.3",
 			},
-			BuildKitImageBuilder: config2.ContainerImage{
+			BuilderImage: config2.ContainerImage{
 				Repository: "ghcr.io/equinor/radix/buildkit-builder",
 				Tag:        "v3.4.5",
 			},

--- a/pkg/apis/config2/config_test.go
+++ b/pkg/apis/config2/config_test.go
@@ -122,6 +122,10 @@ func TestParse_HappyPath(t *testing.T) {
 				Repository: "ghcr.io/equinor/radix-job-scheduler",
 				Tag:        "v1.2.3",
 			},
+			BuildKitImageBuilder: config2.ContainerImage{
+				Repository: "ghcr.io/equinor/radix/buildkit-builder",
+				Tag:        "v3.4.5",
+			},
 			PodSecurityStandard: config2.PodSecurityStandardConfig{
 				AppNamespace: config2.PodSecurityStandardPolicyConfig{
 					Enforce: config2.PodSecurityStandardModeConfig{

--- a/pkg/apis/config2/testdata/config-happypath.yaml
+++ b/pkg/apis/config2/testdata/config-happypath.yaml
@@ -62,7 +62,7 @@ operator:
   jobSchedulerImage:
     repository: ghcr.io/equinor/radix-job-scheduler
     tag: v1.2.3
-  buildKitImageBuilder:
+  builderImage:
     repository: ghcr.io/equinor/radix/buildkit-builder
     tag: v3.4.5
   podSecurityStandard:

--- a/pkg/apis/config2/testdata/config-happypath.yaml
+++ b/pkg/apis/config2/testdata/config-happypath.yaml
@@ -53,19 +53,20 @@ operator:
     defaultMemory: 555M
     defaultRequestMemory: 444M
     defaultRequestCPU: 111m
-  builderResources:
-    limits:
-      memory: 500M
-      cpu: 2000m
-    requests:
-      memory: 500M
-      cpu: 200m
+  builder:
+    resources:
+      limits:
+        memory: 500M
+        cpu: 2000m
+      requests:
+        memory: 500M
+        cpu: 200m
+    image:
+      repository: ghcr.io/equinor/radix/buildkit-builder
+      tag: v3.4.5
   jobSchedulerImage:
     repository: ghcr.io/equinor/radix-job-scheduler
     tag: v1.2.3
-  builderImage:
-    repository: ghcr.io/equinor/radix/buildkit-builder
-    tag: v3.4.5
   podSecurityStandard:
     appNamespace:
       enforce:

--- a/pkg/apis/config2/testdata/config-happypath.yaml
+++ b/pkg/apis/config2/testdata/config-happypath.yaml
@@ -62,6 +62,9 @@ operator:
   jobSchedulerImage:
     repository: ghcr.io/equinor/radix-job-scheduler
     tag: v1.2.3
+  buildKitImageBuilder:
+    repository: ghcr.io/equinor/radix/buildkit-builder
+    tag: v3.4.5
   podSecurityStandard:
     appNamespace:
       enforce:

--- a/pkg/apis/defaults/environment_variables.go
+++ b/pkg/apis/defaults/environment_variables.go
@@ -136,9 +136,6 @@ const (
 	// SeccompProfileFileNameEnvironmentVariable Filename of the seccomp profile injected by daemonset, relative to the /var/lib/kubelet/seccomp directory
 	SeccompProfileFileNameEnvironmentVariable = "SECCOMP_PROFILE_FILENAME"
 
-	// RadixBuildKitImageBuilderEnvironmentVariable Repository and tag for the buildkit image builder
-	RadixBuildKitImageBuilderEnvironmentVariable = "RADIX_BUILDKIT_IMAGE_BUILDER_IMAGE"
-
 	RadixCertificateAutomationGatewayClusterIssuerVariable = "RADIXOPERATOR_CERTIFICATE_AUTOMATION_GATEWAY_CLUSTER_ISSUER"
 
 	// RadixCertificateAutomationDurationVariable Defines duration for certificates issued by cluster issuer

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -75,22 +75,22 @@ func (s *RadixJobTestSuiteBase) setupTest() {
 			ClusterName: "AnyClusterName",
 		},
 		Operator: config2.OperatorConfig{
-			ContainerRegistry:    s.config.registry,
-			AppContainerRegistry: s.config.appRegistry,
-			BuilderImage: config2.ContainerImage{
-				Repository: "docker.io/buildkit",
-				Tag:        "any",
-			},
 			ContainerRegistry:    "anybuildregistry",
 			AppContainerRegistry: "anycacheregistry",
-			BuilderResources: config2.Resources{
-				Requests: config2.ResourceRequirements{
-					CPU:    new(resource.MustParse("100m")),
-					Memory: new(resource.MustParse("1000Mi")),
+			Builder: config2.BuilderConfig{
+				Image: config2.ContainerImage{
+					Repository: "docker.io/buildkit",
+					Tag:        "any",
 				},
-				Limits: config2.ResourceRequirements{
-					CPU:    new(resource.MustParse("200m")),
-					Memory: new(resource.MustParse("2000Mi")),
+				Resources: config2.Resources{
+					Requests: config2.ResourceRequirements{
+						CPU:    new(resource.MustParse("100m")),
+						Memory: new(resource.MustParse("1000Mi")),
+					},
+					Limits: config2.ResourceRequirements{
+						CPU:    new(resource.MustParse("200m")),
+						Memory: new(resource.MustParse("2000Mi")),
+					},
 				},
 			},
 			ClusterType: "anyclustertype",
@@ -284,12 +284,12 @@ func (s *RadixJobTestSuite) TestObjectSynced_PipelineJobCreated() {
 				fmt.Sprintf("--RADIX_APP=%s", appName),
 				fmt.Sprintf("--JOB_NAME=%s", jobName),
 				fmt.Sprintf("--PIPELINE_TYPE=%s", radixv1.BuildDeploy),
-				fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsMemory, s.config2.Operator.BuilderResources.Requests.Memory.String()),
-				fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsCPU, s.config2.Operator.BuilderResources.Requests.CPU.String()),
-				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsMemory, s.config2.Operator.BuilderResources.Limits.Memory.String()),
-				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsCPU, s.config2.Operator.BuilderResources.Limits.CPU.String()),
+				fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsMemory, s.config2.Operator.Builder.Resources.Requests.Memory.String()),
+				fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsCPU, s.config2.Operator.Builder.Resources.Requests.CPU.String()),
+				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsMemory, s.config2.Operator.Builder.Resources.Limits.Memory.String()),
+				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsCPU, s.config2.Operator.Builder.Resources.Limits.CPU.String()),
 				fmt.Sprintf("--RADIX_EXTERNAL_REGISTRY_DEFAULT_AUTH_SECRET=%s", config.ContainerRegistryConfig.ExternalRegistryAuthSecret),
-				fmt.Sprintf("--%s=%s", flags.BuilderImage, s.config2.Operator.BuilderImage.String()),
+				fmt.Sprintf("--%s=%s", flags.BuilderImage, s.config2.Operator.Builder.Image.String()),
 				fmt.Sprintf("--SECCOMP_PROFILE_FILENAME=%s", s.config.buildahSecComp),
 				fmt.Sprintf("--%s=%s", flags.ClusterType, s.config2.Operator.ClusterType),
 				fmt.Sprintf("--%s=%s", flags.ClusterName, s.config2.Common.ClusterName),
@@ -1626,14 +1626,16 @@ func (s *RadixJobTestSuite) TestObjectSynced_UseBuildKid_HasResourcesArgs() {
 
 	testCfg := config2.Config{
 		Operator: config2.OperatorConfig{
-			BuilderResources: config2.Resources{
-				Requests: config2.ResourceRequirements{
-					CPU:    new(resource.MustParse("123m")),
-					Memory: new(resource.MustParse("1234Mi")),
-				},
-				Limits: config2.ResourceRequirements{
-					CPU:    new(resource.MustParse("456m")),
-					Memory: new(resource.MustParse("2345Mi")),
+			Builder: config2.BuilderConfig{
+				Resources: config2.Resources{
+					Requests: config2.ResourceRequirements{
+						CPU:    new(resource.MustParse("123m")),
+						Memory: new(resource.MustParse("1234Mi")),
+					},
+					Limits: config2.ResourceRequirements{
+						CPU:    new(resource.MustParse("456m")),
+						Memory: new(resource.MustParse("2345Mi")),
+					},
 				},
 			},
 		},
@@ -1673,10 +1675,10 @@ func (s *RadixJobTestSuite) TestObjectSynced_UseBuildKid_HasResourcesArgs() {
 
 			s.Len(jobList, 1)
 			job := jobList[0]
-			s.Equal(testCfg.Operator.BuilderResources.Requests.CPU.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesRequestsCPU), "Invalid or missing AppBuilderResourcesRequestsCPU")
-			s.Equal(testCfg.Operator.BuilderResources.Requests.Memory.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesRequestsMemory), "Invalid or missing AppBuilderResourcesRequestsMemory")
-			s.Equal(testCfg.Operator.BuilderResources.Limits.Memory.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesLimitsMemory), "Invalid or missing AppBuilderResourcesLimitsMemory")
-			s.Equal(testCfg.Operator.BuilderResources.Limits.CPU.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesLimitsCPU), "Invalid or missing AppBuilderResourcesLimitsCPU")
+			s.Equal(testCfg.Operator.Builder.Resources.Requests.CPU.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesRequestsCPU), "Invalid or missing AppBuilderResourcesRequestsCPU")
+			s.Equal(testCfg.Operator.Builder.Resources.Requests.Memory.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesRequestsMemory), "Invalid or missing AppBuilderResourcesRequestsMemory")
+			s.Equal(testCfg.Operator.Builder.Resources.Limits.Memory.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesLimitsMemory), "Invalid or missing AppBuilderResourcesLimitsMemory")
+			s.Equal(testCfg.Operator.Builder.Resources.Limits.CPU.String(), getJobContainerArgument(job.Spec.Template.Spec.Containers[0], flags.BuilderResourcesLimitsCPU), "Invalid or missing AppBuilderResourcesLimitsCPU")
 		})
 
 	}

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -86,7 +86,7 @@ func (s *RadixJobTestSuiteBase) setupTest() {
 		Operator: config2.OperatorConfig{
 			ContainerRegistry:    s.config.registry,
 			AppContainerRegistry: s.config.appRegistry,
-			BuildKitImageBuilder: config2.ContainerImage{
+			BuilderImage: config2.ContainerImage{
 				Repository: "docker.io/buildkit",
 				Tag:        "any",
 			},
@@ -296,7 +296,7 @@ func (s *RadixJobTestSuite) TestObjectSynced_PipelineJobCreated() {
 				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsMemory, s.config2.Operator.BuilderResources.Limits.Memory.String()),
 				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsCPU, s.config2.Operator.BuilderResources.Limits.CPU.String()),
 				fmt.Sprintf("--RADIX_EXTERNAL_REGISTRY_DEFAULT_AUTH_SECRET=%s", config.ContainerRegistryConfig.ExternalRegistryAuthSecret),
-				fmt.Sprintf("--%s=%s", flags.BuildKitImageBuilder, s.config2.Operator.BuildKitImageBuilder.String()),
+				fmt.Sprintf("--%s=%s", flags.BuilderImage, s.config2.Operator.BuilderImage.String()),
 				fmt.Sprintf("--SECCOMP_PROFILE_FILENAME=%s", s.config.buildahSecComp),
 				fmt.Sprintf("--RADIX_CLUSTER_TYPE=%s", s.config.clusterType),
 				fmt.Sprintf("--%s=%s", flags.ClusterName, s.config2.Common.ClusterName),

--- a/pkg/apis/job/job_test.go
+++ b/pkg/apis/job/job_test.go
@@ -39,7 +39,6 @@ type RadixJobTestSuiteBase struct {
 	radixClient *radix.Clientset
 	config2     config2.Config
 	config      struct {
-		buildkitImage  string
 		buildahSecComp string
 		gitImage       string
 		clusterType    string
@@ -50,15 +49,12 @@ type RadixJobTestSuiteBase struct {
 
 func (s *RadixJobTestSuiteBase) SetupSuite() {
 	s.config = struct {
-		buildkitImage  string
 		buildahSecComp string
 		gitImage       string
 		clusterType    string
 		registry       string
 		appRegistry    string
 	}{
-
-		buildkitImage:  "docker.io/buildkit:any",
 		buildahSecComp: "anyseccomp",
 		gitImage:       "docker.io/git:any",
 		clusterType:    "anyclustertype",
@@ -90,6 +86,10 @@ func (s *RadixJobTestSuiteBase) setupTest() {
 		Operator: config2.OperatorConfig{
 			ContainerRegistry:    s.config.registry,
 			AppContainerRegistry: s.config.appRegistry,
+			BuildKitImageBuilder: config2.ContainerImage{
+				Repository: "docker.io/buildkit",
+				Tag:        "any",
+			},
 			BuilderResources: config2.Resources{
 				Requests: config2.ResourceRequirements{
 					CPU:    new(resource.MustParse("100m")),
@@ -104,7 +104,6 @@ func (s *RadixJobTestSuiteBase) setupTest() {
 	}
 
 	s.T().Setenv(defaults.OperatorClusterTypeEnvironmentVariable, s.config.clusterType)
-	s.T().Setenv(defaults.RadixBuildKitImageBuilderEnvironmentVariable, s.config.buildkitImage)
 	s.T().Setenv(defaults.SeccompProfileFileNameEnvironmentVariable, s.config.buildahSecComp)
 	s.T().Setenv(defaults.RadixGitCloneGitImageEnvironmentVariable, s.config.gitImage)
 }
@@ -297,7 +296,7 @@ func (s *RadixJobTestSuite) TestObjectSynced_PipelineJobCreated() {
 				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsMemory, s.config2.Operator.BuilderResources.Limits.Memory.String()),
 				fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsCPU, s.config2.Operator.BuilderResources.Limits.CPU.String()),
 				fmt.Sprintf("--RADIX_EXTERNAL_REGISTRY_DEFAULT_AUTH_SECRET=%s", config.ContainerRegistryConfig.ExternalRegistryAuthSecret),
-				fmt.Sprintf("--RADIX_BUILDKIT_IMAGE_BUILDER_IMAGE=%s", s.config.buildkitImage),
+				fmt.Sprintf("--%s=%s", flags.BuildKitImageBuilder, s.config2.Operator.BuildKitImageBuilder.String()),
 				fmt.Sprintf("--SECCOMP_PROFILE_FILENAME=%s", s.config.buildahSecComp),
 				fmt.Sprintf("--RADIX_CLUSTER_TYPE=%s", s.config.clusterType),
 				fmt.Sprintf("--%s=%s", flags.ClusterName, s.config2.Common.ClusterName),

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -145,14 +145,14 @@ func (job *Job) getPipelineJobArguments(appName, jobName, workspace, radixConfig
 		fmt.Sprintf("--%s=%s", defaults.RadixAppEnvironmentVariable, appName),
 		fmt.Sprintf("--%s=%s", defaults.RadixPipelineJobEnvironmentVariable, jobName),
 		fmt.Sprintf("--%s=%s", defaults.RadixPipelineTypeEnvironmentVariable, pipeline.Type),
-		fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsMemory, job.config2.Operator.BuilderResources.Requests.Memory.String()),
-		fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsCPU, job.config2.Operator.BuilderResources.Requests.CPU.String()),
-		fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsMemory, job.config2.Operator.BuilderResources.Limits.Memory.String()),
-		fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsCPU, job.config2.Operator.BuilderResources.Limits.CPU.String()),
+		fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsMemory, job.config2.Operator.Builder.Resources.Requests.Memory.String()),
+		fmt.Sprintf("--%s=%s", flags.BuilderResourcesRequestsCPU, job.config2.Operator.Builder.Resources.Requests.CPU.String()),
+		fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsMemory, job.config2.Operator.Builder.Resources.Limits.Memory.String()),
+		fmt.Sprintf("--%s=%s", flags.BuilderResourcesLimitsCPU, job.config2.Operator.Builder.Resources.Limits.CPU.String()),
 		fmt.Sprintf("--%s=%s", defaults.RadixExternalRegistryDefaultAuthEnvironmentVariable, job.config.ContainerRegistryConfig.ExternalRegistryAuthSecret),
 
 		// Pass tekton and builder images
-		fmt.Sprintf("--%s=%s", flags.BuilderImage, job.config2.Operator.BuilderImage.String()),
+		fmt.Sprintf("--%s=%s", flags.BuilderImage, job.config2.Operator.Builder.Image.String()),
 		fmt.Sprintf("--%s=%s", defaults.SeccompProfileFileNameEnvironmentVariable, os.Getenv(defaults.SeccompProfileFileNameEnvironmentVariable)),
 
 		// Used for tagging source of image

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -153,7 +153,7 @@ func (job *Job) getPipelineJobArguments(appName, jobName, workspace, radixConfig
 		fmt.Sprintf("--%s=%s", defaults.RadixExternalRegistryDefaultAuthEnvironmentVariable, job.config.ContainerRegistryConfig.ExternalRegistryAuthSecret),
 
 		// Pass tekton and builder images
-		fmt.Sprintf("--%s=%s", flags.BuildKitImageBuilder, job.config2.Operator.BuildKitImageBuilder.String()),
+		fmt.Sprintf("--%s=%s", flags.BuilderImage, job.config2.Operator.BuilderImage.String()),
 		fmt.Sprintf("--%s=%s", defaults.SeccompProfileFileNameEnvironmentVariable, os.Getenv(defaults.SeccompProfileFileNameEnvironmentVariable)),
 
 		// Used for tagging source of image

--- a/pkg/apis/job/kubejob.go
+++ b/pkg/apis/job/kubejob.go
@@ -153,7 +153,7 @@ func (job *Job) getPipelineJobArguments(appName, jobName, workspace, radixConfig
 		fmt.Sprintf("--%s=%s", defaults.RadixExternalRegistryDefaultAuthEnvironmentVariable, job.config.ContainerRegistryConfig.ExternalRegistryAuthSecret),
 
 		// Pass tekton and builder images
-		fmt.Sprintf("--%s=%s", defaults.RadixBuildKitImageBuilderEnvironmentVariable, os.Getenv(defaults.RadixBuildKitImageBuilderEnvironmentVariable)),
+		fmt.Sprintf("--%s=%s", flags.BuildKitImageBuilder, job.config2.Operator.BuildKitImageBuilder.String()),
 		fmt.Sprintf("--%s=%s", defaults.SeccompProfileFileNameEnvironmentVariable, os.Getenv(defaults.SeccompProfileFileNameEnvironmentVariable)),
 
 		// Used for tagging source of image


### PR DESCRIPTION
Update the configuration for the BuildKit image builder to streamline its usage and improve clarity in the codebase. This change replaces the previous environment variable with a more consistent naming convention and integrates the new configuration into relevant components.