### PR TITLE
fix: add identity validation in key vaults 

### DIFF
--- a/e2e/radix_application_validation_test.go
+++ b/e2e/radix_application_validation_test.go
@@ -771,3 +771,116 @@ func TestRadixApplicationComponentReplicasValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestRadixApplicationAzureKeyVaultUseAzureIdentityValidation tests that a component with an Azure Key Vault
+// using useAzureIdentity requires identity.azure.clientId in the common or the relevant environment config.
+func TestRadixApplicationAzureKeyVaultUseAzureIdentityValidation(t *testing.T) {
+	c := getClient(t)
+	appName := "test-akv-identity"
+	appNamespace := createRadixRegistrationAndNamespaceForTest(t, c, appName)
+
+	clientId := "11111111-2222-3333-4444-555555555555"
+	azureIdentity := &v1.Identity{Azure: &v1.AzureIdentity{ClientId: clientId}}
+	azureKeyVaults := func(useAzureIdentity *bool) v1.RadixSecretRefs {
+		return v1.RadixSecretRefs{
+			AzureKeyVaults: []v1.RadixAzureKeyVault{
+				{
+					Name:             "my-key-vault",
+					UseAzureIdentity: useAzureIdentity,
+					Items:            []v1.RadixAzureKeyVaultItem{{Name: "my-secret"}},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		component   v1.RadixComponent
+		shouldError bool
+	}{
+		{
+			name: "invalid - useAzureIdentity without any identity",
+			component: v1.RadixComponent{
+				Name:       "app",
+				SecretRefs: azureKeyVaults(new(true)),
+				EnvironmentConfig: []v1.RadixEnvironmentConfig{
+					{Environment: "dev"},
+					{Environment: "prod"},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "invalid - useAzureIdentity with identity only in one environment",
+			component: v1.RadixComponent{
+				Name:       "app",
+				SecretRefs: azureKeyVaults(new(true)),
+				EnvironmentConfig: []v1.RadixEnvironmentConfig{
+					{Environment: "dev"},
+					{Environment: "prod", Identity: azureIdentity},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "valid - useAzureIdentity with common identity",
+			component: v1.RadixComponent{
+				Name:       "app",
+				Identity:   azureIdentity,
+				SecretRefs: azureKeyVaults(new(true)),
+				EnvironmentConfig: []v1.RadixEnvironmentConfig{
+					{Environment: "dev"},
+					{Environment: "prod"},
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "valid - useAzureIdentity with identity in all environments",
+			component: v1.RadixComponent{
+				Name:       "app",
+				SecretRefs: azureKeyVaults(new(true)),
+				EnvironmentConfig: []v1.RadixEnvironmentConfig{
+					{Environment: "dev", Identity: azureIdentity},
+					{Environment: "prod", Identity: azureIdentity},
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "valid - useAzureIdentity disabled without identity",
+			component: v1.RadixComponent{
+				Name:       "app",
+				SecretRefs: azureKeyVaults(new(false)),
+				EnvironmentConfig: []v1.RadixEnvironmentConfig{
+					{Environment: "dev"},
+					{Environment: "prod"},
+				},
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ra := &v1.RadixApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName,
+					Namespace: appNamespace,
+				},
+				Spec: v1.RadixApplicationSpec{
+					Environments: []v1.Environment{{Name: "dev"}, {Name: "prod"}},
+					Components:   []v1.RadixComponent{tc.component},
+				},
+			}
+
+			err := c.Create(t.Context(), ra, client.DryRunAll)
+
+			if tc.shouldError {
+				assert.ErrorContains(t, err, "missing Azure identity for Azure Key vault with useAzureIdentity enabled")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/webhook/validation/radixapplication/validate_ra_test.go
+++ b/webhook/validation/radixapplication/validate_ra_test.go
@@ -1849,6 +1849,127 @@ func Test_ValidationOfVolumeMounts_Errors(t *testing.T) {
 	}
 }
 
+func Test_ValidationOfSecretRefsAzureIdentity(t *testing.T) {
+	const clientId = "11111111-2222-3333-4444-555555555555"
+
+	boolPtr := func(b bool) *bool { return &b }
+	azureKeyVaults := func(useAzureIdentity *bool) radixv1.RadixSecretRefs {
+		return radixv1.RadixSecretRefs{
+			AzureKeyVaults: []radixv1.RadixAzureKeyVault{
+				{
+					Name:             "my-key-vault",
+					UseAzureIdentity: useAzureIdentity,
+					Items:            []radixv1.RadixAzureKeyVaultItem{{Name: "secret1"}},
+				},
+			},
+		}
+	}
+	getComponent := func(ra *radixv1.RadixApplication, name string) *radixv1.RadixComponent {
+		for i := range ra.Spec.Components {
+			if ra.Spec.Components[i].Name == name {
+				return &ra.Spec.Components[i]
+			}
+		}
+		require.FailNowf(t, "component not found", "component %s", name)
+		return nil
+	}
+	getEnvConfig := func(component *radixv1.RadixComponent, environment string) *radixv1.RadixEnvironmentConfig {
+		for i := range component.EnvironmentConfig {
+			if component.EnvironmentConfig[i].Environment == environment {
+				return &component.EnvironmentConfig[i]
+			}
+		}
+		require.FailNowf(t, "environment config not found", "environment %s", environment)
+		return nil
+	}
+	azureIdentity := &radixv1.Identity{Azure: &radixv1.AzureIdentity{ClientId: clientId}}
+
+	// The "redis" component in testdata has no identity and is enabled in both dev and prod.
+	var testScenarios = map[string]struct {
+		updateRA      func(ra *radixv1.RadixApplication)
+		expectedError error
+	}{
+		"common useAzureIdentity without any identity fails": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				getComponent(ra, "redis").SecretRefs = azureKeyVaults(boolPtr(true))
+			},
+			expectedError: radixapplication.ErrMissingAzureIdentityForAzureKeyVault,
+		},
+		"common useAzureIdentity with identity only in one environment fails for the other": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				component := getComponent(ra, "redis")
+				component.SecretRefs = azureKeyVaults(boolPtr(true))
+				getEnvConfig(component, "prod").Identity = azureIdentity
+			},
+			expectedError: radixapplication.ErrMissingAzureIdentityForAzureKeyVault,
+		},
+		"common useAzureIdentity with common identity succeeds": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				component := getComponent(ra, "redis")
+				component.SecretRefs = azureKeyVaults(boolPtr(true))
+				component.Identity = azureIdentity
+			},
+			expectedError: nil,
+		},
+		"common useAzureIdentity with identity in all environments succeeds": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				component := getComponent(ra, "redis")
+				component.SecretRefs = azureKeyVaults(boolPtr(true))
+				getEnvConfig(component, "dev").Identity = azureIdentity
+				getEnvConfig(component, "prod").Identity = azureIdentity
+			},
+			expectedError: nil,
+		},
+		"useAzureIdentity disabled without identity succeeds": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				getComponent(ra, "redis").SecretRefs = azureKeyVaults(boolPtr(false))
+			},
+			expectedError: nil,
+		},
+		"environment useAzureIdentity with identity in the same environment succeeds": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				component := getComponent(ra, "redis")
+				envConfig := getEnvConfig(component, "dev")
+				envConfig.SecretRefs = azureKeyVaults(boolPtr(true))
+				envConfig.Identity = azureIdentity
+			},
+			expectedError: nil,
+		},
+		"environment useAzureIdentity with identity in another environment fails": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				component := getComponent(ra, "redis")
+				getEnvConfig(component, "dev").SecretRefs = azureKeyVaults(boolPtr(true))
+				getEnvConfig(component, "prod").Identity = azureIdentity
+			},
+			expectedError: radixapplication.ErrMissingAzureIdentityForAzureKeyVault,
+		},
+		"environment useAzureIdentity overriding common useAzureIdentity to false succeeds": {
+			updateRA: func(ra *radixv1.RadixApplication) {
+				component := getComponent(ra, "redis")
+				component.SecretRefs = azureKeyVaults(boolPtr(true))
+				getEnvConfig(component, "dev").SecretRefs = azureKeyVaults(boolPtr(false))
+				getEnvConfig(component, "prod").SecretRefs = azureKeyVaults(boolPtr(false))
+			},
+			expectedError: nil,
+		},
+	}
+
+	client := test.CreateClient("testdata/radixregistration.yaml")
+	for name, scenario := range testScenarios {
+		t.Run(name, func(t *testing.T) {
+			validRA := test.Load[*radixv1.RadixApplication]("./testdata/radixconfig.yaml")
+			scenario.updateRA(validRA)
+			validator := radixapplication.CreateOnlineValidator(client, []string{"grafana"}, map[string]string{"console": "radix-web-console"})
+			_, err := validator.Validate(context.Background(), validRA)
+			if scenario.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, scenario.expectedError)
+			}
+		})
+	}
+}
+
 func Test_HorizontalScaling_Validation(t *testing.T) {
 	var testScenarios = []struct {
 		name     string

--- a/webhook/validation/radixapplication/validate_secrets.go
+++ b/webhook/validation/radixapplication/validate_secrets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 
 	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 )
@@ -53,6 +54,10 @@ func validateRadixComponentSecrets(component radixv1.RadixCommonComponent, app *
 		return err
 	}
 
+	if err := validateAzureKeyVaultAzureIdentity(component, app.Spec.Environments); err != nil {
+		return err
+	}
+
 	return validateConflictingEnvironmentAndSecretRefsNames(component, envsEnvVarsMap)
 }
 
@@ -92,12 +97,6 @@ func validateSecretRefs(commonComponent radixv1.RadixCommonComponent, secretRefs
 				return fmt.Errorf("azure Key vault %s, component %s, path %s: %w", azureKeyVault.Name, commonComponent.GetName(), *path, ErrDuplicatePathForAzureKeyVault)
 			}
 			existingAzureKeyVaultPath[*path] = true
-		}
-		useAzureIdentity := azureKeyVault.UseAzureIdentity
-		if useAzureIdentity != nil && *useAzureIdentity {
-			if !azureIdentityIsSet(commonComponent) {
-				return fmt.Errorf("azure Key vault %s, component %s: %w", azureKeyVault.Name, commonComponent.GetName(), ErrMissingAzureIdentityForAzureKeyVault)
-			}
 		}
 		for _, keyVaultItem := range azureKeyVault.Items {
 			if len(keyVaultItem.EnvVar) > 0 {
@@ -155,21 +154,59 @@ func getEnvVarNameMap(componentEnvVarsMap radixv1.EnvVarsMap, envsEnvVarsMap rad
 	return envVarsMap
 }
 
-func azureIdentityIsSet(commonComponent radixv1.RadixCommonComponent) bool {
-	identity := commonComponent.GetIdentity()
-	if identity != nil && identity.Azure != nil && identity.Azure.ClientId != "" {
-		return true
-	}
-	for _, envConfig := range commonComponent.GetEnvironmentConfig() {
-		if !commonComponent.GetEnabledForEnvironmentConfig(envConfig) {
+// validateAzureKeyVaultAzureIdentity verifies that, for every environment where the component is enabled
+// and has an Azure Key Vault with useAzureIdentity enabled, an identity.azure.clientId is configured in
+// either the common component config or the environment config.
+func validateAzureKeyVaultAzureIdentity(component radixv1.RadixCommonComponent, environments []radixv1.Environment) error {
+	commonIdentitySet := azureIdentityClientIdIsSet(component.GetIdentity())
+	for _, env := range environments {
+		if !component.GetEnabledForEnvironment(env.Name) {
 			continue
 		}
-		envIdentity := envConfig.GetIdentity()
-		if envIdentity != nil && envIdentity.Azure != nil && envIdentity.Azure.ClientId != "" {
-			return true
+		envConfig := component.GetEnvironmentConfigByName(env.Name)
+		if commonIdentitySet || azureIdentityClientIdIsSet(environmentConfigIdentity(envConfig)) {
+			continue
+		}
+		for _, azureKeyVaultName := range azureKeyVaultsUsingAzureIdentityForEnvironment(component, envConfig) {
+			return fmt.Errorf("azure Key vault %s, component %s, environment %s: %w", azureKeyVaultName, component.GetName(), env.Name, ErrMissingAzureIdentityForAzureKeyVault)
 		}
 	}
-	return false
+	return nil
+}
+
+// azureKeyVaultsUsingAzureIdentityForEnvironment returns the names of Azure Key Vaults with an effective
+// useAzureIdentity enabled for the environment, applying environment overrides over the common config.
+func azureKeyVaultsUsingAzureIdentityForEnvironment(component radixv1.RadixCommonComponent, envConfig radixv1.RadixCommonEnvironmentConfig) []string {
+	effectiveUseAzureIdentity := make(map[string]*bool)
+	for _, azureKeyVault := range component.GetSecretRefs().AzureKeyVaults {
+		effectiveUseAzureIdentity[azureKeyVault.Name] = azureKeyVault.UseAzureIdentity
+	}
+	if envConfig != radixv1.RadixCommonEnvironmentConfig(nil) {
+		for _, azureKeyVault := range envConfig.GetSecretRefs().AzureKeyVaults {
+			if _, exists := effectiveUseAzureIdentity[azureKeyVault.Name]; !exists || azureKeyVault.UseAzureIdentity != nil {
+				effectiveUseAzureIdentity[azureKeyVault.Name] = azureKeyVault.UseAzureIdentity
+			}
+		}
+	}
+	var names []string
+	for name, useAzureIdentity := range effectiveUseAzureIdentity {
+		if useAzureIdentity != nil && *useAzureIdentity {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+func environmentConfigIdentity(envConfig radixv1.RadixCommonEnvironmentConfig) *radixv1.Identity {
+	if envConfig == radixv1.RadixCommonEnvironmentConfig(nil) {
+		return nil
+	}
+	return envConfig.GetIdentity()
+}
+
+func azureIdentityClientIdIsSet(identity *radixv1.Identity) bool {
+	return identity != nil && identity.Azure != nil && identity.Azure.ClientId != ""
 }
 
 func validateConflictingEnvironmentAndSecretRefsNames(component radixv1.RadixCommonComponent, envsEnvVarMap map[string]map[string]bool) error {


### PR DESCRIPTION
Make sure that a component or job using an Azure Key Vault with `useAzureIdentity: true` has an Azure identity with a non-empty `clientId`.